### PR TITLE
Docs Proofread

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,33 @@
-MediaBundle - Media management on steroid
-=========================================
+MediaBundle - Media management on steroids
+==========================================
 
-The ``MediaBundle`` is a media library based on dedicated ``provider`` which handle different
-``type`` of media: file, video or image.
+The ``MediaBundle`` is a media library based on a dedicated ``provider`` which
+handles different ``type`` of media: files, videos or images.
 
-Each ``type`` is managed by a ``provider`` service which is in charge of :
+The full documentation can be found in the ``Resources/doc/`` directory and
+is best read offline after cloning this repository.
+
+Each ``type`` is managed by a ``provider`` service which is in charge of:
 
   - retrieving media metadata
   - generating media thumbnail
   - tweaking the edit form
   - rendering the media
 
-Each ``media`` can be linked to a ``context``. A context can be ``news``, ``user`` or any
-name you need. A context allows to regroup a set of picture into one group. As requirement
-can be different for each context, a context is defined by a set of ``formats`` and a set of
-``providers``.
+Each ``media`` can be linked to a ``context``. A context can be ``news``,
+``user`` or any name you want. A context allows you to group a set of pictures
+together. As requirements can be different for each context, a context
+is defined by a set of ``formats`` and a set of ``providers``.
 
-As the infrastructure is not standard, the ``MediaBundle`` abstracts the ``filesystem`` layer
-and the ``cdn`` layer.
+As the infrastructure is not standard, the ``MediaBundle`` abstracts the
+``filesystem`` layer and the ``cdn`` layer.
 
 The backend is handled by the ``AdminBundle``.
 
 Available services
 ------------------
 
- Providers
+### Providers
 
     - sonata.media.provider.image         : Image
     - sonata.media.provider.file          : File
@@ -32,26 +35,27 @@ Available services
     - sonata.media.provider.vimeo         : Vimeo
     - sonata.media.provider.youtube       : Youtube
 
- Filesystem
+### Filesystem
 
     - sonata.media.filesystem.local       : The local filesystem (default)
     - sonata.media.filesystem.ftp         : FTP
     - sonata.media.filesystem.s3          : Amazon S3
     - sonata.media.filesystem.replicate   : Replicate file to a master and to a slave
 
- CDN
+### CDN
 
     - sonata.media.cdn.server             : The local http server (default)
     - sonata.media.cdn.panther            : Panther Portal
-    - sonata.media.cdn.fallback           : Fallback, use the fallback fallback (the http server) if the Media is not yet flushed on the CDN
+    - sonata.media.cdn.fallback           : Fallback, use the fallback (the http server) if the Media is not yet flushed on the CDN
 
-More services will be available in the futur depend on your contributions :)
+More services will be available in the future depending on your contributions! :)
 
 More information
 ----------------
 
-You need to go to the Ressources/doc folder where the reStructuredText documentation is available.
-Please note the Github preview might break and hide some content.
+You need to go to the Resources/doc folder where the reStructuredText documentation
+is available. Please note the Github preview might break and hide some content
+(so your best bet is to clone this repository and read the source files locally!).
 
 TODO
 ----

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -1,29 +1,28 @@
-Welcome to MediaBundle documentation
+Welcome to MediaBundle Documentation
 ====================================
 
-The ``MediaBundle`` is a media library based on dedicated ``provider`` which handle different
-``type`` of media: file, video or image.
+The ``MediaBundle`` is a media library based on a dedicated ``provider`` which
+handles different ``type`` of media: files, videos or images.
 
-Each ``type`` is managed by a ``provider`` service which is in charge of :
+Each ``type`` is managed by a ``provider`` service which is in charge of:
 
   - retrieving media metadata
   - generating media thumbnail
   - tweaking the edit form
   - rendering the media
 
-Each ``media`` can be linked to a ``context``. A context can be ``news``, ``user`` or any
-name you need. A context allows to regroup a set of picture into one group. As requirement
-can be different for each context, a context is defined by a set of ``formats`` and a set of
-``providers``.
+Each ``media`` can be linked to a ``context``. A context can be ``news``,
+``user`` or any name you want. A context allows you to group a set of pictures
+together. As requirements can be different for each context, a context
+is defined by a set of ``formats`` and a set of ``providers``.
 
-As the infrastructure is not standard, the ``MediaBundle`` abstracts the ``filesystem`` layer
-and the ``cdn`` layer. 
-
+As the infrastructure is not standard, the ``MediaBundle`` abstracts the
+``filesystem`` layer and the ``cdn`` layer.
 
 Available services
 ------------------
 
- Providers
+### Providers
 
     - sonata.media.provider.image         : Image
     - sonata.media.provider.file          : File
@@ -31,18 +30,20 @@ Available services
     - sonata.media.provider.vimeo         : Vimeo
     - sonata.media.provider.youtube       : Youtube
 
- Filesystem
+### Filesystem
 
     - sonata.media.filesystem.local       : The local filesystem (default)
     - sonata.media.filesystem.ftp         : FTP
     - sonata.media.filesystem.s3          : Amazon S3
     - sonata.media.filesystem.replicate   : Replicate file to a master and to a slave
 
- CDN
+### CDN
 
     - sonata.media.cdn.server             : The local http server (default)
     - sonata.media.cdn.panther            : Panther Portal
-    - sonata.media.cdn.fallback           : Fallback, use the fallback fallback (the http server) if the Media is not yet flushed on the CDN
+    - sonata.media.cdn.fallback           : Fallback, use the fallback (the http server) if the Media is not yet flushed on the CDN
+
+More services will be available in the future depending on your contributions! :)
 
 Reference Guide
 ---------------

--- a/Resources/doc/reference/advanced_configuration.rst
+++ b/Resources/doc/reference/advanced_configuration.rst
@@ -1,10 +1,9 @@
 Advanced Configuration
 ======================
 
-Full configuration option
+Full configuration options:
 
-
-.. code-block:: php
+.. code-block:: yaml
 
     sonata_media:
         contexts:

--- a/Resources/doc/reference/helpers.rst
+++ b/Resources/doc/reference/helpers.rst
@@ -1,15 +1,15 @@
 Helpers
 =======
 
-The bundle comes with different helpers to render the thumbnail or the media itself. The thumbnail always
-represents the media's image preview (ie the thumbnail of a flash video). And the media helper generates
-the media itself (ie the flash video).
-
+The bundle comes with different helpers to render the thumbnail or the media
+itself. The thumbnail always represents the media's image preview (i.e. the
+thumbnail of a flash video). And the media helper generates the media itself
+(i.e. the flash video).
 
 PHP Usage
 ---------
 
-Render the thumbnail :
+Render the thumbnail:
 
 .. code-block:: php
 
@@ -19,7 +19,7 @@ Render the thumbnail :
         'class' => 'myclass'
     ) ?>
 
-Render the media :
+Render the media:
 
 .. code-block:: php
 
@@ -29,21 +29,20 @@ Render the media :
         'class' => 'myclass'
     ) ?>
 
-
 Twig usage
 ----------
 
-Render the thumbnail :
+Render the thumbnail:
 
-.. code-block:: twig
+.. code-block:: jinja
 
     {% thumbnail media, 'small_format' %}
 
     {% thumbnail media, 'small_format', {'class': 'myclass'} %}
 
-Render the media :
+Render the media:
 
-.. code-block:: twig
+.. code-block:: jinja
 
     {% media media, 'small_format' %}
 

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -1,19 +1,18 @@
 Installation
 ============
 
-Make sure you have a ``Sonata`` directory, if not create it::
+Make sure you have a ``Sonata`` directory. If you don't, create it::
 
   mkdir src/Sonata
 
-to begin, add the dependent bundles to the ``src/`` directory. if using
-git, you can add them as submodules::
+To begin, add the dependent bundles to the ``src/`` directory. If you're
+using git, you can add them as submodules::
 
   git submodule add git@github.com:Sonata-project/MediaBundle.git src/Sonata/MediaBundle
 
   // dependency bundles
   git submodule add git@github.com:Sonata-project/AdminBundle.git src/Sonata/AdminBundle
   git submodule add git@github.com:Sonata-project/EasyExtendsBundle.git src/Sonata/EasyExtendsBundle
-
 
 Add the ``imagine`` image processing library
 
@@ -39,16 +38,18 @@ Next, be sure to enable the bundles in your application kernel:
       );
   }
 
-At this point, the bundle is not yet ready. You need to generate the correct entities for the media::
+At this point, the bundle is not yet ready. You need to generate the correct
+entities for the media::
 
-    php kooqit/console Sonata:easy-extends:generate
+    php app/console Sonata:easy-extends:generate
 
 .. note::
 
-    The command will generate domain objects in an ``Application`` namespace. So you can point entities'
-    associations to a global and common namespace. This will make Entities sharing very easier has your
-    models will allows point to a global namespace.
-    For instance the media will be ``Application\Sonata\MediaBundle\Entity\Media``.
+    The command will generate domain objects in an ``Application`` namespace.
+    So you can point entities' associations to a global and common namespace.
+    This will make Entities sharing very easier has your models will allows
+    point to a global namespace. For instance the media will be
+    ``Application\Sonata\MediaBundle\Entity\Media``.
 
 Now, add the new `Application` Bundle into the kernel
 
@@ -80,12 +81,11 @@ Update the ``autoload.php`` to add a new namespaces :
         // ... other declarations
     ));
 
-
 Configuration
 -------------
 
-to use the ``AdminBundle``, add the following to your application
-configuration file.
+To use the ``AdminBundle``, add the following to your application configuration
+file.
 
 .. code-block:: yaml
 
@@ -112,8 +112,7 @@ configuration file.
                 directory:  %kernel.root_dir%/../web/uploads/media
                 create:     false
 
-
 .. note::
 
-    you can define formats per provider type. you might want to set
-    an transversal ``admin`` format to be used by the ``mediaadmin`` class.
+    You can define formats per provider type. You might want to set
+    a transversal ``admin`` format to be used by the ``mediaadmin`` class.

--- a/Resources/doc/reference/media_context.rst
+++ b/Resources/doc/reference/media_context.rst
@@ -1,15 +1,14 @@
 Media Context
 =============
 
-When a site has to handle pictures, you can have different type of images : news pictures, users pictures or
-any others kind of picture. But at the end  pictures require the same feature : resize, cdn and database
-relationship with entities.
+When a site has to handle pictures, you can have different type of pictures:
+news pictures, users pictures etc. But in the end,pictures require the same
+features: resize, cdn and database relationship with entities.
 
-The ``MediaBundle`` try to solve this situation by introducing ``context`` : a context has its own set of media providers
-and its own set of formats. That means you can have a ``small`` user picture format and a ``small`` news pictures
-formats with different size and providers.
-
-Example :
+The ``MediaBundle`` tries to solve this situation by introducing ``context``:
+a context has its own set of media providers and its own set of formats.
+That means you can have a ``small`` user picture format and a ``small`` news
+picture format with different sizes and providers. For example:
 
 .. code-block:: yml
 
@@ -34,8 +33,7 @@ Example :
                 small: { width: 150 , quality: 95}
                 big:   { width: 500 , quality: 90}
 
-
-``AdminBundle`` integration
+``AdminBundle`` Integration
 ---------------------------
 
 When you create a new blog post, you might want to link an image to that post.
@@ -51,24 +49,27 @@ When you create a new blog post, you might want to link an image to that post.
             </cascade>
         </many-to-one>
 
-In the ``PostAdmin``, you can add a new field ``image`` with a ``link_parameters`` option. This option will add an extra
-parameter into the ``add`` link, this parameter will be used by the related controller.
+In the ``PostAdmin``, you can add a new field ``image`` with a ``link_parameters``
+option. This option will add an extra parameter into the ``add`` link. This
+parameter will be used by the related controller.
 
 .. code-block:: php
 
     public function configureFormFields(FormMapper $form)
     {
-        // [... ]
+        // ... 
         $form->add('image', array(), array('edit' => 'list', 'link_parameters' => array('context' => 'news')));
-        // [... ]
+        // ...
     }
 
-If you have a look to the ``MediaAdmin`` class, the class defined a ``getPersistentParameters`` method. This method
-allows to define persistent parameters across the ``MediaAdminController``. Depends on the action the parameter can
-change the Admin behaviors :
+If you look in the ``MediaAdmin`` class, the class defined a ``getPersistentParameters``
+method. This method allows you to define persistent parameters across the
+``MediaAdminController``. Depending on the action, the parameter can change
+the Admin behaviors:
 
- - list : filter the list to display only one ``context``
- - create : create a new media with the provided ``context``
+* *list*: filters the list to display only one ``context``
+
+* *create*: creates a new media asset with the provided ``context``
 
 .. code-block:: php
 


### PR DESCRIPTION
Hey guys!

This is just a proofread of the docs - they should be a little cleaner now :).

Overall, I think the main README goes into too much detail - it should be used for marketing: show some end-user use cases that really show off the bundle and then give the user clear instructions on exactly what to do next to use the bundle (e.g. read the installation docs, but then what should I read after that)?

I haven't had time to test this bundle out yet, but I'm excited by it. Not to turn a PR into a conversation, but what is the `SonataEasyExtendsBundle` and why do I have to run a special command to generate my entities (e.g. `Sonata:easy-extends:generate`)? As an outsider, it seems potentially "imposing" on my project.

Keep up the good work!
