### PR TITLE
Swap out SoapClient mock for ClientSpy to avoid PHP BC break with mocking internal classes.

### DIFF
--- a/Tests/CDN/PantherPortalTest.php
+++ b/Tests/CDN/PantherPortalTest.php
@@ -17,7 +17,7 @@ class PantherPortalTest extends \PHPUnit_Framework_TestCase
 {
     public function testPortal()
     {
-        $client = $this->getMock('\SoapClient', array('flush'), array(), '', false);
+        $client = $this->getMock('ClientSpy', array('flush'), array(), '', false);
         $client->expects($this->exactly(3))->method('flush')->will($this->returnValue("Flush successfully submitted."));
 
         $panther = new PantherPortal('/foo', 'login', 'pass', 42);
@@ -36,12 +36,19 @@ class PantherPortalTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('\RuntimeException', 'Unable to flush : Failed!!');
 
-        $client = $this->getMock('\SoapClient', array('flush'), array(), '', false);
+        $client = $this->getMock('ClientSpy', array('flush'), array(), '', false);
         $client->expects($this->exactly(1))->method('flush')->will($this->returnValue('Failed!!'));
 
         $panther = new PantherPortal('/foo', 'login', 'pass', 42);
         $panther->setClient($client);
 
         $panther->flushPaths(array('boom'));
+    }
+}
+
+class ClientSpy
+{
+    public function flush()
+    {
     }
 }


### PR DESCRIPTION
Fixes #589
