### PR TITLE
sets providerMetadata doctrine type as 'json_array' instead of unsupport...

### DIFF
--- a/Resources/config/doctrine/BaseMedia.orm.xml
+++ b/Resources/config/doctrine/BaseMedia.orm.xml
@@ -14,7 +14,7 @@
         <field name="providerName"      column="provider_name"            type="string"   nullable="false" length="255" default="image" />
         <field name="providerStatus"    column="provider_status"          type="integer"  nullable="false" />
         <field name="providerReference" column="provider_reference"       type="string"   nullable="false" length="255"/>
-        <field name="providerMetadata"  column="provider_metadata"        type="json"     nullable="true" />
+        <field name="providerMetadata"  column="provider_metadata"        type="json_array"     nullable="true" />
 
         <field name="width"             column="width"             type="integer"  nullable="true" />
         <field name="height"            column="height"            type="integer"  nullable="true" />


### PR DESCRIPTION
Hi,

I was generating the schema for my database and got a dbalexception saying:

[Doctrine\DBAL\DBALException]
  Unknown column type "json" requested.

So I this fixed for me: changing it to 'json_array' according to Doctrine\DBAL\Types\Type

regards
javier
