### PR TITLE
Fix SimpleResizer image ratios when one of the parameters isn't set.

### DIFF
--- a/Resizer/SimpleResizer.php
+++ b/Resizer/SimpleResizer.php
@@ -13,9 +13,11 @@ namespace Sonata\MediaBundle\Resizer;
 
 use Imagine\Image\ImagineInterface;
 use Imagine\Image\Box;
+use Imagine\Image\BoxInterface;
+use Imagine\Image\ImageInterface;
+use Imagine\Image\Point;
 use Gaufrette\File;
 use Sonata\MediaBundle\Model\MediaInterface;
-use Imagine\Image\ImageInterface;
 use Imagine\Exception\InvalidArgumentException;
 use Sonata\MediaBundle\Metadata\MetadataBuilderInterface;
 
@@ -30,6 +32,7 @@ class SimpleResizer implements ResizerInterface
     /**
      * @param ImagineInterface $adapter
      * @param string           $mode
+     * @param MetadataBuilderInterface $metadata
      */
     public function __construct(ImagineInterface $adapter, $mode, MetadataBuilderInterface $metadata)
     {
@@ -49,8 +52,8 @@ class SimpleResizer implements ResizerInterface
 
         $image = $this->adapter->load($in->getContent());
 
-        $content = $image
-            ->thumbnail($this->getBox($media, $settings), $this->mode)
+        $content = $this
+            ->thumbnail($image, $this->getBox($media, $settings), $this->mode, $this->computeRatio($media, $settings))
             ->get($format, array('quality' => $settings['quality']));
 
         $out->setContent($content, $this->metadata->get($media, $out->getName()));
@@ -63,36 +66,37 @@ class SimpleResizer implements ResizerInterface
     {
         $size = $media->getBox();
 
-        if ($settings['width'] == null && $settings['height'] == null) {
-            throw new \RuntimeException(sprintf('Width/Height parameter is missing in context "%s" for provider "%s". Please add at least one parameter.', $media->getContext(), $media->getProviderName()));
-        }
-
-        if ($settings['height'] == null) {
-            $settings['height'] = (int) ($settings['width'] * $size->getHeight() / $size->getWidth());
-        }
-
-        if ($settings['width'] == null) {
-            $settings['width'] = (int) ($settings['height'] * $size->getWidth() / $size->getHeight());
-        }
-
-        return $this->computeBox($media, $settings);
+        return $size->scale($this->computeRatio($media, $settings));
     }
 
     /**
      * @throws InvalidArgumentException
+     * @throws \RuntimeException
      *
      * @param MediaInterface $media
      * @param array          $settings
      *
-     * @return Box
+     * @return float         $ratio
      */
-    private function computeBox(MediaInterface $media, array $settings)
+    private function computeRatio(MediaInterface $media, array $settings)
     {
         if ($this->mode !== ImageInterface::THUMBNAIL_INSET && $this->mode !== ImageInterface::THUMBNAIL_OUTBOUND) {
             throw new InvalidArgumentException('Invalid mode specified');
         }
 
         $size = $media->getBox();
+
+        if ($settings['width'] == null && $settings['height'] == null) {
+            throw new \RuntimeException(sprintf('Width/Height parameter is missing in context "%s" for provider "%s". Please add at least one parameter.', $media->getContext(), $media->getProviderName()));
+        }
+
+        if ($settings['height'] == null) {
+            $settings['height'] = $settings['width'] * $size->getHeight() / $size->getWidth();
+        }
+
+        if ($settings['width'] == null) {
+            $settings['width'] = $settings['height'] * $size->getWidth() / $size->getHeight();
+        }
 
         $ratios = array(
             $settings['width'] / $size->getWidth(),
@@ -105,6 +109,54 @@ class SimpleResizer implements ResizerInterface
             $ratio = max($ratios);
         }
 
-        return $size->scale($ratio);
+        return $ratio;
+    }
+
+
+    /**
+     * @param ImageInterface $image
+     * @param BoxInterface $size
+     * @param string $mode
+     * @param float $ratio
+     *
+     * @return \Imagine\Image\ManipulatorInterface
+     */
+    private function thumbnail(ImageInterface $image, BoxInterface $size, $mode = ImageInterface::THUMBNAIL_INSET, $ratio)
+    {
+
+        $imageSize = $image->getSize();
+        $thumbnail = $image->copy();
+
+        // if target width is larger than image width
+        // AND target height is longer than image height
+        if ($size->contains($imageSize)) {
+            return $thumbnail;
+        }
+
+        if ($mode === ImageInterface::THUMBNAIL_OUTBOUND) {
+            if (!$imageSize->contains($size)) {
+                $size = new Box(
+                    min($imageSize->getWidth(), $size->getWidth()),
+                    min($imageSize->getHeight(), $size->getHeight())
+                );
+            } else {
+                $imageSize = $thumbnail->getSize()->scale($ratio);
+                $thumbnail->resize($imageSize);
+            }
+            $thumbnail->crop(new Point(
+                max(0, round(($imageSize->getWidth() - $size->getWidth()) / 2)),
+                max(0, round(($imageSize->getHeight() - $size->getHeight()) / 2))
+            ), $size);
+        } else {
+            if (!$imageSize->contains($size)) {
+                $imageSize = $imageSize->scale($ratio);
+                $thumbnail->resize($imageSize);
+            } else {
+                $imageSize = $thumbnail->getSize()->scale($ratio);
+                $thumbnail->resize($imageSize);
+            }
+        }
+
+        return $thumbnail;
     }
 }

--- a/Tests/Resizer/SimpleResizerTest.php
+++ b/Tests/Resizer/SimpleResizerTest.php
@@ -35,16 +35,22 @@ class SimpleResizerTest extends \PHPUnit_Framework_TestCase
 
     public function testResize()
     {
+        $thumbnail = $this->getMock('Imagine\Image\ImageInterface');
+        $thumbnail->expects($this->once())->method('getSize')->will($this->returnValue(new Box(535, 132)));
+        $thumbnail->expects($this->once())->method('get')->will($this->returnValue(file_get_contents(__DIR__.'/../fixtures/logo.png')));
+        $thumbnail->expects($this->once())->method('resize')->will($this->returnValue($thumbnail));
+        $thumbnail->expects($this->once())->method('crop')->will($this->returnValue($thumbnail));
 
         $image = $this->getMock('Imagine\Image\ImageInterface');
-        $image->expects($this->once())->method('thumbnail')->will($this->returnValue($image));
-        $image->expects($this->once())->method('get')->will($this->returnValue(file_get_contents(__DIR__.'/../fixtures/logo.png')));
+        $image->expects($this->once())->method('getSize')->will($this->returnValue(new Box(535, 132)));
+        $image->expects($this->once())->method('copy')->will($this->returnValue($thumbnail));
+
 
         $adapter = $this->getMock('Imagine\Image\ImagineInterface');
         $adapter->expects($this->any())->method('load')->will($this->returnValue($image));
 
         $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
-        $media->expects($this->exactly(2))->method('getBox')->will($this->returnValue(new Box(535, 132)));
+        $media->expects($this->exactly(3))->method('getBox')->will($this->returnValue(new Box(535, 132)));
 
         $filesystem = new Filesystem(new InMemory);
         $in = $filesystem->get('in', true);
@@ -57,6 +63,7 @@ class SimpleResizerTest extends \PHPUnit_Framework_TestCase
 
         $resizer = new SimpleResizer($adapter, 'outbound', $metadata);
         $resizer->resize($media, $in, $out, 'bar', array('height' => null, 'width' => 90, 'quality' => 100));
+
     }
 
     /**
@@ -87,7 +94,7 @@ class SimpleResizerTest extends \PHPUnit_Framework_TestCase
             array('inset', array( 'width' => 90, 'height' => 90 ), new Box(100, 120), new Box(75, 90)),
             array('inset', array( 'width' => 90, 'height' => 90 ), new Box(50, 50), new Box(90, 90)),
             array('inset', array( 'width' => 90, 'height' => null ), new Box(50, 50), new Box(90, 90)),
-            array('inset', array( 'width' => 90, 'height' => null ), new Box(567, 200), new Box(88, 31)),
+            array('inset', array( 'width' => 90, 'height' => null ), new Box(567, 200), new Box(90, 32)),
             array('inset', array( 'width' => 100, 'height' => 100 ), new Box(567, 200), new Box(100, 35)),
 
             array('outbound', array( 'width' => 90, 'height' => 90 ), new Box(100, 120), new Box(90, 108)),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #480
| License       | MIT

When scaling images, the ratio is calculated of both width and height. If one of these isn't set in the context format setting, is is calculated and rounded to an integer value. The ratio is then calculated of this rounded value which gives unexpected results as shown in #480 issue.
Fixes test too, as scaling a 567x200 image to 90px width should return a 90x32 image and not 88x31 (easily checked in any image editor).