### PR TITLE
SONATA-319 - Enable modal for media/gallery status

### DIFF
--- a/Admin/BaseMediaAdmin.php
+++ b/Admin/BaseMediaAdmin.php
@@ -45,7 +45,10 @@ abstract class BaseMediaAdmin extends Admin
     {
         $listMapper
             ->add('custom', 'string', array('template' => 'SonataMediaBundle:MediaAdmin:list_custom.html.twig'))
-            ->add('enabled', 'boolean', array('editable' => true))
+            ->add('enabled', 'boolean', array(
+                'editable'     => true,
+                'confirmation' => true,
+            ))
             ->add('_action', 'actions', array(
                 'actions' => array(
                     'show' => array(),

--- a/Admin/GalleryAdmin.php
+++ b/Admin/GalleryAdmin.php
@@ -83,7 +83,10 @@ class GalleryAdmin extends Admin
     {
         $listMapper
             ->addIdentifier('name')
-            ->add('enabled', 'boolean', array('editable' => true))
+            ->add('enabled', 'boolean', array(
+                'editable'     => true,
+                'confirmation' => true,
+            ))
             ->add('context', 'trans', array('catalogue' => 'SonataMediaBundle'))
             ->add('defaultFormat', 'trans', array('catalogue' => 'SonataMediaBundle'))
         ;


### PR DESCRIPTION
Added confirmation modal for media & gallery `enabled` fields in administration list template.

Merge or the following PR is needed before: sonata-project/SonataAdminBundle#1873
