### PR TITLE
Removed default template passing to setTemplates in Mongo and PHPRC

### DIFF
--- a/Resources/config/doctrine_mongodb_admin.xml
+++ b/Resources/config/doctrine_mongodb_admin.xml
@@ -36,10 +36,6 @@
             </call>
             <call method="setTemplates">
                 <argument type="collection">
-                    <argument key="layout">SonataAdminBundle::standard_layout.html.twig</argument>
-                    <argument key="ajax">SonataAdminBundle::ajax_layout.html.twig</argument>
-                    <argument key="edit">SonataAdminBundle:CRUD:edit.html.twig</argument>
-                    <argument key="show">SonataAdminBundle:CRUD:show.html.twig</argument>
                     <argument key="list">SonataMediaBundle:MediaAdmin:list.html.twig</argument>
                 </argument>
             </call>
@@ -63,10 +59,6 @@
 
             <call method="setTemplates">
                 <argument type="collection">
-                    <argument key="layout">SonataAdminBundle::standard_layout.html.twig</argument>
-                    <argument key="ajax">SonataAdminBundle::ajax_layout.html.twig</argument>
-                    <argument key="edit">SonataAdminBundle:CRUD:edit.html.twig</argument>
-                    <argument key="show">SonataAdminBundle:CRUD:show.html.twig</argument>
                     <argument key="list">SonataMediaBundle:GalleryAdmin:list.html.twig</argument>
                 </argument>
             </call>

--- a/Resources/config/doctrine_phpcr_admin.xml
+++ b/Resources/config/doctrine_phpcr_admin.xml
@@ -37,10 +37,6 @@
 
             <call method="setTemplates">
                 <argument type="collection">
-                    <argument key="layout">SonataAdminBundle::standard_layout.html.twig</argument>
-                    <argument key="ajax">SonataAdminBundle::ajax_layout.html.twig</argument>
-                    <argument key="edit">SonataAdminBundle:CRUD:edit.html.twig</argument>
-                    <argument key="show">SonataAdminBundle:CRUD:show.html.twig</argument>
                     <argument key="list">SonataMediaBundle:MediaAdmin:list.html.twig</argument>
                 </argument>
             </call>
@@ -64,10 +60,6 @@
 
             <!--<call method="setTemplates">-->
                 <!--<argument type="collection">-->
-                    <!--<argument key="layout">SonataAdminBundle::standard_layout.html.twig</argument>-->
-                    <!--<argument key="ajax">SonataAdminBundle::ajax_layout.html.twig</argument>-->
-                    <!--<argument key="edit">SonataAdminBundle:CRUD:edit.html.twig</argument>-->
-                    <!--<argument key="show">SonataAdminBundle:CRUD:show.html.twig</argument>-->
                     <!--<argument key="list">SonataMediaBundle:GalleryAdmin:list.html.twig</argument>-->
                 <!--</argument>-->
             <!--</call>-->


### PR DESCRIPTION
Removed default template passing to setTemplates in Mongo and PHPRC config files.
https://github.com/sonata-project/SonataMediaBundle/pull/239
