### PR TITLE
Update contentType length

### DIFF
--- a/Resources/config/doctrine/BaseMedia.orm.xml
+++ b/Resources/config/doctrine/BaseMedia.orm.xml
@@ -19,7 +19,7 @@
         <field name="width"             column="width"             type="integer"  nullable="true" />
         <field name="height"            column="height"            type="integer"  nullable="true" />
         <field name="length"            column="length"            type="decimal"  nullable="true" />
-        <field name="contentType"       column="content_type"      type="string"   nullable="true" length="64" />
+        <field name="contentType"       column="content_type"      type="string"   nullable="true" length="255" />
         <field name="size"              column="content_size"      type="integer"  nullable="true" />
 
         <field name="copyright"         column="copyright"         type="string"  nullable="true"/>


### PR DESCRIPTION
In some case the contentType can be more than 64 characters, Mysql truncate the string in that case however PostgreSQL throws an exception.
