### PR TITLE
Fix, to allow batchDelete

### DIFF
--- a/Admin/Manager/DoctrineMongoDBManager.php
+++ b/Admin/Manager/DoctrineMongoDBManager.php
@@ -54,7 +54,7 @@ class DoctrineMongoDBManager extends ModelManager
     public function batchDelete($class, ProxyQueryInterface $queryProxy)
     {
         foreach ($queryProxy->getQuery()->iterate() as $pos => $object) {
-            $this->delete($object[0]);
+            $this->delete($object);
         }
     }
 }


### PR DESCRIPTION
Hi,
Batch delete was causing a 

```
FatalErrorException: Error: Cannot use object of type Application\Sonata\MediaBundle\Document\Media
as array in [...] vendor/sonata-project/media-bundle/Sonata/MediaBundle/Admin/Manager/DoctrineMongoDBManager.php line 57
```

before this.
Thanks !
