### PR TITLE
orm mapping missing SonataMediaBundle 

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -176,6 +176,8 @@ Now that your module is generated, you can register it
                   default:
                       mappings:
                           ApplicationSonataMediaBundle: ~
+                          SonataMediaBundle: ~
+                          # add your own bundles here
 
 
 Now, you can build up your database:


### PR DESCRIPTION
I had a lot of trouble with this: for the doctrine.orm.entity_managers.default.mappings section it is said to add ApplicationSonataMediaBundle, but then, when you update the database schema, you get tables with only an 'id' field. So, after much googling I found out that you should also add SonataMediaBundle, and also your own bundles, because somehow the auto_mapping does not work anymore.
