### PR TITLE
deprecated methods removed

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -64,7 +64,6 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                             ->arrayNode('providers')
-                                ->addDefaultsIfNotSet()
                                 ->prototype('scalar')
                                     ->defaultValue(array())
                                 ->end()
@@ -94,7 +93,6 @@ class Configuration implements ConfigurationInterface
         $node
             ->children()
                 ->arrayNode('cdn')
-                    ->useAttributeAsKey('id')
                     ->children()
                         ->arrayNode('server')
                             ->addDefaultsIfNotSet()
@@ -129,7 +127,6 @@ class Configuration implements ConfigurationInterface
         $node
             ->children()
                 ->arrayNode('filesystem')
-                    ->useAttributeAsKey('id')
                     ->children()
 
                         ->arrayNode('local')
@@ -181,7 +178,6 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->arrayNode('providers')
                     ->addDefaultsIfNotSet()
-                    ->useAttributeAsKey('id')
                     ->children()
                         ->arrayNode('file')
                             ->addDefaultsIfNotSet()
@@ -325,7 +321,6 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->arrayNode('resizer')
                     ->addDefaultsIfNotSet()
-                    ->useAttributeAsKey('id')
                     ->children()
                         ->arrayNode('simple')
                             ->addDefaultsIfNotSet()


### PR DESCRIPTION
The previous rebase goes wrong.
This is a correct pull request that removes some deprecated methods from di configuration
