### PR TITLE
PHPCR - update MediaManager::save + update MediaEventSubscriber

### DIFF
--- a/Listener/PHPCR/MediaEventSubscriber.php
+++ b/Listener/PHPCR/MediaEventSubscriber.php
@@ -37,8 +37,13 @@ class MediaEventSubscriber extends BaseMediaEventSubscriber
      */
     protected function recomputeSingleEntityChangeSet(EventArgs $args)
     {
-//        $dm = $args->getDocumentManager();
-        // TODO: is this needed for PHPCR?
+        /** @var $args \Doctrine\Common\Persistence\Event\LifecycleEventArgs */
+        /** @var $dm \Doctrine\ODM\PHPCR\DocumentManager */
+        $dm = $args->getObjectManager();
+
+        $dm->getUnitOfWork()->computeSingleDocumentChangeSet(
+            $this->getMedia($args)
+        );
     }
 
     /**
@@ -46,6 +51,6 @@ class MediaEventSubscriber extends BaseMediaEventSubscriber
      */
     protected function getMedia(EventArgs $args)
     {
-        return $args->getDocument();
+        return $args->getObject();
     }
 }

--- a/PHPCR/MediaManager.php
+++ b/PHPCR/MediaManager.php
@@ -104,21 +104,6 @@ class MediaManager extends AbstractMediaManager
             $media->setProviderName($providerName);
         }
 
-        $isNew = $media->getId() === null;
-
-        if ($isNew) {
-            $this->pool->getProvider($media->getProviderName())->prePersist($media);
-            $this->modelManager->create($media);
-        } else {
-            $this->pool->getProvider($media->getProviderName())->preUpdate($media);
-        }
-
-        if ($isNew) {
-            $this->pool->getProvider($media->getProviderName())->postPersist($media);
-        } else {
-            $this->pool->getProvider($media->getProviderName())->postUpdate($media);
-        }
-
         // just in case the pool alter the media
         $this->modelManager->update($media);
     }
@@ -131,10 +116,6 @@ class MediaManager extends AbstractMediaManager
      */
     public function delete(MediaInterface $media)
     {
-        $this->pool->preRemove($media);
         $this->modelManager->delete($media);
-
-        $this->pool->postRemove($media);
-        $this->modelManager->getDocumentManager()->flush();
     }
 }


### PR DESCRIPTION
- the MediaManager::save was outdated and is updated
- PHPCR-ODM is using since 2013-05-27 the doctrine commons 2.4 events were possible, the MediaEventSubscriber is updated for this

/cc @dantleech
