### PR TITLE
Fix link generation for media pills

### DIFF
--- a/Resources/views/MediaAdmin/list.html.twig
+++ b/Resources/views/MediaAdmin/list.html.twig
@@ -16,28 +16,33 @@ file that was distributed with this source code.
     <ul class="nav nav-pills">
         <li><a><strong>{{ "label.select_context"|trans({}, 'SonataMediaBundle') }}</strong></a></li>
         {% for name, context in media_pool.contexts %}
+            {% set provider = context.providers[0] %}
             {% if name == persistent_parameters.context %}
-                <li class="active"><a href="{{ admin.generateUrl('list', {'context' : name }) }}">{{ name }}</a></li>
+                <li class="active"><a href="{{ admin.generateUrl('list', {'context' : name, 'provider' : provider }) }}">{{ name }}</a></li>
             {% else %}
-                <li><a href="{{ admin.generateUrl('list', {'context' : name }) }}">{{ name }}</a></li>
+                <li><a href="{{ admin.generateUrl('list', {'context' : name, 'provider' : provider }) }}">{{ name }}</a></li>
             {% endif %}
         {% endfor %}
 
-        <li><a><strong>{{ "label.select_provider"|trans({}, 'SonataMediaBundle') }}</strong></a></li>
-
-        {% if not persistent_parameters.provider %}
-            <li class="active"><a href="{{ admin.generateUrl('list', {'context': persistent_parameters.context, 'provider': null}) }}">{{ "link.all_providers"|trans({}, 'SonataMediaBundle') }}</a></li>
-        {% else %}
-            <li><a href="{{ admin.generateUrl('list', {'context': persistent_parameters.context, 'provider': null}) }}">{{ "link.all_providers"|trans({}, 'SonataMediaBundle') }}</a></li>
+        {% set providers = media_pool.getProviderNamesByContext(persistent_parameters.context) %}
+        
+        {% if providers|length > 1 %}
+            <li><a><strong>{{ "label.select_provider"|trans({}, 'SonataMediaBundle') }}</strong></a></li>
+            
+            {% if not persistent_parameters.provider %}
+                <li class="active"><a href="{{ admin.generateUrl('list', {'context': persistent_parameters.context, 'provider': null}) }}">{{ "link.all_providers"|trans({}, 'SonataMediaBundle') }}</a></li>
+            {% else %}
+                <li><a href="{{ admin.generateUrl('list', {'context': persistent_parameters.context, 'provider': null}) }}">{{ "link.all_providers"|trans({}, 'SonataMediaBundle') }}</a></li>
+            {% endif %}
+    
+            {% for provider_name in providers %}
+                {% if persistent_parameters.provider == provider_name%}
+                    <li class="active"><a href="{{ admin.generateUrl('list', {'context': persistent_parameters.context, 'provider': provider_name}) }}">{{ provider_name|trans({}, 'SonataMediaBundle') }}</a></li>
+                {% else %}
+                    <li><a href="{{ admin.generateUrl('list', {'context': persistent_parameters.context, 'provider': provider_name}) }}">{{ provider_name|trans({}, 'SonataMediaBundle') }}</a></li>
+                {% endif %}
+            {% endfor %}
         {% endif %}
-
-        {% for provider_name in media_pool.getProviderNamesByContext(persistent_parameters.context) %}
-            {% if persistent_parameters.provider == provider_name%}
-                <li class="active"><a href="{{ admin.generateUrl('list', {'context': persistent_parameters.context, 'provider': provider_name}) }}">{{ provider_name|trans({}, 'SonataMediaBundle') }}</a></li>
-            {% else %}
-                <li><a href="{{ admin.generateUrl('list', {'context': persistent_parameters.context, 'provider': provider_name}) }}">{{ provider_name|trans({}, 'SonataMediaBundle') }}</a></li>
-            {% endif %}
-        {% endfor %}
     </ul>
 
 {% endblock %}


### PR DESCRIPTION
This patch fixes the generation of wrong links in the MediaBundles `list` view. Currently, if a context has only 1 provider, let's say an image provider, the generated link will always contain `sonata.media.provider.file` provider, because the `DefaultRouterGenerator` merges the PersistentParameters of the admin class with the ones passed into the `generateUrl` method.

When you then select the context with the single imageprovider and upload an image, you'll end up with an `Invalid extension` validation error, because the provider is set to `file` instead of image.

The PR fixes this issue by passing in the first provider of each context to the generateUrl method in the `list` template. 

Additionally, this PR shows the provider selection pills only if the selected `context` has more than one provider, otherwise the selection between `All` and `Image` makes not really sense.
