### PR TITLE
Added services for AclAwareAmazonS3 Gaufrette Adapter

### DIFF
--- a/DependencyInjection/SonataMediaExtension.php
+++ b/DependencyInjection/SonataMediaExtension.php
@@ -308,11 +308,17 @@ class SonataMediaExtension extends Extension
         }
 
         // add the default configuration for the S3 filesystem
-        if ($container->hasDefinition('sonata.media.adapter.filesystem.s3') && isset($config['filesystem']['s3'])) {
+        if ($container->hasDefinition('sonata.media.adapter.filesystem.s3') && $container->hasDefinition('sonata.media.adapter.filesystem.acl_aware_s3') && isset($config['filesystem']['s3'])) {
             $container->getDefinition('sonata.media.adapter.filesystem.s3')
                 ->replaceArgument(0, new Reference('sonata.media.adapter.service.s3'))
                 ->replaceArgument(1, $config['filesystem']['s3']['bucket'])
                 ->replaceArgument(2, $config['filesystem']['s3']['create'])
+            ;
+            
+            $container->getDefinition('sonata.media.adapter.filesystem.acl_aware_s3')
+                ->replaceArgument(0, new Reference('sonata.media.adapter.filesystem.s3'))
+                ->replaceArgument(1, new Reference('sonata.media.adapter.service.s3'))
+                ->replaceArgument(2, $config['filesystem']['s3']['bucket'])
             ;
 
             $container->getDefinition('sonata.media.adapter.service.s3')
@@ -323,7 +329,9 @@ class SonataMediaExtension extends Extension
             ;
         } else {
             $container->removeDefinition('sonata.media.adapter.filesystem.s3');
+            $container->removeDefinition('sonata.media.adapter.filesystem.acl_aware_s3');
             $container->removeDefinition('sonata.media.filesystem.s3');
+            $container->removeDefinition('sonata.media.filesystem.acl_aware_s3');
         }
 
         if ($container->hasDefinition('sonata.media.adapter.filesystem.replicate') && isset($config['filesystem']['replicate'])) {

--- a/Resources/config/gaufrette.xml
+++ b/Resources/config/gaufrette.xml
@@ -4,24 +4,30 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="sonata.media.adapter.filesystem.local" class="Gaufrette\Adapter\Local" />
-        <service id="sonata.media.adapter.filesystem.ftp"   class="Gaufrette\Adapter\Ftp" />
-        <service id="sonata.media.adapter.service.s3"       class="AmazonS3" >
+        <service id="sonata.media.adapter.filesystem.local"        class="Gaufrette\Adapter\Local" />
+        <service id="sonata.media.adapter.filesystem.ftp"          class="Gaufrette\Adapter\Ftp" />
+        <service id="sonata.media.adapter.service.s3"              class="AmazonS3" >
             <argument type="collection" />
         </service>
 
-        <service id="sonata.media.adapter.filesystem.s3"    class="Gaufrette\Adapter\AmazonS3" >
+        <service id="sonata.media.adapter.filesystem.s3"           class="Gaufrette\Adapter\AmazonS3" >
+            <argument />
+            <argument />
+            <argument />
+        </service>
+        
+        <service id="sonata.media.adapter.filesystem.acl_aware_s3" class="Gaufrette\Adapter\AclAwareAmazonS3" >
             <argument />
             <argument />
             <argument />
         </service>
 
-        <service id="sonata.media.adapter.filesystem.replicate"  class="Sonata\MediaBundle\Filesystem\Replicate" >
+        <service id="sonata.media.adapter.filesystem.replicate"    class="Sonata\MediaBundle\Filesystem\Replicate" >
             <argument />
             <argument />
         </service>
 
-        <service id="sonata.media.adapter.filesystem.mogilefs"  class="Gaufrette\Adapter\MogileFS" >
+        <service id="sonata.media.adapter.filesystem.mogilefs"     class="Gaufrette\Adapter\MogileFS" >
             <argument />
             <argument />
         </service>
@@ -40,6 +46,10 @@
 
         <service id="sonata.media.filesystem.s3" class="Gaufrette\Filesystem">
             <argument type="service" id="sonata.media.adapter.filesystem.s3" />
+        </service>
+        
+        <service id="sonata.media.filesystem.acl_aware_s3" class="Gaufrette\Filesystem">
+            <argument type="service" id="sonata.media.adapter.filesystem.acl_aware_s3" />
         </service>
 
         <service id="sonata.media.filesystem.replicate" class="Gaufrette\Filesystem">

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -42,24 +42,25 @@ Available services
 
  - Providers
 
-    - sonata.media.provider.image         : Image
-    - sonata.media.provider.file          : File
-    - sonata.media.provider.dailymotion   : Dailymotion
-    - sonata.media.provider.vimeo         : Vimeo
-    - sonata.media.provider.youtube       : Youtube
+    - sonata.media.provider.image          : Image
+    - sonata.media.provider.file           : File
+    - sonata.media.provider.dailymotion    : Dailymotion
+    - sonata.media.provider.vimeo          : Vimeo
+    - sonata.media.provider.youtube        : Youtube
 
  -  Filesystem
 
-    - sonata.media.filesystem.local       : The local filesystem (default)
-    - sonata.media.filesystem.ftp         : FTP
-    - sonata.media.filesystem.s3          : Amazon S3
-    - sonata.media.filesystem.replicate   : Replicate file to a master and to a slave
+    - sonata.media.filesystem.local        : The local filesystem (default)
+    - sonata.media.filesystem.ftp          : FTP
+    - sonata.media.filesystem.s3           : Amazon S3
+    - sonata.media.filesystem.acl_aware_s3 : Amazon S3 (with ACL)
+    - sonata.media.filesystem.replicate    : Replicate file to a master and to a slave
 
  - CDN
 
-    - sonata.media.cdn.server             : The local http server (default)
-    - sonata.media.cdn.panther            : Panther Portal
-    - sonata.media.cdn.fallback           : Fallback, use the fallback (the http server) if the Media is not yet flushed on the CDN
+    - sonata.media.cdn.server              : The local http server (default)
+    - sonata.media.cdn.panther             : Panther Portal
+    - sonata.media.cdn.fallback            : Fallback, use the fallback (the http server) if the Media is not yet flushed on the CDN
 
 More services will be available in the future depending on your contributions! :)
 


### PR DESCRIPTION
To use ACL on AWS S3, you need to use the AclAwareAmazonS3 adapter instead of the AmazonS3 one.

I've added missing services on MediaBundle, but it remains to integrate ACL management. When using this new adapter, new files will be private (see http://docs.amazonwebservices.com/AmazonS3/latest/dev/ACLOverview.html#CannedACL for more information).
