### PR TITLE
Allow deletion of media that are associated with galleries.

### DIFF
--- a/DependencyInjection/SonataMediaExtension.php
+++ b/DependencyInjection/SonataMediaExtension.php
@@ -205,6 +205,7 @@ class SonataMediaExtension extends Extension
             'targetEntity'  => $config['class']['gallery_has_media'],
             'cascade'       => array(
                 'persist',
+                'remove'
             ),
             'mappedBy'      => 'media',
             'orphanRemoval' => false,


### PR DESCRIPTION
Right now the way the mapping is set up there is no cascade of deletes from the Media to the GalleryHasMedia. This means that if you attempt to delete Media and there are still GalleryHasMedia entities pointing at it you get a foreign key error.

Closes #576

Cascade removal from Media to GalleryHasMedia.