### PR TITLE
Fix API DoctrineORMSerializationType to be loaded only when using ORM

### DIFF
--- a/DependencyInjection/SonataMediaExtension.php
+++ b/DependencyInjection/SonataMediaExtension.php
@@ -55,7 +55,7 @@ class SonataMediaExtension extends Extension
 
         $bundles = $container->getParameter('kernel.bundles');
 
-        if (isset($bundles['FOSRestBundle']) && isset($bundles['NelmioApiDocBundle'])) {
+        if ('doctrine_orm' == $config['db_driver'] && isset($bundles['FOSRestBundle']) && isset($bundles['NelmioApiDocBundle'])) {
             $loader->load('api_controllers.xml');
             $loader->load('api_form.xml');
         }


### PR DESCRIPTION
I've moved `api_form.xml` that only contains form types definitions for API using `DoctrineORMSerializationType` when using the Doctrine ORM context.

This is to avoid the same issue encountered in `SonataUserBundle` here: https://github.com/sonata-project/SonataUserBundle/commit/9027604673cec6b67b5edfb47cba3ae55fd772e7#commitcomment-5705945
