### PR TITLE
Updates to work with PHPCR

### DIFF
--- a/Admin/PHPCR/MediaAdmin.php
+++ b/Admin/PHPCR/MediaAdmin.php
@@ -13,9 +13,52 @@ namespace Sonata\MediaBundle\Admin\PHPCR;
 
 use Sonata\MediaBundle\Admin\BaseMediaAdmin as Admin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Route\RouteCollection;
 
 class MediaAdmin extends Admin
 {
+    /**
+     * Path to the root node of simple pages.
+     *
+     * @var string
+     */
+    protected $root;
+
+    public function setRoot($root)
+    {
+        $this->root = $root;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createQuery($context = 'list')
+    {
+        $query = $this->getModelManager()->createQuery($this->getClass(), '', $this->root);
+
+        foreach ($this->extensions as $extension) {
+            $extension->configureQuery($this, $query, $context);
+        }
+
+        return $query;
+    }
+
+    public function generateObjectUrl($name, $object, array $parameters = array(), $absolute = false)
+    {
+        $parameters['id'] = $this->getUrlsafeIdentifier($object);
+        return $this->generateUrl($name, $parameters, $absolute);
+    }
+
+    public function getUrlsafeIdentifier($object)
+    {
+        return $this->modelManager->getUrlsafeIdentifier($object);
+    }
+
+    public function id($object)
+    {
+        return $this->getUrlsafeIdentifier($object);
+    }
+
     /**
      * @param \Sonata\AdminBundle\Datagrid\DatagridMapper $datagridMapper
      * @return void

--- a/Command/BaseCommand.php
+++ b/Command/BaseCommand.php
@@ -15,7 +15,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 
 use Sonata\MediaBundle\Provider\ImageProvider;
-use Sonata\MediaBundle\Document\MediaManager;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;

--- a/Listener/PHPCR/MediaEventSubscriber.php
+++ b/Listener/PHPCR/MediaEventSubscriber.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Listener\PHPCR;
+
+use Doctrine\Common\EventArgs;
+use Doctrine\ODM\PHPCR\Event;
+use Sonata\MediaBundle\Listener\BaseMediaEventSubscriber;
+
+class MediaEventSubscriber extends BaseMediaEventSubscriber
+{
+    /**
+     * @return array
+     */
+    public function getSubscribedEvents()
+    {
+        return array(
+            Event::prePersist,
+            Event::preUpdate,
+            Event::preRemove,
+            Event::postUpdate,
+            Event::postRemove,
+            Event::postPersist,
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function recomputeSingleEntityChangeSet(EventArgs $args)
+    {
+//        $dm = $args->getDocumentManager();
+        // TODO: is this needed for PHPCR?
+    }
+    
+    /**
+     * @inheritdoc
+     */
+    protected function getMedia(EventArgs $args)
+    {
+        return $args->getDocument();
+    }
+}

--- a/PHPCR/GalleryManager.php
+++ b/PHPCR/GalleryManager.php
@@ -12,36 +12,21 @@ namespace Sonata\MediaBundle\PHPCR;
 
 use Sonata\MediaBundle\Model\GalleryManager as AbstractGalleryManager;
 use Sonata\MediaBundle\Model\GalleryInterface;
-use Sonata\MediaBundle\Provider\Pool;
-use Doctrine\ODM\MongoDB\DocumentManager;
-use Doctrine\ODM\MongoDB\DocumentRepository;
+use Sonata\DoctrinePHPCRAdminBundle\Model\ModelManager;
 
 class GalleryManager extends AbstractGalleryManager
 {
-    protected $dm;
-    protected $repository;
+    protected $modelManager;
     protected $class;
 
     /**
-     * @param \Doctrine\ODM\MongoDB\DocumentManager $dm
-     * @param string                                $class
+     * @param \Sonata\DoctrinePHPCRAdminBundle\Model\ModelManager $modelManager
+     * @param $class
      */
-    public function __construct(DocumentManager $dm, $class)
+    public function __construct(ModelManager $modelManager, $class)
     {
-        $this->dm    = $dm;
-        $this->class = $class;
-    }
-
-    /**
-     * @return mixed
-     */
-    protected function getRepository()
-    {
-        if (!$this->repository) {
-            $this->repository = $this->dm->getRepository($this->class);
-        }
-
-        return $this->repository;
+        $this->modelManager = $modelManager;
+        $this->class        = $class;
     }
 
     /**

--- a/Resources/config/doctrine_phpcr.xml
+++ b/Resources/config/doctrine_phpcr.xml
@@ -5,27 +5,29 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="sonata.media.manager.media.class">Sonata\MediaBundle\Document\PHPCR\MediaManager</parameter>
-        <parameter key="sonata.media.manager.gallery.class">Sonata\MediaBundle\Document\PHPCR\GalleryManager</parameter>
+        <parameter key="sonata.media.manager.media.class">Sonata\MediaBundle\PHPCR\MediaManager</parameter>
+        <parameter key="sonata.media.manager.gallery.class">Sonata\MediaBundle\PHPCR\GalleryManager</parameter>
     </parameters>
 
     <services>
-        <service id="sonata.media.document_manager" alias="doctrine_phpcr.odm.default_document_manager" />
-
         <service id="sonata.media.manager.media" class="%sonata.media.manager.media.class%">
             <argument type="service" id="sonata.media.pool" />
-            <argument type="service" id="sonata.media.document_manager" />
+            <argument type="service" id="sonata.admin.manager.doctrine_phpcr" />
             <argument>%sonata.media.media.class%</argument>
         </service>
 
         <service id="sonata.media.manager.gallery" class="%sonata.media.manager.gallery.class%">
-            <argument type="service" id="sonata.media.document_manager" />
-            <argument>Application\Sonata\MediaBundle\Document\PHPCR\Gallery</argument>
+            <argument type="service" id="sonata.admin.manager.doctrine_phpcr" />
+            <argument>%sonata.media.manager.gallery.class%</argument>
         </service>
 
         <!-- Path generator servive -->
-        <service id="sonata.media.generator.default" class="Sonata\MediaBundle\Generator\ODMGenerator">
+        <service id="sonata.media.generator.default" class="Sonata\MediaBundle\Generator\DefaultGenerator" />
 
+        <service id="sonata.media.doctrine.event_subscriber" class="Sonata\MediaBundle\Listener\PHPCR\MediaEventSubscriber">
+            <tag name="doctrine_phpcr.event_subscriber" />
+
+            <argument type="service" id="service_container" />
         </service>
     </services>
 

--- a/Resources/config/doctrine_phpcr_admin.xml
+++ b/Resources/config/doctrine_phpcr_admin.xml
@@ -28,9 +28,6 @@
             <argument>%sonata.media.admin.media.controller%</argument>
             <argument type="service" id="sonata.media.pool" />
 
-            <!--<call method="setModelManager">-->
-                <!--<argument type="service" id="sonata.media.admin.media.manager" />-->
-            <!--</call>-->
             <call method="setTranslationDomain">
                 <argument>%sonata.media.admin.media.translation_domain%</argument>
             </call>
@@ -39,6 +36,10 @@
                 <argument type="collection">
                     <argument key="list">SonataMediaBundle:MediaAdmin:list.html.twig</argument>
                 </argument>
+            </call>
+
+            <call method="setRouteBuilder">
+                <argument type="service" id="sonata.admin.route.path_info_slashes" />
             </call>
         </service>
 

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -48,6 +48,8 @@ Next, add the correct routing files:
 
 Then you must configure the interaction with the orm and add the mediaBundles settings:
 
+Doctrine ORM:
+
 .. code-block:: yaml
 
     # app/config/config.yml
@@ -63,9 +65,26 @@ Then you must configure the interaction with the orm and add the mediaBundles se
             types:
                 json: Sonata\Doctrine\Types\JsonType
 
+Doctrine PHPCR:
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+
+    doctrine_phpcr:
+        odm:
+            auto_mapping: true
+            mappings:
+                SonataMediaBundle:
+                    prefix: Sonata\MediaBundle\PHPCR
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+
     sonata_media:
         default_context: default
-        db_driver: doctrine_orm # or doctrine_mongodb
+        db_driver: doctrine_orm # or doctrine_mongodb, doctrine_phpcr
         contexts:
             default:  # the default context is mandatory
                 providers:

--- a/Resources/views/MediaAdmin/list_custom.html.twig
+++ b/Resources/views/MediaAdmin/list_custom.html.twig
@@ -13,7 +13,7 @@ file that was distributed with this source code.
 
 {% block field %}
     <div>
-        <a href="{{ admin.generateUrl('edit', {'id' : object.id}) }}" style="float: left; margin-right: 6px;">{% thumbnail object, 'admin' with {'width': 75, 'height': 60} %}</a>
+        <a href="{{ admin.generateUrl('edit', {'id' : admin.id(object)}) }}" style="float: left; margin-right: 6px;">{% thumbnail object, 'admin' with {'width': 75, 'height': 60} %}</a>
         <strong>{{ object.name }}</strong> <br />
         {{ object.providerName|trans({}, 'SonataMediaBundle') }}: {{ object.width }}x{{ object.height }} <br />
     </div>

--- a/Resources/views/MediaAdmin/list_image.html.twig
+++ b/Resources/views/MediaAdmin/list_image.html.twig
@@ -12,5 +12,5 @@ file that was distributed with this source code.
 {% extends 'SonataAdminBundle:CRUD:base_list_field.html.twig' %}
 
 {% block field%}
-    <a href="{{ admin.generateUrl('edit', {'id' : object.id}) }}">{% thumbnail object, 'admin' with {'width': 75, 'height': 60} %}</a>
+    <a href="{{ admin.generateUrl('edit', {'id' : admin.id(object)}) }}">{% thumbnail object, 'admin' with {'width': 75, 'height': 60} %}</a>
 {% endblock %}

--- a/Resources/views/MediaAdmin/view.html.twig
+++ b/Resources/views/MediaAdmin/view.html.twig
@@ -27,7 +27,7 @@ file that was distributed with this source code.
         {% if pixlr and pixlr.isEditable(media) %}
             <tr>
                 <td></td>
-                <td><a class="btn" href="{{ path('sonata_media_pixlr_open_editor', {'id': media.id }) }}">{{ "label.edit_with_pixlr"|trans({}, "SonataMediaBundle")}}</a></td>
+                <td><a class="btn" href="{{ path('sonata_media_pixlr_open_editor', {'id': admin.id(media) }) }}">{{ "label.edit_with_pixlr"|trans({}, "SonataMediaBundle")}}</a></td>
             </tr>
         {% endif %}
         <tr>
@@ -68,8 +68,8 @@ file that was distributed with this source code.
         <tr>
             <td>{{ 'label.protected_download_url'|trans({}, 'SonataMediaBundle') }}</td>
             <td>
-                <input type="text" value="{{ path('sonata_media_download', {'id': media.id}) }}" style="width:500px"/>
-                <a href="{{ path('sonata_media_download', {'id': media.id}) }}">{{ 'link.test_protected_url'|trans({}, 'SonataMediaBundle') }}</a>
+                <input type="text" value="{{ path('sonata_media_download', {'id': admin.id(media)}) }}" style="width:500px"/>
+                <a href="{{ path('sonata_media_download', {'id': admin.id(media)}) }}">{{ 'link.test_protected_url'|trans({}, 'SonataMediaBundle') }}</a>
                 <br />
                 <span class="label warning">{{ 'label.protected_download_url_notice'|trans({}, 'SonataMediaBundle') }}</span> {{ security.description }}
             </td>
@@ -85,7 +85,7 @@ file that was distributed with this source code.
     <table>
         <tr>
             <td>
-                <a href="{{ admin.generateUrl('view', { 'id' : media.id, 'format' : 'reference'}) }}">reference</a>
+                <a href="{{ admin.generateUrl('view', { 'id' : admin.id(media), 'format' : 'reference'}) }}">reference</a>
             </td>
             <td>
                 <input type="text" value="{% path media, 'reference' %}"  style="width:500px" />
@@ -95,7 +95,7 @@ file that was distributed with this source code.
         {% for name, format in formats %}
             <tr>
                 <td>
-                    <a href="{{ admin.generateUrl('view', { 'id' : media.id, 'format' : name}) }}">{{ name }}</a>
+                    <a href="{{ admin.generateUrl('view', { 'id' : admin.id(media), 'format' : name}) }}">{{ name }}</a>
                 </td>
                 <td>
                     <input type="text" value="{% path media, name %}"  style="width:500px"/>


### PR DESCRIPTION
This PR does some updates to have the Media object work with PHPCR. 

See also https://groups.google.com/forum/?fromgroups=#!topic/symfony-cmf-devs/l8d9te56r6s

Remarks:
- the Gallery is not updated in this PR.
- also the PHPCR/MediaManager.php contains a hack for the findBy and findOneBy that still needs to be solved
- some templates are updated to use the admin.id method for the id parameter when generating url's, this fixes for PHPCR to use no leading "/", there are some templates left (pixlr) that could not be fixed this way.  The urls in these templates will not work at moment for PHPCR
