### PR TITLE
Default context in gallery

### DIFF
--- a/Admin/GalleryAdmin.php
+++ b/Admin/GalleryAdmin.php
@@ -136,7 +136,7 @@ class GalleryAdmin extends Admin
         }
 
         return array(
-            'context'  => $this->getRequest()->get('context', 'default'),
+            'context'  => $this->getRequest()->get('context', $this->pool->getDefaultContext()),
         );
     }
 


### PR DESCRIPTION
The context should be taken from the new default_context parameter instead of 'default'
