### PR TITLE
Removing word "Medias" from translations

### DIFF
--- a/Resources/translations/SonataMediaBundle.en.xliff
+++ b/Resources/translations/SonataMediaBundle.en.xliff
@@ -32,7 +32,7 @@
             </trans-unit>
             <trans-unit id="breadcrumb.link_media_list">
                 <source>breadcrumb.link_media_list</source>
-                <target>Medias</target>
+                <target>Media</target>
             </trans-unit>
             <trans-unit id="breadcrumb.link_media_edit">
                 <source>breadcrumb.link_media_edit</source>
@@ -124,7 +124,7 @@
             </trans-unit>
             <trans-unit id="form.label_gallery_has_medias">
                 <source>form.label_gallery_has_medias</source>
-                <target>Medias</target>
+                <target>Media</target>
             </trans-unit>
             <trans-unit id="form.label_author_name">
                 <source>form.label_author_name</source>


### PR DESCRIPTION
According to http://www.oxforddictionaries.com/definition/american_english/media the word "media" is the plural form of "medium". Therefore, there is no word "medias".
I did not go so far to rename the models and associations, but IMO at least the translations should follow grammar.
