### PR TITLE
Fix Doctrine MediaManager to implement MediaManagerInterface too

### DIFF
--- a/Entity/MediaManager.php
+++ b/Entity/MediaManager.php
@@ -10,11 +10,13 @@
  */
 namespace Sonata\MediaBundle\Entity;
 
-use Sonata\CoreBundle\Entity\DoctrineBaseManager;
 use Doctrine\ORM\EntityManager;
+
+use Sonata\CoreBundle\Entity\DoctrineBaseManager;
+use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Sonata\MediaBundle\Provider\Pool;
 
-class MediaManager extends DoctrineBaseManager
+class MediaManager extends DoctrineBaseManager implements MediaManagerInterface
 {
     /**
      * Constructor.

--- a/Model/MediaManagerInterface.php
+++ b/Model/MediaManagerInterface.php
@@ -11,55 +11,12 @@
 
 namespace Sonata\MediaBundle\Model;
 
-interface MediaManagerInterface
+use Sonata\CoreBundle\Entity\ManagerInterface;
+
+/**
+ * @deprecated Use Sonata\CoreBundle\Entity\ManagerInterface instead
+ */
+interface MediaManagerInterface extends ManagerInterface
 {
-    /**
-     * Creates an empty media instance
-     *
-     * @return MediaInterface
-     */
-    public function create();
 
-    /**
-     * Deletes a media
-     *
-     * @param MediaInterface $media
-     *
-     * @return void
-     */
-    public function delete(MediaInterface $media);
-
-    /**
-     * Finds many media by the given criteria
-     *
-     * @param array $criteria
-     *
-     * @return MediaInterface
-     */
-    public function findBy(array $criteria);
-
-    /**
-     * Finds one media by the given criteria
-     *
-     * @param array $criteria
-     *
-     * @return MediaInterface
-     */
-    public function findOneBy(array $criteria);
-
-    /**
-     * Returns the media's fully qualified class name
-     *
-     * @return string
-     */
-    public function getClass();
-
-    /**
-     * @param MediaInterface $media
-     * @param null           $context
-     * @param null           $providerName
-     *
-     * @return void
-     */
-    public function save(MediaInterface $media, $context = null, $providerName = null);
 }


### PR DESCRIPTION
After adding the `Sonata\CoreBundle\Entity\DoctrineBaseManager` to this `Entity\MediaManager`, the `MediaManagerInterface` was not implemented anymore.

This results in a fatal error on a video view page because Pixlr class is waiting for a `MediaManagerInterface` in the constructor.
_See: https://github.com/sonata-project/SonataMediaBundle/blob/master/Extra/Pixlr.php#L54_

As the save() and delete() methods are already verified by the `Sonata\CoreBundle\Entity\ManagerInterface` I think we can remove these methods from the `MediaManagerInterface`.
