### PR TITLE
Access level to Sonata\MediaBundle\Listener\ODM\MediaEventSubscriber::recomputeSingleEntityChangeSet() must be protected

### DIFF
--- a/Listener/ODM/MediaEventSubscriber.php
+++ b/Listener/ODM/MediaEventSubscriber.php
@@ -36,7 +36,7 @@ class MediaEventSubscriber extends BaseMediaEventSubscriber
      * @param \Doctrine\Common\EventArgs $args
      * @return void
      */
-    private function recomputeSingleEntityChangeSet(EventArgs $args)
+    protected function recomputeSingleEntityChangeSet(EventArgs $args)
     {
         $em = $args->getDocumentManager();
 


### PR DESCRIPTION
This commit just changed the method from private to protected
