### PR TITLE
Changed default_entity_manager to entity_manager to avoid error when extending

### DIFF
--- a/Resources/config/doctrine_orm.xml
+++ b/Resources/config/doctrine_orm.xml
@@ -10,7 +10,7 @@
     </parameters>
 
     <services>
-        <service id="sonata.media.entity_manager" alias="doctrine.orm.default_entity_manager" />
+        <service id="sonata.media.entity_manager" alias="doctrine.orm.entity_manager" />
 
         <service id="sonata.media.manager.media" class="%sonata.media.manager.media.class%">
             <argument type="service" id="sonata.media.pool" />


### PR DESCRIPTION
When using SonataEasyExtends bundle, an error occurs due to the configuration creating an alias to `doctrine.orm.default_entity_manager` when it should be `doctrine.orm.entity_manager`.
