### PR TITLE
Changed incompatible defaultSetting

### DIFF
--- a/Block/GalleryBlockService.php
+++ b/Block/GalleryBlockService.php
@@ -101,7 +101,7 @@ class GalleryBlockService extends BaseBlockService
             'startPaused' => false,
             'wrap'        => true,
             'template'    => 'SonataMediaBundle:Block:block_gallery.html.twig',
-            'galleryId'   => false
+            'galleryId'   => null
         ));
     }
 


### PR DESCRIPTION
It makes an error "Invalid argument, object or null required" when I tried to modify a block gallery. Value null resolved this issue.
