### PR TITLE
Removed default template passing to setTemplates

### DIFF
--- a/Resources/config/doctrine_orm_admin.xml
+++ b/Resources/config/doctrine_orm_admin.xml
@@ -36,10 +36,6 @@
             </call>
             <call method="setTemplates">
                 <argument type="collection">
-                    <argument key="layout">SonataAdminBundle::standard_layout.html.twig</argument>
-                    <argument key="ajax">SonataAdminBundle::ajax_layout.html.twig</argument>
-                    <argument key="edit">SonataAdminBundle:CRUD:edit.html.twig</argument>
-                    <argument key="show">SonataAdminBundle:CRUD:show.html.twig</argument>
                     <argument key="list">SonataMediaBundle:MediaAdmin:list.html.twig</argument>
                 </argument>
             </call>
@@ -63,10 +59,6 @@
 
             <call method="setTemplates">
                 <argument type="collection">
-                    <argument key="layout">SonataAdminBundle::standard_layout.html.twig</argument>
-                    <argument key="ajax">SonataAdminBundle::ajax_layout.html.twig</argument>
-                    <argument key="edit">SonataAdminBundle:CRUD:edit.html.twig</argument>
-                    <argument key="show">SonataAdminBundle:CRUD:show.html.twig</argument>
                     <argument key="list">SonataMediaBundle:GalleryAdmin:list.html.twig</argument>
                 </argument>
             </call>


### PR DESCRIPTION
This will allow for the bundle to pick up any custom configured template files used in SonataAdminBundle, except for the ones that are really customized by SonataMediaBundle
