### PR TITLE
Fix for smaller thumbnails than it should be for cropped images

### DIFF
--- a/Resizer/SquareResizer.php
+++ b/Resizer/SquareResizer.php
@@ -73,6 +73,7 @@ class SquareResizer implements ResizerInterface
             if ($crop > 0) {
                 $point = $higher == $size->getHeight() ? new Point(0, 0) : new Point($crop / 2, 0);
                 $image->crop($point, new Box($lower, $lower));
+                $size = $image->getSize();
             }
         }
 


### PR DESCRIPTION
When an image needs cropping the resizer is using the old size instead of the new cropped one.
