### PR TITLE
Fixes content_type lenght. Mime types can have length up to 127 chars. http://tools.ietf.org/html/rfc4288#section-4.2

### DIFF
--- a/Resources/config/doctrine/BaseMedia.orm.xml
+++ b/Resources/config/doctrine/BaseMedia.orm.xml
@@ -19,7 +19,7 @@
         <field name="width"             column="width"             type="integer"  nullable="true" />
         <field name="height"            column="height"            type="integer"  nullable="true" />
         <field name="length"            column="length"            type="decimal"  nullable="true" />
-        <field name="contentType"       column="content_type"      type="string"   nullable="true" length="64" />
+        <field name="contentType"       column="content_type"      type="string"   nullable="true" length="127" />
         <field name="size"              column="content_size"      type="integer"  nullable="true" />
 
         <field name="copyright"         column="copyright"         type="string"  nullable="true"/>


### PR DESCRIPTION
Fixes content_type lenght. Mime types can have length up to 127 chars. http://tools.ietf.org/html/rfc4288#section-4.2

Ex: application/vnd.openxmlformats-officedocument.wordprocessingml.document
