### PR TITLE
Move exception for not found media just after media retrieving

### DIFF
--- a/Consumer/CreateThumbnailConsumer.php
+++ b/Consumer/CreateThumbnailConsumer.php
@@ -49,12 +49,12 @@ class CreateThumbnailConsumer implements ConsumerInterface
             'id' => $event->getMessage()->getValue('mediaId')
         ));
 
-        // solve race condition between message queue and database transaction
-        $media->setProviderReference($event->getMessage()->getValue('providerReference'));
-
         if (!$media) {
             throw new HandlingException(sprintf('Media not found - id: %s', $event->getMessage()->getValue('mediaId')));
         }
+
+        // solve race condition between message queue and database transaction
+        $media->setProviderReference($event->getMessage()->getValue('providerReference'));
 
         try {
             $this->getThumbnail($event)->generate($this->pool->getProvider($media->getProviderName()), $media);


### PR DESCRIPTION
Exception was moved just after the media retrieve method call.

This will prevent this error:

```
sonata.media.create_thumbnail : 
Fatal error: Call to a member function setProviderReference() on a non-object in vendor/sonata-project/media-bundle/Sonata/MediaBundle/Consumer/CreateThumbnailConsumer.php on line 53
```
