### PR TITLE
Fix ImageProvider and FileProvider bugs on generating private url for reference

### DIFF
--- a/Provider/FileProvider.php
+++ b/Provider/FileProvider.php
@@ -253,7 +253,11 @@ class FileProvider extends BaseProvider
      */
     public function generatePrivateUrl(MediaInterface $media, $format)
     {
-        return false;
+        if ($format == 'reference') {
+            return $this->getReferenceImage($media);
+        } else {
+            return false;
+        }
     }
 
     /**

--- a/Provider/ImageProvider.php
+++ b/Provider/ImageProvider.php
@@ -138,7 +138,11 @@ class ImageProvider extends FileProvider
      */
     public function generatePrivateUrl(MediaInterface $media, $format)
     {
-        return $this->thumbnail->generatePrivateUrl($this, $media, $format);
+        if ($format == 'reference') {
+            return $this->getReferenceImage($media);
+        } else {
+            return $this->thumbnail->generatePrivateUrl($this, $media, $format);
+        }
     }
 
     /**


### PR DESCRIPTION
(lets see if third is the charm)
MediaProviderInterface\getDownloadResponse() accepts several methods for downloading files, using 'http' by default. When methods other than "http" are used, it uses generatePrivateUrl() to get the file path, which is bugged in two places:
- FileProvider always returns false, which is wrong, as the file does exist. It should only return false only if a thumbnail (!= reference) is requested
- ImageProvider always returns a thumbnail, even if "reference" is being requested.
