### PR TITLE
[WIP] Added repositories and moved idPrefix and ID to base class

### DIFF
--- a/PHPCR/BaseGallery.php
+++ b/PHPCR/BaseGallery.php
@@ -13,6 +13,7 @@ namespace Sonata\MediaBundle\PHPCR;
 
 use Sonata\MediaBundle\Model\Gallery;
 use Sonata\MediaBundle\Model\GalleryHasMediaInterface;
+use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * Bundle\MediaBundle\Document\BaseGallery
@@ -22,14 +23,56 @@ abstract class BaseGallery extends Gallery
     /**
      * @var string
      */
+    protected $id;
+
+    /**
+     * @var string
+     */
     private $uuid;
+
+    /**
+     * The basepath of the id
+     *
+     * @var string
+     */
+    protected $idPrefix;
 
     /**
      * {@inheritdoc}
      */
     public function __construct()
     {
-        $this->galleryHasMedias = new \Doctrine\Common\Collections\ArrayCollection;
+        $this->galleryHasMedias = new ArrayCollection;
+    }
+
+    /**
+     * Get id
+     *
+     * @return string $id
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Get the basepath of the id
+     *
+     * @return string
+     */
+    public function getIdPrefix()
+    {
+        return $this->idPrefix;
+    }
+
+    /**
+     * Set the basepath of the id
+     *
+     * @param string $prefix
+     */
+    public function setPrefix($prefix)
+    {
+        $this->idPrefix = $prefix;
     }
 
     /**

--- a/PHPCR/BaseMedia.php
+++ b/PHPCR/BaseMedia.php
@@ -18,7 +18,49 @@ abstract class BaseMedia extends Media
     /**
      * @var string
      */
+    protected $id;
+
+    /**
+     * @var string
+     */
     private $uuid;
+
+    /**
+     * The basepath of the id
+     *
+     * @var string
+     */
+    protected $idPrefix;
+
+    /**
+     * Get id
+     *
+     * @return string $id
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Get the basepath of the id
+     *
+     * @return string
+     */
+    public function getIdPrefix()
+    {
+        return $this->idPrefix;
+    }
+
+    /**
+     * Set the basepath of the id
+     *
+     * @param string $prefix
+     */
+    public function setPrefix($prefix)
+    {
+        $this->idPrefix = $prefix;
+    }
 
     /**
      * Get universal unique id

--- a/PHPCR/GalleryRepository.php
+++ b/PHPCR/GalleryRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Sandbox\MediaBundle\Document;
+
+use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
+use Doctrine\ODM\PHPCR\DocumentRepository as BaseDocumentRepository;
+
+class GalleryRepository extends BaseDocumentRepository implements RepositoryIdInterface
+{
+    /**
+     * Generate a document id
+     *
+     * @param object $document
+     * @param object $parent
+     *
+     * @return string
+     */
+    public function generateId($document, $parent = null) 
+    {
+        $idPrefix = $document->getIdPrefix();
+
+        if (0 == strlen($idPrefix)) {
+            throw new \LogicException('Can not determine the prefix. Either this is a new, unpersisted document or the listener that calls setPrefix is not set up correctly.');
+        }
+
+        return $idPrefix.'/'.$document->getName();
+    }
+}

--- a/PHPCR/MediaRepository.php
+++ b/PHPCR/MediaRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Sandbox\MediaBundle\Document;
+
+use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
+use Doctrine\ODM\PHPCR\DocumentRepository as BaseDocumentRepository;
+
+class MediaRepository extends BaseDocumentRepository implements RepositoryIdInterface
+{
+    /**
+     * Generate a document id
+     *
+     * @param object $document
+     * @param object $parent
+     *
+     * @return string
+     */
+    public function generateId($document, $parent = null) 
+    {
+        $idPrefix = $document->getIdPrefix();
+
+        if (0 == strlen($idPrefix)) {
+            throw new \LogicException('Can not determine the prefix. Either this is a new, unpersisted document or the listener that calls setPrefix is not set up correctly.');
+        }
+
+        return $idPrefix.'/'.$document->getProviderReference();
+    }
+}

--- a/Resources/config/doctrine/Gallery.phpcr.xml.skeleton
+++ b/Resources/config/doctrine/Gallery.phpcr.xml.skeleton
@@ -13,7 +13,7 @@
     -->
 
     <document name="Application\Sonata\MediaBundle\PHPCR\Gallery"
-              repository-class="Application\Sonata\MediaBundle\PHPCR\GalleryRepository">
+              repository-class="Sonata\MediaBundle\PHPCR\GalleryRepository">
 
         <id name="id" type="id">
             <generator strategy="repository" />

--- a/Resources/config/doctrine/Media.phpcr.xml.skeleton
+++ b/Resources/config/doctrine/Media.phpcr.xml.skeleton
@@ -12,8 +12,8 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
 
-    <document name="Application\Sonata\MediaBundle\Document\Media"
-              repository-class="Application\Sonata\MediaBundle\Document\MediaRepository" >
+    <document name="Application\Sonata\MediaBundle\PHPCR\Media"
+              repository-class="Sonata\MediaBundle\PHPCR\MediaRepository" >
 
         <id name="id" type="id">
             <generator strategy="repository" />


### PR DESCRIPTION
\cc @rmsint

This is more of an illustrative PR.

Not sure how much of this wasn't done by design, I've added the "Repositories" etc and moved the ID and idPrefix to the base objects

Some questions:
- (general) I guess the logic was that ID generation should be delegated to the user? Why?
- Is there an alternative to the "repository" method of ID generation, can we not get the ModelManager to _assign_ an ID instead?

If the ModelManager could _assign_ the ID, then we could remove the _getIdPrefix_ method right? And also the easy-extends bundle would work out-of-the-box.
