### PR TITLE
Updating composer.json to reflect renaming of package sonata/admin-bundl...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": "2.*",
-        "sonata/admin-bundle": "master-dev"
+        "sonata-project/admin-bundle": "master-dev"
     },
     "suggest": {
         "sonata-project/doctrine-orm-admin-bundle": "*"


### PR DESCRIPTION
Composer is throwing a SolverExeption with the current file, i think it's because the package has been renamed?
