### PR TITLE
Move serializer.xml loading

### DIFF
--- a/DependencyInjection/SonataMediaExtension.php
+++ b/DependencyInjection/SonataMediaExtension.php
@@ -51,13 +51,13 @@ class SonataMediaExtension extends Extension
         $loader->load('form.xml');
         $loader->load('gaufrette.xml');
         $loader->load('validators.xml');
+        $loader->load('serializer.xml');
 
         $bundles = $container->getParameter('kernel.bundles');
 
         if (isset($bundles['FOSRestBundle']) && isset($bundles['NelmioApiDocBundle'])) {
             $loader->load('api_controllers.xml');
             $loader->load('api_form.xml');
-            $loader->load('serializer.xml');
         }
 
         if (isset($bundles['SonataNotificationBundle'])) {


### PR DESCRIPTION
The usage of serializer.xml services can be not restrictive to REST API only.
In some cases it is usefull to serialize objects in an internal workflow, so you don't have to load FOSRestBundle nor NelmioApiDocBundle.

For example, in the Sonata commerce bundle, when you move a product from Basket to Order, each product items are serialized but not used in a REST interface.

The same modification can also be done in the following bundles:
- sonata-project\ecommerce\src\CustomerBundle\DependencyInjection\SonataCustomerExtension.php
- sonata-project\ecommerce\src\InvoiceBundle\DependencyInjection\SonataInvoiceExtension.php
- sonata-project\ecommerce\src\OrderBundle\DependencyInjection\SonataOrderExtension.php
- sonata-project\ecommerce\src\ProductBundle\DependencyInjection\SonataProductExtension.php
- sonata-project\news-bundle\DependencyInjection\SonataNewsExtension.php
- sonata-project\page-bundle\DependencyInjection\SonataPageExtension.php
- sonata-project\user-bundle\DependencyInjection\SonataUserExtension.php
