### PR TITLE
Within Pixlr change media route from view to show

### DIFF
--- a/Extra/Pixlr.php
+++ b/Extra/Pixlr.php
@@ -208,7 +208,7 @@ class Pixlr
 
         $this->mediaManager->save($media);
 
-        return new RedirectResponse($this->router->generate('admin_sonata_media_media_view', array('id' => $media->getId())));
+        return new RedirectResponse($this->router->generate('admin_sonata_media_media_show', array('id' => $media->getId())));
     }
 
     /**


### PR DESCRIPTION
Within the Pixlr functionality of the MediaBundle, the targetAction links to a non-existing (old) route. Changed the route to its new name (view => show).
