### PR TITLE
Update SF 2.1's Form BC

### DIFF
--- a/Form/Type/MediaType.php
+++ b/Form/Type/MediaType.php
@@ -61,7 +61,7 @@ class MediaType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent(array $options)
+    public function getParent()
     {
         return 'form';
     }


### PR DESCRIPTION
Forgot to adapt getParent(), as it does not take any "options" argument anymore
