### PR TITLE
The renders of DailyMotion, Vimeo and Youtube should honor the format passed like the image one.

### DIFF
--- a/Provider/BaseVideoProvider.php
+++ b/Provider/BaseVideoProvider.php
@@ -169,4 +169,37 @@ abstract class BaseVideoProvider extends BaseProvider
 
         return $metadata;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHelperProperties(MediaInterface $media, $format, $options = array())
+    {
+        $format_configuration = $this->getFormat($format);
+
+        $width = $media->getWidth();
+        $height = $media->getHeight();
+
+        if (isset($format_configuration['width']) && isset($format_configuration['height'])) {
+            $width = $format_configuration['width'];
+            $height = $format_configuration['height'];
+        }
+        else if (isset($format_configuration['height'])) {
+            $width *= $format_configuration['height'];
+            $width /= $height;
+            $height = $format_configuration['height'];
+        }
+        else if (isset($format_configuration['width'])) {
+            $height *= $format_configuration['width'];
+            $height /= $width;
+            $width = $format_configuration['width'];
+        }
+
+        $params = array(
+            'width'             => isset($options['width'])             ? $options['width']  : $width,
+            'height'            => isset($options['height'])            ? $options['height'] : $height,
+        );
+
+        return $params;
+    }
 }

--- a/Provider/DailyMotionProvider.php
+++ b/Provider/DailyMotionProvider.php
@@ -73,35 +73,13 @@ class DailyMotionProvider extends BaseVideoProvider
 
         $player_parameters =  array_merge($defaults, isset($options['player_parameters']) ? $options['player_parameters'] : array());
 
-        $format_configuration = $this->getFormat($format);
-
-        $width = $media->getWidth();
-        $height = $media->getHeight();
-
-        if (isset($format_configuration['width']) && isset($format_configuration['height'])) {
-            $width = $format_configuration['width'];
-            $height = $format_configuration['height'];
-        }
-        else if (isset($format_configuration['height'])) {
-            $width *= $format_configuration['height'];
-            $width /= $height;
-            $height = $format_configuration['height'];
-        }
-        else if (isset($format_configuration['width'])) {
-            $height *= $format_configuration['width'];
-            $height /= $width;
-            $width = $format_configuration['width'];
-        }
-
         $params = array(
             'player_parameters' => http_build_query($player_parameters),
             'allowFullScreen'   => isset($options['allowFullScreen'])   ? $options['allowFullScreen']     : 'true',
             'allowScriptAccess' => isset($options['allowScriptAccess']) ? $options['allowScriptAccess'] : 'always',
-            'width'             => isset($options['width'])             ? $options['width']  : $width,
-            'height'            => isset($options['height'])            ? $options['height'] : $height,
         );
 
-        return $params;
+        return array_merge(parent::getHelperProperties($media,$format,$options),$params);
     }
 
     /**

--- a/Provider/VimeoProvider.php
+++ b/Provider/VimeoProvider.php
@@ -59,35 +59,13 @@ class VimeoProvider extends BaseVideoProvider
 
         $player_parameters =  array_merge($defaults, isset($options['player_parameters']) ? $options['player_parameters'] : array());
 
-        $format_configuration = $this->getFormat($format);
-
-        $width = $media->getWidth();
-        $height = $media->getHeight();
-
-        if (isset($format_configuration['width']) && isset($format_configuration['height'])) {
-            $width = $format_configuration['width'];
-            $height = $format_configuration['height'];
-        }
-        else if (isset($format_configuration['height'])) {
-            $width *= $format_configuration['height'];
-            $width /= $height;
-            $height = $format_configuration['height'];
-        }
-        else if (isset($format_configuration['width'])) {
-            $height *= $format_configuration['width'];
-            $height /= $width;
-            $width = $format_configuration['width'];
-        }
-
         $params = array(
             'src'         => http_build_query($player_parameters),
             'id'          => $player_parameters['js_swf_id'],
             'frameborder' => isset($options['frameborder']) ? $options['frameborder'] : 0,
-            'width'       => isset($options['width']) ? $options['width']  : $width,
-            'height'      => isset($options['height'])? $options['height'] : $height,
         );
 
-        return $params;
+        return array_merge(parent::getHelperProperties($media,$format,$options),$params);
     }
 
     /**

--- a/Provider/YouTubeProvider.php
+++ b/Provider/YouTubeProvider.php
@@ -115,35 +115,13 @@ class YouTubeProvider extends BaseVideoProvider
 
         $player_parameters =  array_merge($defaults, isset($options['player_parameters']) ? $options['player_parameters'] : array());
 
-        $format_configuration = $this->getFormat($format);
-
-        $width = $media->getWidth();
-        $height = $media->getHeight();
-
-        if (isset($format_configuration['width']) && isset($format_configuration['height'])) {
-            $width = $format_configuration['width'];
-            $height = $format_configuration['height'];
-        }
-        else if (isset($format_configuration['height'])) {
-            $width *= $format_configuration['height'];
-            $width /= $height;
-            $height = $format_configuration['height'];
-        }
-        else if (isset($format_configuration['width'])) {
-            $height *= $format_configuration['width'];
-            $height /= $width;
-            $width = $format_configuration['width'];
-        }
-
         $params = array(
             'player_parameters' => http_build_query($player_parameters),
             'allowFullScreen'   => $player_parameters['fs'] == '1'      ? 'true' : 'false',
             'allowScriptAccess' => isset($options['allowScriptAccess']) ? $options['allowScriptAccess'] : 'always',
-            'width'             => isset($options['width'])             ? $options['width']  : $width,
-            'height'            => isset($options['height'])            ? $options['height'] : $height,
         );
 
-        return $params;
+        return array_merge(parent::getHelperProperties($media,$format,$options),$params);
     }
 
     /**


### PR DESCRIPTION
Dailymotion, Youtube and Vimeo allows to resize the videos as you want and it fills out the extra space as needed
