### PR TITLE
[Bug fix] Pixlr url

### DIFF
--- a/Extra/Pixlr.php
+++ b/Extra/Pixlr.php
@@ -152,7 +152,7 @@ class Pixlr
             's'          => 'c', // ??
             'referrer'   => $this->referrer,
             'exit'       => $this->router->generate('sonata_media_pixlr_exit', array('hash' => $hash, 'id' => $media->getId()), true),
-            'image'      => $provider->generatePublicUrl($media, 'reference'),
+            'image'      => $this->container->get('request')->getUriForPath($provider->generatePublicUrl($media, 'reference')),
             'title'      => $media->getName(),
             'target'     => $this->router->generate('sonata_media_pixlr_target', array('hash' => $hash, 'id' => $media->getId()), true),
             'locktitle'  => true,


### PR DESCRIPTION
I don't know if the problem exists with other providers, But the variable send to pixlr was a path without scheme and host name for the image.

This code fixes (at least for me) the path to an url sended and recognized by pixlr.
