### PR TITLE
Fix incorrect method call for getting provider name

### DIFF
--- a/Media/SimpleResizer.php
+++ b/Media/SimpleResizer.php
@@ -42,7 +42,7 @@ class SimpleResizer implements ResizerInterface
     public function resize(MediaInterface $media, File $in, File $out, $format, $settings)
     {
         if (!isset($settings['width'])) {
-            throw new \RuntimeException(sprintf('Width parameter is missing in context "%s" for provider "%s"', $media->getContext(), $media->getProviderClass()));
+            throw new \RuntimeException(sprintf('Width parameter is missing in context "%s" for provider "%s"', $media->getContext(), $media->getProviderName()));
         }
 
         $image = $this->getAdapter()->load($in->getContent());


### PR DESCRIPTION
There is a call to getProviderClass() here, which is not in MediaInterface.  It's just for an exception message, so fixing this with assumption getProviderName() should be used instead.
