### PR TITLE
allow mulitple resizers to reside in a provider

### DIFF
--- a/DependencyInjection/AddProviderPass.php
+++ b/DependencyInjection/AddProviderPass.php
@@ -114,7 +114,7 @@ class AddProviderPass implements CompilerPassInterface
                     }
                 }
             } else {
-                $definition->addMethodCall('setResizer', array(new Reference('sonata.media.resizer.simple')));
+                $definition->addMethodCall('addResizer', array('sonata.media.resizer.simple', new Reference('sonata.media.resizer.simple')));
             }
         }
     }

--- a/Provider/BaseProvider.php
+++ b/Provider/BaseProvider.php
@@ -27,6 +27,8 @@ abstract class BaseProvider implements MediaProviderInterface
 
     protected $templates = array();
 
+    protected $currentResizer = 'sonata.media.resizer.simple';
+
     protected $resizers;
 
     protected $filesystem;
@@ -217,11 +219,20 @@ abstract class BaseProvider implements MediaProviderInterface
     }
 
     /**
-     * @param string $key or 'default'
+     * @return string
+     */
+    public function getCurrentResizer()
+    {
+        return $this->currentResizer;
+    }
+
+    /**
+     * @param string $key or null selects currentResizer
      * @return \Sonata\MediaBundle\Media\ResizerInterface
      */
-    public function getResizer($key = 'default')
+    public function getResizer($key = null)
     {
+        $key = $key ? $key : $this->currentResizer;
         return isset($this->resizers[$key]) ? $this->resizers[$key] : null;
     }
 
@@ -261,6 +272,15 @@ abstract class BaseProvider implements MediaProviderInterface
     public function setResizer(ResizerInterface $resizer)
     {
         $this->resizers = array('default' => $resizer);
+    }
+
+    /**
+     * @param string $currentResizer
+     * @return void
+     */
+    public function setCurrentResizer($currentResizer)
+    {
+        $this->currentResizer = $currentResizer;
     }
 
     /**


### PR DESCRIPTION
I have a multiple stage upload and process. I'm uploading the image and passing back a link to a resized image that is used to in a cropping modal for the user to crop down to a sqaure area. Then when the form is submitted, I need to crop and scale the original image based on the cropping information passed back with the form. These are two distinct cropping tasks. No resizer in config still defaults to SimpleResizer. Keeps BC
