### PR TITLE
Update default 'mediaId' value

### DIFF
--- a/Block/MediaBlockService.php
+++ b/Block/MediaBlockService.php
@@ -90,7 +90,7 @@ class MediaBlockService extends BaseBlockService
             'media'    => false,
             'title'    => false,
             'context'  => false,
-            'mediaId'  => false,
+            'mediaId'  => null,
             'format'   => false,
             'template' => 'SonataMediaBundle:Block:block_media.html.twig'
         ));


### PR DESCRIPTION
I changed false to null because I had an error message when mediaId value was 'false' and was passed to getFormatChoices()
