### PR TITLE
Add a block translation example for sonata_template_box twig node tag

### DIFF
--- a/Resources/translations/SonataMediaBundle.de.xliff
+++ b/Resources/translations/SonataMediaBundle.de.xliff
@@ -338,6 +338,10 @@
                 <source>sonata_media_gallery_index</source>
                 <target>sonata_media_gallery_index</target>
             </trans-unit>
+            <trans-unit id="sonata_template_box_media_gallery_block">
+                <source>sonata_template_box_media_gallery_block</source>
+                <target>This is the gallery media block. Feel free to override it.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataMediaBundle.en.xliff
+++ b/Resources/translations/SonataMediaBundle.en.xliff
@@ -353,6 +353,10 @@
                 <source>sonata_media_gallery_index</source>
                 <target>Gallery</target>
             </trans-unit>
+            <trans-unit id="sonata_template_box_media_gallery_block">
+                <source>sonata_template_box_media_gallery_block</source>
+                <target>This is the gallery media block. Feel free to override it.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataMediaBundle.es.xliff
+++ b/Resources/translations/SonataMediaBundle.es.xliff
@@ -353,6 +353,10 @@
                 <source>sonata_media_gallery_index</source>
                 <target>sonata_media_gallery_index</target>
             </trans-unit>
+            <trans-unit id="sonata_template_box_media_gallery_block">
+                <source>sonata_template_box_media_gallery_block</source>
+                <target>This is the gallery media block. Feel free to override it.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataMediaBundle.fr.xliff
+++ b/Resources/translations/SonataMediaBundle.fr.xliff
@@ -353,6 +353,10 @@
                 <source>sonata_media_gallery_index</source>
                 <target>Galeries</target>
             </trans-unit>
+            <trans-unit id="sonata_template_box_media_gallery_block">
+                <source>sonata_template_box_media_gallery_block</source>
+                <target>Ceci est un bloc de gallerie de médias. Vous pouvez le surcharger librement.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataMediaBundle.hu.xliff
+++ b/Resources/translations/SonataMediaBundle.hu.xliff
@@ -353,6 +353,10 @@
                 <source>sonata_media_gallery_index</source>
                 <target>Galéria</target>
             </trans-unit>
+            <trans-unit id="sonata_template_box_media_gallery_block">
+                <source>sonata_template_box_media_gallery_block</source>
+                <target>This is the gallery media block. Feel free to override it.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataMediaBundle.lt.xliff
+++ b/Resources/translations/SonataMediaBundle.lt.xliff
@@ -353,6 +353,10 @@
                 <source>sonata_media_gallery_index</source>
                 <target>sonata_media_gallery_index</target>
             </trans-unit>
+            <trans-unit id="sonata_template_box_media_gallery_block">
+                <source>sonata_template_box_media_gallery_block</source>
+                <target>This is the gallery media block. Feel free to override it.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataMediaBundle.nl.xliff
+++ b/Resources/translations/SonataMediaBundle.nl.xliff
@@ -353,6 +353,10 @@
                 <source>sonata_media_gallery_index</source>
                 <target>sonata_media_gallery_index</target>
             </trans-unit>
+            <trans-unit id="sonata_template_box_media_gallery_block">
+                <source>sonata_template_box_media_gallery_block</source>
+                <target>This is the gallery media block. Feel free to override it.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataMediaBundle.pl.xliff
+++ b/Resources/translations/SonataMediaBundle.pl.xliff
@@ -353,6 +353,10 @@
                 <source>sonata_media_gallery_index</source>
                 <target>sonata_media_gallery_index</target>
             </trans-unit>
+            <trans-unit id="sonata_template_box_media_gallery_block">
+                <source>sonata_template_box_media_gallery_block</source>
+                <target>This is the gallery media block. Feel free to override it.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataMediaBundle.pt_BR.xliff
+++ b/Resources/translations/SonataMediaBundle.pt_BR.xliff
@@ -353,6 +353,10 @@
                 <source>sonata_media_gallery_index</source>
                 <target>sonata_media_gallery_index</target>
             </trans-unit>
+            <trans-unit id="sonata_template_box_media_gallery_block">
+                <source>sonata_template_box_media_gallery_block</source>
+                <target>This is the gallery media block. Feel free to override it.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataMediaBundle.ru.xliff
+++ b/Resources/translations/SonataMediaBundle.ru.xliff
@@ -353,6 +353,10 @@
                 <source>sonata_media_gallery_index</source>
                 <target>sonata_media_gallery_index</target>
             </trans-unit>
+            <trans-unit id="sonata_template_box_media_gallery_block">
+                <source>sonata_template_box_media_gallery_block</source>
+                <target>This is the gallery media block. Feel free to override it.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataMediaBundle.sl.xliff
+++ b/Resources/translations/SonataMediaBundle.sl.xliff
@@ -353,6 +353,10 @@
                 <source>sonata_media_gallery_index</source>
                 <target>sonata_media_gallery_index</target>
             </trans-unit>
+            <trans-unit id="sonata_template_box_media_gallery_block">
+                <source>sonata_template_box_media_gallery_block</source>
+                <target>This is the gallery media block. Feel free to override it.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/views/Block/block_gallery.html.twig
+++ b/Resources/views/Block/block_gallery.html.twig
@@ -16,7 +16,7 @@ file that was distributed with this source code.
             <h3 class="sonata-media-block-media-title">{{ settings.title }}</h3>
         {% endif %}
 
-        {% sonata_template_box 'This is the gallery media block. Feel free to override it.' %}
+        {% sonata_template_box 'sonata_template_box_media_gallery_block' 'SonataMediaBundle' %}
 
         <div class="sonata-media-block-gallery-container">
             <div id="sonata-media-block-gallery-{{ block.id }}" class="nivoGallery">


### PR DESCRIPTION
I've added an example for the translations key use with `sonata_template_box` Twig tag due to the following PR: https://github.com/sonata-project/SonataCoreBundle/pull/34
