### PR TITLE
in media.xml switch class usage Imagine\Imagick\Imagine and Imagine\Gmagick\Imagine

### DIFF
--- a/Resources/config/media.xml
+++ b/Resources/config/media.xml
@@ -11,8 +11,8 @@
     <services>
         <!-- image manipulation service -->
         <service id="sonata.media.adapter.image.gd" class="Imagine\Gd\Imagine" />
-        <service id="sonata.media.adapter.image.imagick" class="Imagine\Gmagick\Imagine" />
-        <service id="sonata.media.adapter.image.gmagick" class="Imagine\Imagick\Imagine" />
+        <service id="sonata.media.adapter.image.imagick" class="Imagine\Imagick\Imagine" />
+        <service id="sonata.media.adapter.image.gmagick" class="Imagine\Gmagick\Imagine" />
 
         <service id="sonata.media.resizer.simple" class="%sonata.media.resizer.simple.class%">
             <argument type="service" id="sonata.media.adapter.image.gd" />


### PR DESCRIPTION
service id sonata.media.adapter.image.imagick is now using class Imagine\Imagick\Imagine
and
service id sonata.media.adapter.image.gmagick is now using class Imagine\Gmagick\Imagine
see also: https://github.com/sonata-project/SonataMediaBundle/issues/26
