### PR TITLE
Fix SonataAdminBundle:CRUDController compatibility

### DIFF
--- a/Controller/MediaAdminController.php
+++ b/Controller/MediaAdminController.php
@@ -25,7 +25,7 @@ class MediaAdminController extends Controller
      *
      * @return \Symfony\Bundle\FrameworkBundle\Controller\Response
      */
-    public function showAction($id)
+    public function showAction($id = null)
     {
         if (false === $this->admin->isGranted('SHOW')) {
             throw new AccessDeniedException();


### PR DESCRIPTION
Commit 56eb4150adc0cfac26d43eccbb41d3ea6975686e of @rande broken the MediaAdminController with this erorr:

``` php
  [ErrorException]                                                                                                                                                                                           
  Runtime Notice: Declaration of Sonata\MediaBundle\Controller\MediaAdminController::showAction() should be compatible with that of Sonata\AdminBundle\Controller\CRUDController::showAction() in /Users/sa  
  muel/git/srozeio/website/vendor/sonata-project/media-bundle/Sonata/MediaBundle/Controller/MediaAdminController.php line 118                                                                                
```

Fix it.
