### PR TITLE
Catch exceptions thrown during form transformation

### DIFF
--- a/Provider/ImageProvider.php
+++ b/Provider/ImageProvider.php
@@ -83,13 +83,17 @@ class ImageProvider extends FileProvider
         parent::doTransform($media);
 
         if ($media->getBinaryContent()) {
-            $image = $this->imagineAdapter->open($media->getBinaryContent()->getPathname());
-            $size  = $image->getSize();
-
-            $media->setWidth($size->getWidth());
-            $media->setHeight($size->getHeight());
-
-            $media->setProviderStatus(MediaInterface::STATUS_OK);
+            try {
+                $image = $this->imagineAdapter->open($media->getBinaryContent()->getPathname());
+                $size = $image->getSize();
+    
+                $media->setWidth($size->getWidth());
+                $media->setHeight($size->getHeight());
+    
+                $media->setProviderStatus(MediaInterface::STATUS_OK);
+            } catch (\Exception $e) {
+                $media->setProviderStatus(MediaInterface::STATUS_ERROR);
+            }
         }
     }
 


### PR DESCRIPTION
Imagine\Gd\Imagine::open throws numerous exceptions when handed a non-image file. This happens before form validation, so instead of errors, the user is shown only a status 500 page.
