### PR TITLE
Composer for imagine and for symfony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "symfony/symfony": "dev-master",
+        "symfony/symfony": "2.1.*",
         "sonata-project/admin-bundle": "dev-master",
         "sonata-project/notification-bundle": "dev-master",
         "sonata-project/easy-extends-bundle": "dev-master",


### PR DESCRIPTION
for the imagine dependency see [this issue](https://github.com/sonata-project/SonataMediaBundle/issues/190)
for symfony, now the 2.1 branch is stable, so it make sense to require the 2.1.\* version, like the [NotificationBundle](https://github.com/sonata-project/SonataNotificationBundle/blob/master/composer.json) already does
