### PR TITLE
Replaces array type into json_array for Doctrine ORM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+CHANGELOG
+=========
+
+A [BC BREAK] means the update will break the project for many reasons:
+
+* new mandatory configuration
+* new dependencies
+* class refactoring
+
+### 2012-10-29
+
+* [BC BREAK] The provider metadata field now uses the "json" type from sonata-project/doctrine-extensions
+
+  Use the Migrate command to change old provider metadata fields into json:
+
+  app/console sonata:media:migrate-json --table=media__media

--- a/Command/MigrateToJsonTypeCommand.php
+++ b/Command/MigrateToJsonTypeCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Command;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\Output;
+
+class MigrateToJsonTypeCommand extends BaseCommand
+{
+    public function configure()
+    {
+        $this->setName('sonata:media:migrate-json');
+        $this->addOption('table', null, InputOption::VALUE_OPTIONAL, 'Media table', 'media__media');
+        $this->addOption('column', null, InputOption::VALUE_OPTIONAL, 'Column name for provider_metadata', 'provider_metadata');
+        $this->addOption('column_id', null, InputOption::VALUE_OPTIONAL, 'Column name for id', 'id');
+        $this->setDescription('Migrate all media provider metadata to the doctrine JsonType');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $count = 0;
+        $table = $input->getOption('table');
+        $column = $input->getOption('column');
+        $columnId = $input->getOption('column_id');
+        $connection = $this->getContainer()->get('doctrine.orm.entity_manager')->getConnection();
+        $medias = $connection->fetchAll("SELECT * FROM $table");
+
+        foreach($medias as $media) {
+            // if the row need to migrate
+            if (0 !== strpos($media[$column], '{') && $media[$column] !== '[]') {
+                $media[$column] = json_encode(unserialize($media[$column]));
+                $connection->update($table, array($column => $media[$column]), array($columnId => $media[$columnId]));
+                $count++;
+            }
+        }
+
+        $output->writeln("Migrated $count medias");
+    }
+}

--- a/Resources/config/doctrine/BaseMedia.orm.xml
+++ b/Resources/config/doctrine/BaseMedia.orm.xml
@@ -14,7 +14,7 @@
         <field name="providerName"      column="provider_name"            type="string"   nullable="false" length="255" default="image" />
         <field name="providerStatus"    column="provider_status"          type="integer"  nullable="false" />
         <field name="providerReference" column="provider_reference"       type="string"   nullable="false" length="255"/>
-        <field name="providerMetadata"  column="provider_metadata"        type="array"    nullable="true" />
+        <field name="providerMetadata"  column="provider_metadata"        type="json"     nullable="true" />
 
         <field name="width"             column="width"             type="integer"  nullable="true" />
         <field name="height"            column="height"            type="integer"  nullable="true" />

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "sonata-project/admin-bundle": "dev-master",
         "sonata-project/notification-bundle": "dev-master",
         "sonata-project/easy-extends-bundle": "dev-master",
+        "sonata-project/doctrine-extensions": "dev-master",
         "knplabs/gaufrette": "dev-master",
         "imagine/Imagine": "v0.3.0",
         "kriswallsmith/buzz": "0.7"


### PR DESCRIPTION
Doctrine 2.3 introduced a native "json_array" type which fits better than the array field (which serializes data and makes it hard to read and nearly uneditable in database)
