### PR TITLE
Fix permission checking in MediaAdminController::show()

### DIFF
--- a/Controller/MediaAdminController.php
+++ b/Controller/MediaAdminController.php
@@ -27,7 +27,7 @@ class MediaAdminController extends Controller
      */
     public function showAction($id = null)
     {
-        if (false === $this->admin->isGranted('SHOW')) {
+        if (false === $this->admin->isGranted('VIEW')) {
             throw new AccessDeniedException();
         }
 


### PR DESCRIPTION
The `SHOW` permission does not exist. The correct permission is `VIEW` (and is correctly used in `SonataAdminBundle`).
