### PR TITLE
sets SonataMediaBundle translation domain for the side menu items

### DIFF
--- a/Admin/BaseMediaAdmin.php
+++ b/Admin/BaseMediaAdmin.php
@@ -157,12 +157,12 @@ abstract class BaseMediaAdmin extends Admin
         $id = $this->getRequest()->get('id');
 
         $menu->addChild(
-            $this->trans('sidemenu.link_edit_media'),
+            $this->trans('sidemenu.link_edit_media', array(), 'SonataMediaBundle'),
             array('uri' => $admin->generateUrl('edit', array('id' => $id)))
         );
 
         $menu->addChild(
-            $this->trans('sidemenu.link_media_view'),
+            $this->trans('sidemenu.link_media_view', array(), 'SonataMediaBundle'),
             array('uri' => $admin->generateUrl('view', array('id' => $id)))
         );
     }


### PR DESCRIPTION
hi, just a small detail I picked, for not getting the translation key on the media admin side menu.
regards
javier
