### PR TITLE
Patch 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "sonata-project/notification-bundle": "dev-master",
         "sonata-project/easy-extends-bundle": "dev-master",
         "knplabs/gaufrette": "dev-master",
-        "imagine/Imagine": "dev-master",
+        "imagine/Imagine": "0.3.0",
         "kriswallsmith/buzz": "0.7"
     },
     "require-dev": {


### PR DESCRIPTION
To use the bundle with HWIOAuthBundle it must use the same buzz version.

HWIOAuthBundle use the latest tag 0.7.

So in gerneral it is a good idea to use tags instate of latest dev version.
