### PR TITLE
Media widgets

### DIFF
--- a/Resources/views/Form/media_widgets.html.twig
+++ b/Resources/views/Form/media_widgets.html.twig
@@ -5,7 +5,7 @@
                 {% thumbnail value, 'admin' with {'class': 'img-polaroid media-object'} %}
             </div>
 
-            {% if sonata_admin_enabled is defined and sonata_admin_enabled %}
+            {% if sonata_admin_enabled is defined and sonata_admin_enabled and sonata_admin.field_description.associationAdmin.hasRoute('edit') %}
                 <a href="{{ sonata_admin.field_description.associationAdmin.generateObjectUrl('edit', value) }}"><strong>{{ value.name }}</strong></a>
             {% else %}
                 <strong>{{ value.name }}</strong>

--- a/Resources/views/Form/media_widgets.html.twig
+++ b/Resources/views/Form/media_widgets.html.twig
@@ -6,17 +6,17 @@
             </div>
 
             {% if sonata_admin_enabled is defined and sonata_admin_enabled %}
-                <a href="{{ url('admin_sonata_media_media_edit', {id: value.id}) }}"><strong>{{ value.name }}</strong></a>
+                <a href="{{ sonata_admin.field_description.associationAdmin.generateObjectUrl('edit', value) }}"><strong>{{ value.name }}</strong></a>
             {% else %}
                 <strong>{{ value.name }}</strong>
             {% endif %}
-             <br />
+            <br />
             <span type="label">{{ value.providerName|trans({}, 'SonataMediaBundle') }}</span> ~ {{ value.context }}
         {% else %}
             <div class="pull-left" style="margin-right: 5px">
                 <img src="{{ asset('bundles/sonatamedia/grey.png') }}" class="img-polaroid media-object" style="width: 85px; height: 85px"/>
             </div>
-            <strong>{{ 'no_linked_media'|trans({}, 'SonataMediaBundle') }}</strong> <br />
+            <strong>{{ 'no_linked_media'|trans({}, 'SonataMediaBundle') }}</strong><br />
             <span type="label">{{ form.vars['provider']|trans({}, 'SonataMediaBundle') }} ~ {{ form.vars['context']|trans({}, 'SonataMediaBundle') }}</span>
         {% endif %}
     </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

This fixes route generation for media admin edit in ``media_widgets.html.twig`` when using custom ``Media`` class (extending ``\Sonata\MediaBundle\Entity\BaseMedia``) instead of default ``\Application\Sonata\MediaBundle\Entity\Media``.

```yaml
# app/config.yml

sonata_media:
    class:
        media:              Acme\DemoBundle\Entity\Media
```