### PR TITLE
Configurable admin services

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -45,6 +45,7 @@ class Configuration implements ConfigurationInterface
         $this->addModelSection($node);
         $this->addBuzzSection($node);
         $this->addResizerSection($node);
+        $this->addAdminSection($node);
 
         return $treeBuilder;
     }
@@ -460,6 +461,49 @@ class Configuration implements ConfigurationInterface
                             ->addDefaultsIfNotSet()
                             ->children()
                                 ->scalarNode('mode')->defaultValue('inset')->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    /**
+     * @param \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $node
+     */
+    private function addAdminSection(ArrayNodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->arrayNode('admin')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('media')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->scalarNode('class')->cannotBeEmpty()->end()
+                                ->scalarNode('controller')->cannotBeEmpty()->defaultValue('SonataMediaBundle:MediaAdmin')->end()
+                                ->scalarNode('translation')->cannotBeEmpty()->defaultValue('SonataMediaBundle')->end()
+                                ->booleanNode('show_in_dashboard')->defaultValue(true)->end()
+                            ->end()
+                        ->end()
+                        ->arrayNode('gallery')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->scalarNode('class')->cannotBeEmpty()->end()
+                                ->scalarNode('controller')->cannotBeEmpty()->defaultValue('SonataMediaBundle:GalleryAdmin')->end()
+                                ->scalarNode('translation')->cannotBeEmpty()->defaultValue('SonataMediaBundle')->end()
+                                ->booleanNode('show_in_dashboard')->defaultValue(true)->end()
+                            ->end()
+                        ->end()
+                        ->arrayNode('gallery_has_media')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->scalarNode('class')->cannotBeEmpty()->end()
+                                ->scalarNode('controller')->cannotBeEmpty()->defaultValue('SonataAdminBundle:CRUD')->end()
+                                ->scalarNode('translation')->cannotBeEmpty()->defaultValue('SonataMediaBundle')->end()
+                                ->booleanNode('show_in_dashboard')->defaultValue(false)->end()
                             ->end()
                         ->end()
                     ->end()

--- a/DependencyInjection/SonataMediaExtension.php
+++ b/DependencyInjection/SonataMediaExtension.php
@@ -127,6 +127,7 @@ class SonataMediaExtension extends Extension
         $this->configureExtra($container, $config);
         $this->configureBuzz($container, $config);
         $this->configureProviders($container, $config);
+        $this->configureAdmin($container, $config);
         $this->configureClassesToCompile();
     }
 
@@ -448,6 +449,35 @@ class SonataMediaExtension extends Extension
         } else {
             $container->removeDefinition('sonata.media.extra.pixlr');
         }
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $config
+     */
+    public function configureAdmin(ContainerBuilder $container, array $config)
+    {
+        if (array_key_exists('class', $config['admin']['media'])) {
+            $container->setParameter('sonata.media.admin.media.class', $config['admin']['media']['class']);
+        }
+        if (array_key_exists('class', $config['admin']['gallery'])) {
+            $container->setParameter('sonata.media.admin.gallery.class', $config['admin']['gallery']['class']);
+        }
+        if (array_key_exists('class', $config['admin']['gallery_has_media'])) {
+            $container->setParameter('sonata.media.admin.gallery_has_media.class', $config['admin']['gallery_has_media']['class']);
+        }
+
+        $container->setParameter('sonata.media.admin.media.controller', $config['admin']['media']['controller']);
+        $container->setParameter('sonata.media.admin.gallery.controller', $config['admin']['gallery']['controller']);
+        $container->setParameter('sonata.media.admin.gallery_has_media.controller', $config['admin']['gallery_has_media']['controller']);
+
+        $container->setParameter('sonata.media.admin.media.translation_domain', $config['admin']['media']['translation']);
+        $container->setParameter('sonata.media.admin.gallery.translation_domain', $config['admin']['gallery']['translation']);
+        $container->setParameter('sonata.media.admin.gallery_has_media.translation_domain', $config['admin']['gallery_has_media']['translation']);
+
+        $container->setParameter('sonata.media.admin.media.show_in_dashboard', $config['admin']['media']['show_in_dashboard']);
+        $container->setParameter('sonata.media.admin.gallery.show_in_dashboard', $config['admin']['gallery']['show_in_dashboard']);
+        $container->setParameter('sonata.media.admin.gallery_has_media.show_in_dashboard', $config['admin']['gallery_has_media']['show_in_dashboard']);
     }
 
     /**

--- a/Resources/config/doctrine_mongodb_admin.xml
+++ b/Resources/config/doctrine_mongodb_admin.xml
@@ -4,25 +4,14 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <!-- MEDIA -->
         <parameter key="sonata.media.admin.media.class">Sonata\MediaBundle\Admin\ODM\MediaAdmin</parameter>
-        <parameter key="sonata.media.admin.media.controller">SonataMediaBundle:MediaAdmin</parameter>
-        <parameter key="sonata.media.admin.media.translation_domain">SonataMediaBundle</parameter>
-
-        <!-- GALLERY -->
         <parameter key="sonata.media.admin.gallery.class">Sonata\MediaBundle\Admin\GalleryAdmin</parameter>
-        <parameter key="sonata.media.admin.gallery.controller">SonataMediaBundle:GalleryAdmin</parameter>
-        <parameter key="sonata.media.admin.gallery.translation_domain">%sonata.media.admin.media.translation_domain%</parameter>
-
-        <!-- GALLERY HAS MEDIA -->
         <parameter key="sonata.media.admin.gallery_has_media.class">Sonata\MediaBundle\Admin\GalleryHasMediaAdmin</parameter>
-        <parameter key="sonata.media.admin.gallery_has_media.controller">SonataAdminBundle:CRUD</parameter>
-        <parameter key="sonata.media.admin.gallery_has_media.translation_domain">%sonata.media.admin.media.translation_domain%</parameter>
     </parameters>
 
     <services>
         <service id="sonata.media.admin.media" class="%sonata.media.admin.media.class%">
-            <tag name="sonata.admin" manager_type="doctrine_mongodb" group="sonata_media" label_catalogue="%sonata.media.admin.media.translation_domain%" label="media" label_translator_strategy="sonata.admin.label.strategy.underscore" />
+            <tag name="sonata.admin" manager_type="doctrine_mongodb" show_in_dashboard="%sonata.media.admin.media.show_in_dashboard%" group="sonata_media" label_catalogue="%sonata.media.admin.media.translation_domain%" label="media" label_translator_strategy="sonata.admin.label.strategy.underscore" />
             <argument />
             <argument>%sonata.media.admin.media.entity%</argument>
             <argument>%sonata.media.admin.media.controller%</argument>
@@ -50,7 +39,7 @@
         </service>
 
         <service id="sonata.media.admin.gallery" class="%sonata.media.admin.gallery.class%">
-            <tag name="sonata.admin" manager_type="doctrine_mongodb" group="sonata_media"  label_catalogue="%sonata.media.admin.gallery.translation_domain%" label="gallery" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
+            <tag name="sonata.admin" manager_type="doctrine_mongodb" show_in_dashboard="%sonata.media.admin.gallery.show_in_dashboard%" group="sonata_media"  label_catalogue="%sonata.media.admin.gallery.translation_domain%" label="gallery" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
             <argument />
             <argument>%sonata.media.admin.gallery.entity%</argument>
             <argument>%sonata.media.admin.gallery.controller%</argument>
@@ -68,7 +57,7 @@
         </service>
 
         <service id="sonata.media.admin.gallery_has_media" class="%sonata.media.admin.gallery_has_media.class%">
-            <tag name="sonata.admin" manager_type="doctrine_mongodb" group="sonata_media"  label_catalogue="%sonata.media.admin.gallery_has_media.translation_domain%" label="gallery_has_media" show_in_dashboard="false" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
+            <tag name="sonata.admin" manager_type="doctrine_mongodb" show_in_dashboard="%sonata.media.admin.gallery_has_media.show_in_dashboard%" group="sonata_media"  label_catalogue="%sonata.media.admin.gallery_has_media.translation_domain%" label="gallery_has_media" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
             <argument />
             <argument>%sonata.media.admin.gallery_has_media.entity%</argument>
             <argument>%sonata.media.admin.gallery_has_media.controller%</argument>

--- a/Resources/config/doctrine_orm_admin.xml
+++ b/Resources/config/doctrine_orm_admin.xml
@@ -6,23 +6,17 @@
     <parameters>
         <!-- MEDIA -->
         <parameter key="sonata.media.admin.media.class">Sonata\MediaBundle\Admin\ORM\MediaAdmin</parameter>
-        <parameter key="sonata.media.admin.media.controller">SonataMediaBundle:MediaAdmin</parameter>
-        <parameter key="sonata.media.admin.media.translation_domain">SonataMediaBundle</parameter>
 
         <!-- GALLERY -->
         <parameter key="sonata.media.admin.gallery.class">Sonata\MediaBundle\Admin\GalleryAdmin</parameter>
-        <parameter key="sonata.media.admin.gallery.controller">SonataMediaBundle:GalleryAdmin</parameter>
-        <parameter key="sonata.media.admin.gallery.translation_domain">%sonata.media.admin.media.translation_domain%</parameter>
 
         <!-- GALLERY HAS MEDIA -->
         <parameter key="sonata.media.admin.gallery_has_media.class">Sonata\MediaBundle\Admin\GalleryHasMediaAdmin</parameter>
-        <parameter key="sonata.media.admin.gallery_has_media.controller">SonataAdminBundle:CRUD</parameter>
-        <parameter key="sonata.media.admin.gallery_has_media.translation_domain">%sonata.media.admin.media.translation_domain%</parameter>
     </parameters>
 
     <services>
         <service id="sonata.media.admin.media" class="%sonata.media.admin.media.class%">
-            <tag name="sonata.admin" manager_type="orm" group="sonata_media" label_catalogue="%sonata.media.admin.media.translation_domain%" label="media" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
+            <tag name="sonata.admin" manager_type="orm" show_in_dashboard="%sonata.media.admin.media.show_in_dashboard%" group="sonata_media" label_catalogue="%sonata.media.admin.media.translation_domain%" label="media" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
             <argument />
             <argument>%sonata.media.admin.media.entity%</argument>
             <argument>%sonata.media.admin.media.controller%</argument>
@@ -52,7 +46,7 @@
         </service>
 
         <service id="sonata.media.admin.gallery" class="%sonata.media.admin.gallery.class%">
-            <tag name="sonata.admin" manager_type="orm" group="sonata_media" label="gallery" label_catalogue="%sonata.media.admin.gallery.translation_domain%" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
+            <tag name="sonata.admin" manager_type="orm" show_in_dashboard="%sonata.media.admin.gallery.show_in_dashboard%" group="sonata_media" label="gallery" label_catalogue="%sonata.media.admin.gallery.translation_domain%" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
             <argument />
             <argument>%sonata.media.admin.gallery.entity%</argument>
             <argument>%sonata.media.admin.gallery.controller%</argument>
@@ -70,7 +64,7 @@
         </service>
 
         <service id="sonata.media.admin.gallery_has_media" class="%sonata.media.admin.gallery_has_media.class%">
-            <tag name="sonata.admin" manager_type="orm" show_in_dashboard="false" group="sonata_media" label_catalogue="%sonata.media.admin.gallery_has_media.translation_domain%" label="gallery_has_media" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
+            <tag name="sonata.admin" manager_type="orm" show_in_dashboard="%sonata.media.admin.gallery_has_media.show_in_dashboard%" group="sonata_media" label_catalogue="%sonata.media.admin.gallery_has_media.translation_domain%" label="gallery_has_media" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
             <argument />
             <argument>%sonata.media.admin.gallery_has_media.entity%</argument>
             <argument>%sonata.media.admin.gallery_has_media.controller%</argument>

--- a/Resources/config/doctrine_orm_admin.xml
+++ b/Resources/config/doctrine_orm_admin.xml
@@ -4,13 +4,8 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <!-- MEDIA -->
         <parameter key="sonata.media.admin.media.class">Sonata\MediaBundle\Admin\ORM\MediaAdmin</parameter>
-
-        <!-- GALLERY -->
         <parameter key="sonata.media.admin.gallery.class">Sonata\MediaBundle\Admin\GalleryAdmin</parameter>
-
-        <!-- GALLERY HAS MEDIA -->
         <parameter key="sonata.media.admin.gallery_has_media.class">Sonata\MediaBundle\Admin\GalleryHasMediaAdmin</parameter>
     </parameters>
 

--- a/Resources/config/doctrine_phpcr_admin.xml
+++ b/Resources/config/doctrine_phpcr_admin.xml
@@ -4,27 +4,16 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <!-- MEDIA -->
         <parameter key="sonata.media.admin.media.class">Sonata\MediaBundle\Admin\PHPCR\MediaAdmin</parameter>
-        <parameter key="sonata.media.admin.media.controller">SonataMediaBundle:MediaAdmin</parameter>
-        <parameter key="sonata.media.admin.media.translation_domain">SonataMediaBundle</parameter>
-
-        <!-- GALLERY -->
         <parameter key="sonata.media.admin.gallery.class">Sonata\MediaBundle\Admin\PHPCR\GalleryAdmin</parameter>
-        <parameter key="sonata.media.admin.gallery.controller">SonataMediaBundle:GalleryAdmin</parameter>
-        <parameter key="sonata.media.admin.gallery.translation_domain">%sonata.media.admin.media.translation_domain%</parameter>
-
-        <!-- GALLERY HAS MEDIA -->
         <parameter key="sonata.media.admin.gallery_has_media.class">Sonata\MediaBundle\Admin\GalleryHasMediaAdmin</parameter>
-        <parameter key="sonata.media.admin.gallery_has_media.controller">SonataAdminBundle:CRUD</parameter>
-        <parameter key="sonata.media.admin.gallery_has_media.translation_domain">%sonata.media.admin.media.translation_domain%</parameter>
     </parameters>
 
     <services>
         <service id="sonata.media.admin.media.manager" alias="sonata.admin.manager.doctrine_phpcr" />
 
         <service id="sonata.media.admin.media" class="%sonata.media.admin.media.class%">
-            <tag name="sonata.admin" manager_type="doctrine_phpcr" group="sonata_media" label_catalogue="%sonata.media.admin.media.translation_domain%" label="media" label_translator_strategy="sonata.admin.label.strategy.underscore" />
+            <tag name="sonata.admin" manager_type="doctrine_phpcr" show_in_dashboard="%sonata.media.admin.media.show_in_dashboard%" group="sonata_media" label_catalogue="%sonata.media.admin.media.translation_domain%" label="media" label_translator_strategy="sonata.admin.label.strategy.underscore" />
             <argument />
             <argument>%sonata.media.admin.media.entity%</argument>
             <argument>%sonata.media.admin.media.controller%</argument>
@@ -49,7 +38,7 @@
         </service>
 
         <service id="sonata.media.admin.gallery" class="%sonata.media.admin.gallery.class%">
-            <tag name="sonata.admin" manager_type="doctrine_phpcr" group="sonata_media" label_catalogue="%sonata.media.admin.gallery.translation_domain%" label="gallery" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
+            <tag name="sonata.admin" manager_type="doctrine_phpcr" show_in_dashboard="%sonata.media.admin.gallery.show_in_dashboard%" group="sonata_media" label_catalogue="%sonata.media.admin.gallery.translation_domain%" label="gallery" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
             <argument />
             <argument>%sonata.media.admin.gallery.entity%</argument>
             <argument>%sonata.media.admin.gallery.controller%</argument>
@@ -71,7 +60,7 @@
         </service>
 
         <service id="sonata.media.admin.gallery_has_media" class="%sonata.media.admin.gallery_has_media.class%">
-            <tag name="sonata.admin" manager_type="doctrine_phpcr" show_in_dashboard="false" group="sonata_media" label_catalogue="%sonata.media.admin.gallery_has_media.translation_domain%" label="gallery_has_media" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
+            <tag name="sonata.admin" manager_type="doctrine_phpcr" show_in_dashboard="%sonata.media.admin.gallery_has_media.show_in_dashboard%" group="sonata_media" label_catalogue="%sonata.media.admin.gallery_has_media.translation_domain%" label="gallery_has_media" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
             <argument />
             <argument>%sonata.media.admin.gallery_has_media.entity%</argument>
             <argument>%sonata.media.admin.gallery_has_media.controller%</argument>

--- a/Resources/doc/reference/advanced_configuration.rst
+++ b/Resources/doc/reference/advanced_configuration.rst
@@ -170,4 +170,20 @@ Full configuration options:
 
         buzz:
             connector:  sonata.media.buzz.connector.file_get_contents # sonata.media.buzz.connector.curl
+        admin:
+            media:
+                class: Sonata\MediaBundle\Admin\ORM\MediaAdmin  #If not specified, the default may change according to the selected db_driver 
+                controller: SonataMediaBundle:MediaAdmin
+                translation: SonataMediaBundle
+                show_in_dashboard: true
+            gallery:
+                class: Sonata\MediaBundle\Admin\GalleryAdmin  #If not specified, the default may change according to the selected db_driver
+                controller: SonataMediaBundle:GalleryAdmin
+                translation: SonataMediaBundle
+                show_in_dashboard: true
+            gallery_has_media:
+                class: Sonata\MediaBundle\Admin\GalleryHasMediaAdmin  #If not specified, the default may change according to the selected db_driver
+                controller: SonataAdminBundle:CRUD
+                translation: SonataMediaBundle
+                show_in_dashboard: false
 

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\DependencyInjection;
+
+use Sonata\MediaBundle\DependencyInjection\Configuration;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDefaultOptions()
+    {
+        $processor     = new Processor();
+        $configuration = new Configuration();
+        $config        = $processor->processConfiguration($configuration, $this->getConfig());
+    }
+
+    public function testAdminOptions()
+    {
+        $adminConfig = array(
+            'admin' => array(
+                'media' => array(
+                    'show_in_dashboard' => false,
+                    'class' => 'SomeCustomClass',
+                    'controller' => 'SomeCustomController',
+                ),
+                'gallery' => array(
+                    'translation' => 'SomeCustomDomain',
+                )
+            )
+        );
+
+        $processor     = new Processor();
+        $configuration = new Configuration();
+        $config        = $processor->processConfiguration($configuration, $this->getConfig($adminConfig));
+
+        $this->assertArrayHasKey('class', $config['admin']['media']);
+        $this->assertArrayHasKey('controller', $config['admin']['media']);
+        $this->assertArrayHasKey('translation', $config['admin']['media']);
+        $this->assertArrayHasKey('show_in_dashboard', $config['admin']['media']);
+
+        $this->assertEquals($config['admin']['media']['class'], 'SomeCustomClass');
+        $this->assertEquals($config['admin']['media']['controller'], 'SomeCustomController');
+        $this->assertEquals($config['admin']['media']['translation'], 'SonataMediaBundle');
+        $this->assertFalse($config['admin']['media']['show_in_dashboard']);
+
+
+        $this->assertFalse(array_key_exists('class', $config['admin']['gallery']));
+        $this->assertArrayHasKey('controller', $config['admin']['gallery']);
+        $this->assertArrayHasKey('translation', $config['admin']['gallery']);
+        $this->assertArrayHasKey('show_in_dashboard', $config['admin']['gallery']);
+
+        $this->assertEquals($config['admin']['gallery']['controller'], 'SonataMediaBundle:GalleryAdmin');
+        $this->assertEquals($config['admin']['gallery']['translation'], 'SomeCustomDomain');
+        $this->assertTrue($config['admin']['gallery']['show_in_dashboard']);
+
+
+        $this->assertFalse(array_key_exists('class', $config['admin']['gallery_has_media']));
+        $this->assertArrayHasKey('controller', $config['admin']['gallery_has_media']);
+        $this->assertArrayHasKey('translation', $config['admin']['gallery_has_media']);
+        $this->assertArrayHasKey('show_in_dashboard', $config['admin']['gallery_has_media']);
+
+        $this->assertEquals($config['admin']['gallery_has_media']['controller'], 'SonataAdminBundle:CRUD');
+        $this->assertEquals($config['admin']['gallery_has_media']['translation'], 'SonataMediaBundle');
+        $this->assertFalse($config['admin']['gallery_has_media']['show_in_dashboard']);
+    }
+
+    private function getConfig($config = array()) {
+        $default = array(
+            'default_context' => 'default',
+            'db_driver' => 'orm',
+            'contexts' => array(
+                'default' => array(
+                    'providers' => array(
+                        'sonata.media.provider.file'
+                    ),
+                    'formats' => array(
+                        'small' => array(
+                            'width' => 100,
+                            'quality' => 70,
+                        )
+                    )
+                )
+            ),
+            'cdn' => array(
+                'server' => array(
+                    'path' => '/uploads/media'
+                )
+            ),
+            'filesystem' => array(
+                'local' => array(
+                    'directory' => '%kernel.root_dir%/../web/uploads/media',
+                    'create' => false,
+                )
+            )
+        );
+
+        return (array($default, $config));
+    }
+}


### PR DESCRIPTION
Depends on https://github.com/sonata-project/SonataAdminBundle/pull/1674

Make admin services configurable, similar to what already exists in SonataUserBundle.
Added possibility to hide an admin entry by getting the "show_in_dashboard" from a configurable parameter.
Defaults keep the existing values, so no BC is expected.

Tests and docs included