### PR TITLE
Use parameters instead of hardcoded class references (relates to #37)

### DIFF
--- a/Resources/config/mongodb.xml
+++ b/Resources/config/mongodb.xml
@@ -5,8 +5,11 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
+        <parameter key="sonata.media.generator.default.class">Sonata\MediaBundle\Generator\ODMGenerator</parameter>
         <parameter key="sonata.media.manager.media.class">Sonata\MediaBundle\Document\MediaManager</parameter>
+        <parameter key="sonata.media.manager.media.entity">Application\Sonata\MediaBundle\Document\Media</parameter>
         <parameter key="sonata.media.manager.gallery.class">Sonata\MediaBundle\Document\GalleryManager</parameter>
+        <parameter key="sonata.media.manager.gallery.entity">Application\Sonata\MediaBundle\Document\Gallery</parameter>
     </parameters>
 
     <services>
@@ -15,17 +18,16 @@
         <service id="sonata.media.manager.media" class="%sonata.media.manager.media.class%">
             <argument type="service" id="sonata.media.pool" />
             <argument type="service" id="sonata.media.document_manager" />
-            <argument>Application\Sonata\MediaBundle\Document\Media</argument>
+            <argument>%sonata.media.manager.media.entity%</argument>
         </service>
 
         <service id="sonata.media.manager.gallery" class="%sonata.media.manager.gallery.class%">
             <argument type="service" id="sonata.media.document_manager" />
-            <argument>Application\Sonata\MediaBundle\Document\Gallery</argument>
+            <argument>%sonata.media.manager.gallery.entity%</argument>
         </service>
 
         <!-- Path generator servive -->
-        <service id="sonata.media.generator.default" class="Sonata\MediaBundle\Generator\ODMGenerator">
-
+        <service id="sonata.media.generator.default" class="%sonata.media.generator.default.class%">
         </service>
     </services>
 

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -5,8 +5,11 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
+        <parameter key="sonata.media.generator.default.class">Sonata\MediaBundle\Generator\DefaultGenerator</parameter>
         <parameter key="sonata.media.manager.media.class">Sonata\MediaBundle\Entity\MediaManager</parameter>
         <parameter key="sonata.media.manager.gallery.class">Sonata\MediaBundle\Entity\GalleryManager</parameter>
+        <parameter key="sonata.media.manager.media.entity">Application\Sonata\MediaBundle\Entity\Media</parameter>
+        <parameter key="sonata.media.manager.gallery.entity">Application\Sonata\MediaBundle\Entity\Gallery</parameter>
     </parameters>
 
     <services>
@@ -15,17 +18,16 @@
         <service id="sonata.media.manager.media" class="%sonata.media.manager.media.class%">
             <argument type="service" id="sonata.media.pool" />
             <argument type="service" id="sonata.media.entity_manager" />
-            <argument>Application\Sonata\MediaBundle\Entity\Media</argument>
+            <argument>%sonata.media.manager.media.entity%</argument>
         </service>
 
         <service id="sonata.media.manager.gallery" class="%sonata.media.manager.gallery.class%">
             <argument type="service" id="sonata.media.entity_manager" />
-            <argument>Application\Sonata\MediaBundle\Entity\Gallery</argument>
+            <argument>%sonata.media.manager.gallery.entity%</argument>
         </service>
 
         <!-- Path generator servive -->
-        <service id="sonata.media.generator.default" class="Sonata\MediaBundle\Generator\DefaultGenerator">
-
+        <service id="sonata.media.generator.default" class="%sonata.media.generator.default.class%">
         </service>
     </services>
 


### PR DESCRIPTION
_Adding @IamPersistent, @merk, @stof_

I've been using `Sonata*Bundles` for only a day and a half now, and I've run into some problems regarding namespaces:
1. My project uses different architecture than Symfony default, application files are stored in `/src/App/` as opposed to `/Application/`. After easy-extending the core bundles everything was dandy, I just had to move files around and change some namespaces. But I ran into troubles, as the namespaces are hardcoded in XML files (which this PR fixes, for this bundle, for now).
2. Now `SonataPageBundle`. While making things more configurable for `MediaBundle`, matters are a lot worse for `SonataPageBundle`. Apart from the hardcoded class locations in configuration files (which can be similarly fixed), there are also use statement references from code (ie take a look at `SnapshotManager.php`)

I am not sure the current solution to reference application entities from the core `Sonata` namespace is a good idea. Perhaps a  Sonata core service should be introduced which allows the application to register it's overrides. This way every extending bundle could have any namespace.

Another idea (in case the previous gets shot down) is to define a parameter (`sonata.app.ns`?) which defaults to `Application\Sonata`. Then you could address your specific namespace needs by overriding only one parameter (instead of dozens of classes, as mentioned by @rande in the original issue)

Thoughts?
