### PR TITLE
Apply sonata_urlsafeid to templates

### DIFF
--- a/Resources/doc/reference/security.rst
+++ b/Resources/doc/reference/security.rst
@@ -49,7 +49,7 @@ The related download route name is ``sonata_media_download``.
 
 .. code-block:: jinja
 
-    <a href="{{ path('sonata_media_download', {'id': media.id}) }}">Download file</a>
+    <a href="{{ path('sonata_media_download', {'id': media|sonata_urlsafeid }) }}">Download file</a>
 
 Creating your own Security Download Strategy
 --------------------------------------------

--- a/Resources/views/Extra/pixlr_editor.html.twig
+++ b/Resources/views/Extra/pixlr_editor.html.twig
@@ -99,12 +99,12 @@ file that was distributed with this source code.
                 {{ "label.pixlr_warning"|trans({}, "SonataMediaBundle")|raw }}
             </div>
 
-            <a href="{{ url('sonata_media_pixlr_edit', {'id': media.id, 'mode': 'express'}) }}" class="box">
+            <a href="{{ url('sonata_media_pixlr_edit', {'id': media|sonata_urlsafeid , 'mode': 'express'}) }}" class="box">
                 <img src="{{ asset('bundles/sonatamedia/extra/pixlr/express_128.png')}}" alt="Pixlr Express" style="margin-left: -5px;"/>
                 {{ "label.pixlr_express_editor"|trans({}, "SonataMediaBundle")|raw }}
             </a>
 
-            <a href="{{ url('sonata_media_pixlr_edit', {'id': media.id, 'mode': 'editor'}) }}" class="box">
+            <a href="{{ url('sonata_media_pixlr_edit', {'id': media|sonata_urlsafeid , 'mode': 'editor'}) }}" class="box">
                 <img src="{{ asset('bundles/sonatamedia/extra/pixlr/editor_128.png')}}" alt="Pixlr Editor" style="margin-left: -5px;"/>
                 {{ "label.pixlr_advanced_editor"|trans({}, "SonataMediaBundle")|raw }}
             </a>

--- a/Resources/views/Gallery/index.html.twig
+++ b/Resources/views/Gallery/index.html.twig
@@ -11,6 +11,6 @@ file that was distributed with this source code.
 
 <ul>
     {% for gallery in galleries %}
-        <li><a href="{{ url('sonata_media_gallery_view', {'id' : gallery.id }) }}">{{ gallery.name }}</a></li>
+        <li><a href="{{ url('sonata_media_gallery_view', {'id' : gallery|sonata_urlsafeid }) }}">{{ gallery.name }}</a></li>
     {% endfor %}
 </ul>

--- a/Resources/views/Gallery/view.html.twig
+++ b/Resources/views/Gallery/view.html.twig
@@ -14,7 +14,7 @@ file that was distributed with this source code.
 <div class="sonata-media-gallery-media-list">
     {% for galleryHasMedia in gallery.GalleryHasMedias %}
         <div class="sonata-media-gallery-media-item">
-            <a class="sonata-media-gallery-media-item-link" href="{{ url('sonata_media_view', {'id': galleryHasMedia.media.id }) }}">
+            <a class="sonata-media-gallery-media-item-link" href="{{ url('sonata_media_view', {'id': galleryHasMedia.media|sonata_urlsafeid }) }}">
                 {% thumbnail galleryHasMedia.media, gallery.defaultFormat %}
             </a>
         </div>

--- a/Resources/views/Media/view.html.twig
+++ b/Resources/views/Media/view.html.twig
@@ -28,9 +28,9 @@ file that was distributed with this source code.
 
 <h2>Formats</h2>
 <ul>
-    <li><a href="{{ url('sonata_media_view', { 'id' : media.id, 'format' : 'reference'}) }}">reference</a></li>
+    <li><a href="{{ url('sonata_media_view', { 'id' : media|sonata_urlsafeid , 'format' : 'reference'}) }}">reference</a></li>
 
     {% for name, format in formats %}
-        <li><a href="{{ url('sonata_media_view', { 'id' : media.id, 'format' : name}) }}">{{ name }}</a></li>
+        <li><a href="{{ url('sonata_media_view', { 'id' : media|sonata_urlsafeid , 'format' : name}) }}">{{ name }}</a></li>
     {% endfor %}
 </ul>

--- a/Resources/views/MediaAdmin/list_custom.html.twig
+++ b/Resources/views/MediaAdmin/list_custom.html.twig
@@ -13,7 +13,7 @@ file that was distributed with this source code.
 
 {% block field %}
     <div>
-        <a href="{{ admin.generateUrl('edit', {'id' : admin.id(object)}) }}" style="float: left; margin-right: 6px;">{% thumbnail object, 'admin' with {'width': 75, 'height': 60} %}</a>
+        <a href="{{ admin.generateUrl('edit', {'id' : object|sonata_urlsafeid }) }}" style="float: left; margin-right: 6px;">{% thumbnail object, 'admin' with {'width': 75, 'height': 60} %}</a>
         <strong>{{ object.name }}</strong> <br />
         {{ object.providerName|trans({}, 'SonataMediaBundle') }}: {{ object.width }}x{{ object.height }} <br />
     </div>

--- a/Resources/views/MediaAdmin/list_image.html.twig
+++ b/Resources/views/MediaAdmin/list_image.html.twig
@@ -12,5 +12,5 @@ file that was distributed with this source code.
 {% extends 'SonataAdminBundle:CRUD:base_list_field.html.twig' %}
 
 {% block field%}
-    <a href="{{ admin.generateUrl('edit', {'id' : admin.id(object)}) }}">{% thumbnail object, 'admin' with {'width': 75, 'height': 60} %}</a>
+    <a href="{{ admin.generateUrl('edit', {'id' : object|sonata_urlsafeid }) }}">{% thumbnail object, 'admin' with {'width': 75, 'height': 60} %}</a>
 {% endblock %}

--- a/Resources/views/MediaAdmin/view.html.twig
+++ b/Resources/views/MediaAdmin/view.html.twig
@@ -27,7 +27,7 @@ file that was distributed with this source code.
         {% if pixlr and pixlr.isEditable(media) %}
             <tr>
                 <td></td>
-                <td><a class="btn" href="{{ path('sonata_media_pixlr_open_editor', {'id': admin.id(media) }) }}">{{ "label.edit_with_pixlr"|trans({}, "SonataMediaBundle")}}</a></td>
+                <td><a class="btn" href="{{ path('sonata_media_pixlr_open_editor', {'id': media|sonata_urlsafeid }) }}">{{ "label.edit_with_pixlr"|trans({}, "SonataMediaBundle")}}</a></td>
             </tr>
         {% endif %}
         <tr>
@@ -68,8 +68,8 @@ file that was distributed with this source code.
         <tr>
             <td>{{ 'label.protected_download_url'|trans({}, 'SonataMediaBundle') }}</td>
             <td>
-                <input type="text" value="{{ path('sonata_media_download', {'id': admin.id(media)}) }}" style="width:500px"/>
-                <a href="{{ path('sonata_media_download', {'id': admin.id(media)}) }}">{{ 'link.test_protected_url'|trans({}, 'SonataMediaBundle') }}</a>
+                <input type="text" value="{{ path('sonata_media_download', {'id': media|sonata_urlsafeid }) }}" style="width:500px"/>
+                <a href="{{ path('sonata_media_download', {'id': media|sonata_urlsafeid }) }}">{{ 'link.test_protected_url'|trans({}, 'SonataMediaBundle') }}</a>
                 <br />
                 <span class="label warning">{{ 'label.protected_download_url_notice'|trans({}, 'SonataMediaBundle') }}</span> {{ security.description }}
             </td>
@@ -85,7 +85,7 @@ file that was distributed with this source code.
     <table>
         <tr>
             <td>
-                <a href="{{ admin.generateUrl('view', { 'id' : admin.id(media), 'format' : 'reference'}) }}">reference</a>
+                <a href="{{ admin.generateUrl('view', { 'id' : media|sonata_urlsafeid , 'format' : 'reference'}) }}">reference</a>
             </td>
             <td>
                 <input type="text" value="{% path media, 'reference' %}"  style="width:500px" />
@@ -95,7 +95,7 @@ file that was distributed with this source code.
         {% for name, format in formats %}
             <tr>
                 <td>
-                    <a href="{{ admin.generateUrl('view', { 'id' : admin.id(media), 'format' : name}) }}">{{ name }}</a>
+                    <a href="{{ admin.generateUrl('view', { 'id' : media|sonata_urlsafeid , 'format' : name}) }}">{{ name }}</a>
                 </td>
                 <td>
                     <input type="text" value="{% path media, name %}"  style="width:500px"/>


### PR DESCRIPTION
Apply new twig filter `sonata_urlsafeid` to templates.

Related to https://github.com/sonata-project/SonataAdminBundle/pull/1178
