### PR TITLE
moved list template to admin classes

### DIFF
--- a/Admin/BaseMediaAdmin.php
+++ b/Admin/BaseMediaAdmin.php
@@ -171,4 +171,13 @@ abstract class BaseMediaAdmin extends Admin
     {
         return $this->pool;
     }
+    
+    /**
+     * {inheritdoc}
+     */
+    public function setTemplates(array $templates) 
+    {
+        $templates['list'] = 'SonataMediaBundle:GalleryAdmin:list.html.twig';
+        parent::setTemplates($templates);
+    }
 }

--- a/Admin/GalleryAdmin.php
+++ b/Admin/GalleryAdmin.php
@@ -153,5 +153,13 @@ class GalleryAdmin extends Admin
 
         return $gallery;
     }
-
+    
+    /**
+     * {inheritdoc}
+     */
+    public function setTemplates(array $templates)
+    {
+        $templates['list'] = 'SonataMediaBundle:GalleryAdmin:list.html.twig';
+        parent::setTemplates($templates);
+    }
 }

--- a/Resources/config/doctrine_mongodb_admin.xml
+++ b/Resources/config/doctrine_mongodb_admin.xml
@@ -34,15 +34,6 @@
             <call method="setTranslationDomain">
                 <argument>%sonata.media.admin.media.translation_domain%</argument>
             </call>
-            <call method="setTemplates">
-                <argument type="collection">
-                    <argument key="layout">SonataAdminBundle::standard_layout.html.twig</argument>
-                    <argument key="ajax">SonataAdminBundle::ajax_layout.html.twig</argument>
-                    <argument key="edit">SonataAdminBundle:CRUD:edit.html.twig</argument>
-                    <argument key="show">SonataAdminBundle:CRUD:show.html.twig</argument>
-                    <argument key="list">SonataMediaBundle:MediaAdmin:list.html.twig</argument>
-                </argument>
-            </call>
         </service>
 
         <service id="sonata.media.admin.media.manager" class="Sonata\MediaBundle\Admin\Manager\DoctrineMongoDBManager">
@@ -59,16 +50,6 @@
 
             <call method="setTranslationDomain">
                 <argument>%sonata.media.admin.gallery.translation_domain%</argument>
-            </call>
-
-            <call method="setTemplates">
-                <argument type="collection">
-                    <argument key="layout">SonataAdminBundle::standard_layout.html.twig</argument>
-                    <argument key="ajax">SonataAdminBundle::ajax_layout.html.twig</argument>
-                    <argument key="edit">SonataAdminBundle:CRUD:edit.html.twig</argument>
-                    <argument key="show">SonataAdminBundle:CRUD:show.html.twig</argument>
-                    <argument key="list">SonataMediaBundle:GalleryAdmin:list.html.twig</argument>
-                </argument>
             </call>
         </service>
 

--- a/Resources/config/doctrine_orm_admin.xml
+++ b/Resources/config/doctrine_orm_admin.xml
@@ -34,15 +34,6 @@
             <call method="setTranslationDomain">
                 <argument>%sonata.media.admin.media.translation_domain%</argument>
             </call>
-            <call method="setTemplates">
-                <argument type="collection">
-                    <argument key="layout">SonataAdminBundle::standard_layout.html.twig</argument>
-                    <argument key="ajax">SonataAdminBundle::ajax_layout.html.twig</argument>
-                    <argument key="edit">SonataAdminBundle:CRUD:edit.html.twig</argument>
-                    <argument key="show">SonataAdminBundle:CRUD:show.html.twig</argument>
-                    <argument key="list">SonataMediaBundle:MediaAdmin:list.html.twig</argument>
-                </argument>
-            </call>
         </service>
 
         <service id="sonata.media.admin.media.manager" class="Sonata\MediaBundle\Admin\Manager\DoctrineORMManager">
@@ -61,15 +52,6 @@
                 <argument>%sonata.media.admin.gallery.translation_domain%</argument>
             </call>
 
-            <call method="setTemplates">
-                <argument type="collection">
-                    <argument key="layout">SonataAdminBundle::standard_layout.html.twig</argument>
-                    <argument key="ajax">SonataAdminBundle::ajax_layout.html.twig</argument>
-                    <argument key="edit">SonataAdminBundle:CRUD:edit.html.twig</argument>
-                    <argument key="show">SonataAdminBundle:CRUD:show.html.twig</argument>
-                    <argument key="list">SonataMediaBundle:GalleryAdmin:list.html.twig</argument>
-                </argument>
-            </call>
         </service>
 
         <service id="sonata.media.admin.gallery_has_media" class="%sonata.media.admin.gallery_has_media.class%">

--- a/Resources/config/doctrine_phpcr_admin.xml
+++ b/Resources/config/doctrine_phpcr_admin.xml
@@ -34,16 +34,6 @@
             <call method="setTranslationDomain">
                 <argument>%sonata.media.admin.media.translation_domain%</argument>
             </call>
-
-            <call method="setTemplates">
-                <argument type="collection">
-                    <argument key="layout">SonataAdminBundle::standard_layout.html.twig</argument>
-                    <argument key="ajax">SonataAdminBundle::ajax_layout.html.twig</argument>
-                    <argument key="edit">SonataAdminBundle:CRUD:edit.html.twig</argument>
-                    <argument key="show">SonataAdminBundle:CRUD:show.html.twig</argument>
-                    <argument key="list">SonataMediaBundle:MediaAdmin:list.html.twig</argument>
-                </argument>
-            </call>
         </service>
 
         <!--<service id="sonata.media.admin.media.manager" class="Sonata\MediaBundle\Admin\Manager\DoctrineMongoDBManager">-->
@@ -60,16 +50,6 @@
 
             <!--<call method="setTranslationDomain">-->
                 <!--<argument>%sonata.media.admin.gallery.translation_domain%</argument>-->
-            <!--</call>-->
-
-            <!--<call method="setTemplates">-->
-                <!--<argument type="collection">-->
-                    <!--<argument key="layout">SonataAdminBundle::standard_layout.html.twig</argument>-->
-                    <!--<argument key="ajax">SonataAdminBundle::ajax_layout.html.twig</argument>-->
-                    <!--<argument key="edit">SonataAdminBundle:CRUD:edit.html.twig</argument>-->
-                    <!--<argument key="show">SonataAdminBundle:CRUD:show.html.twig</argument>-->
-                    <!--<argument key="list">SonataMediaBundle:GalleryAdmin:list.html.twig</argument>-->
-                <!--</argument>-->
             <!--</call>-->
         <!--</service>-->
 


### PR DESCRIPTION
The current configuration does not take into account the `sonata.admin.configuration.templates` parameter. Currently, the media bundle has a different layout than other admin bundles if a custom layout has been defined.

This PR solves this by moving the `SonataMediaBundle:GalleryAdmin:list.html.twig` template into the admin class.
