### PR TITLE
Proxy Doctrine MongoDB ODM event calls to provider in MediaManager

### DIFF
--- a/Document/ODM/MediaManager.php
+++ b/Document/ODM/MediaManager.php
@@ -21,6 +21,7 @@ class MediaManager extends AbstractMediaManager
     protected $dm;
     protected $repository;
     protected $class;
+    protected $pool;
 
     /**
      * @param \Sonata\MediaBundle\Provider\Pool     $pool
@@ -30,7 +31,7 @@ class MediaManager extends AbstractMediaManager
     public function __construct(Pool $pool, DocumentManager $dm, $class)
     {
         $this->dm = $dm;
-
+        $this->pool = $pool;
         parent::__construct($pool, $class);
     }
 
@@ -59,16 +60,20 @@ class MediaManager extends AbstractMediaManager
             $media->setProviderName($providerName);
         }
 
+        $subscriber = new ProviderSubscriber($this->pool->getProvider($media->getProviderName()));
+        $this->dm->getEventManager()->addEventSubscriber($subscriber);
         // just in case the pool alter the media
         $this->dm->persist($media);
         $this->dm->flush();
     }
-
+    
     /**
      * {@inheritdoc}
      */
     public function delete(MediaInterface $media)
     {
+        $subscriber = new ProviderSubscriber($this->pool->getProvider($media->getProviderName()));
+        $this->dm->getEventManager()->addEventSubscriber($subscriber);
         $this->dm->remove($media);
         $this->dm->flush();
     }

--- a/Document/ODM/ProviderSubscriber.php
+++ b/Document/ODM/ProviderSubscriber.php
@@ -1,0 +1,44 @@
+<?php
+namespace Sonata\MediaBundle\Document\ODM;
+
+use Sonata\MediaBundle\Provider\MediaProviderInterface;
+use Doctrine\Common\EventSubscriber;
+
+class ProviderSubscriber implements EventSubscriber
+{
+	/**
+	 * @var MediaProviderInterface
+	 */
+	protected $provider;
+	protected $events = array();
+
+	/**
+	 * @param MediaProviderInterface $provider
+	 */
+	public function __construct(MediaProviderInterface $provider)
+	{
+		$this->provider = $provider;
+	}
+	
+	/**
+	 * Proxy event calls to profiler
+	 * 
+	 * @param string $name
+	 * @param array $arguments
+	 */
+	public function __call($name, $arguments)
+	{
+		if (in_array($name, $this->events))
+			$this->provider->$name($arguments[0]->getDocument());
+	}
+	
+	/**
+	 * @inheritdoc
+	 */
+	public function getSubscribedEvents()
+	{
+		$reflector = new \ReflectionClass('\Doctrine\ODM\MongoDB\Events');
+		$methods = get_class_methods($this->provider);
+		return $this->events = array_intersect($reflector->getConstants(), $methods);
+	}
+}


### PR DESCRIPTION
I haven't any experience with SonataMediaBundle, but after switch from Doctrine ORM to Doctrine MongoDB ODM, files stopped to write into filesystem. So after some research i found that prePersist/postPersist/etc methods in Provider was not called. In the MediaManager I added a class ProviderSubscriber witch listening to appropriate Doctrine MongoDB ODM events http://docs.doctrine-project.org/projects/doctrine-mongodb-odm/en/latest/reference/events.html.

Now works fine. Maybe there is better solution in implementation. Please suggest if any.
