### PR TITLE
Fixed Bloc Media View

### DIFF
--- a/Resources/views/Block/block_media.html.twig
+++ b/Resources/views/Block/block_media.html.twig
@@ -8,7 +8,7 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
-{% extends 'SonataBlockBundle:Block:block_base.html.twig' %}
+{% extends sonata_block.templates.block_base %}
 
 {% block block %}
     {% if settings.title %}


### PR DESCRIPTION
I had a bug using MediaBundle with PageBundle : When I double-click on a media block on the front, I can't edit it. I have an error.
I notice that "data-*" params was not passed to the div tag. This fix solve the problem
