### PR TITLE
removed "v" in front of 0.3.0 imagine/Imagine

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "sonata-project/easy-extends-bundle": "dev-master",
         "sonata-project/doctrine-extensions": "dev-master",
         "knplabs/gaufrette": "dev-master",
-        "imagine/Imagine": "v0.3.0",
+        "imagine/Imagine": "0.3.0",
         "kriswallsmith/buzz": "0.7"
     },
     "require-dev": {


### PR DESCRIPTION
Problem 1
    - Can only install one of: imagine/Imagine v0.3.0, imagine/Imagine dev-master.
    - Can only install one of: imagine/Imagine v0.3.0, imagine/Imagine dev-master.
    - sonata-project/media-bundle dev-master requires imagine/imagine v0.3.0 -> satisfiable by imagine/Imagine v0.3.0.
    - Installation request for sonata-project/media-bundle dev-master -> satisfiable by sonata-project/media-bundle dev-master.
    - Installation request for imagine/imagine dev-master -> satisfiable by imagine/Imagine dev-master.
