### PR TITLE
Fix public URL generation in LiipImagineThumbnail

### DIFF
--- a/Thumbnail/LiipImagineThumbnail.php
+++ b/Thumbnail/LiipImagineThumbnail.php
@@ -42,9 +42,10 @@ class LiipImagineThumbnail implements ThumbnailInterface
                 sprintf('_imagine_%s', $format),
                 array('path' => sprintf('%s/%s_%s.jpg', $provider->generatePath($media), $media->getId(), $format))
             );
+            $path = ltrim($path, '/');
         }
 
-        return $provider->getCdnPath($path, $media->getCdnIsFlushable());
+        return $path;
     }
 
     /**


### PR DESCRIPTION
LiipImagineThumbnail::generatePublicUrl returns a path with two leading slashes (one added by Router::generate and the other by ImageProvider::getCdnPath), which at the end results in a path with three leading slashes, because ImageProvider::getCdnPath gets called again by ImageProvider::generatePublicUrl. 
FormatThumbnail::generatePublicUrl is an example of a working thumbnail provider that returns a path with no leading slashes.

The issue is documented here: https://groups.google.com/d/msg/sonata-users/xstEkej6TqY/ZcNYvGLxNQEJ
