### PR TITLE
do not compile Twig FormatterMediaExtension class 

### DIFF
--- a/DependencyInjection/SonataMediaExtension.php
+++ b/DependencyInjection/SonataMediaExtension.php
@@ -429,7 +429,6 @@ class SonataMediaExtension extends Extension
             "Sonata\\MediaBundle\\Thumbnail\\ConsumerThumbnail",
             "Sonata\\MediaBundle\\Thumbnail\\FormatThumbnail",
             "Sonata\\MediaBundle\\Thumbnail\\ThumbnailInterface",
-            "Sonata\\MediaBundle\\Twig\\Extension\\FormatterMediaExtension",
             "Sonata\\MediaBundle\\Twig\\Extension\\MediaExtension",
             "Sonata\\MediaBundle\\Twig\\Node\\MediaNode",
             "Sonata\\MediaBundle\\Twig\\Node\\PathNode",


### PR DESCRIPTION
This caused an error if the (optional) SonataFormatterBundle is not used.

Related to: https://github.com/symfony-cmf/cmf-sandbox/pull/159
