### PR TITLE
CKEditor integration doc

### DIFF
--- a/Resources/doc/reference/extra.rst
+++ b/Resources/doc/reference/extra.rst
@@ -113,3 +113,36 @@ You also need to alter the ``sonata_media`` configuration to use the ``sonata.me
 
     The ``SonataMediaBundle:Media:liipImagineFilter`` is a specific controller to link the MediaBundle with LiipImagineBundle
 
+CKEditor Integration
+====================
+
+`CoopTilleulsCKEditorSonataMediaBundle <https://github.com/coopTilleuls/CoopTilleulsCKEditorSonataMediaBundle>`_ allows to browse and upload files managed by SonataMedia directly from the UI of the `CKEditor <http://ckeditor.com/>`_ WYSIWYG editor.
+
+To use this feature, follow `CoopTilleulsCKEditorSonataMediaBundle installation instructions <https://github.com/coopTilleuls/CoopTilleulsCKEditorSonataMediaBundle/blob/master/Resources/doc/install.md>`.
+
+Now, just create a field with ckeditor as type and your done:
+
+.. code-block:: yaml
+
+    protected function configureFormFields(FormMapper $formMapper)
+    {
+        $formMapper
+            ->add(
+                'mytext',
+                'ckeditor',
+                array(
+                'config' => array(
+                    'toolbar' => array(
+                        array(
+                            'name' => 'links',
+                            'items' => array('Link','Unlink'),
+                        ),
+                        array(
+                            'name' => 'insert',
+                            'items' => array('Image'),
+                        ),
+                    )
+                );
+            );
+    }
+

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         "liip/imagine-bundle": "~0.9",
         "amazonwebservices/aws-sdk-for-php": "~1.5",
         "rackspace/php-opencloud": "~1.6",
-        "sonata-project/seo-bundle": "~1.1"
+        "sonata-project/seo-bundle": "~1.1",
+        "tilleuls/ckeditor-sonata-mediabundle": "~1.0"
     },
     "autoload": {
         "psr-0": { "Sonata\\MediaBundle": "" }


### PR DESCRIPTION
At [La Coopérative des Tilleuls](http://les-tilleuls.coop) we've wrote [a bundle](https://github.com/coopTilleuls/CoopTilleulsCKEditorSonataMediaBundle) to integrate SonataMedia with CKEditor.

It allows to browse, select and upload SonataMedia files and images directly from the CKEditor UI.
It integrates well with IvoryCKEditorBundle and SonataFormatterBundle.

If @rande is interested we are OK to move this bundle to the Sonata Project.

This PR update the doc of SonataMedia to explain how to use this new bundle and update the "suggest" field of `composer.json`.
