### PR TITLE
Fix errors upload_max_filesize, wrong mimetypes for SonataAdmin

### DIFF
--- a/Provider/BaseProvider.php
+++ b/Provider/BaseProvider.php
@@ -71,7 +71,10 @@ abstract class BaseProvider implements MediaProviderInterface
             return;
         }
 
-        $this->doTransform($media);
+        try {
+            $this->doTransform($media);
+        } catch (\Exception $e) {
+        }
     }
 
     /**

--- a/Provider/FileProvider.php
+++ b/Provider/FileProvider.php
@@ -218,7 +218,7 @@ class FileProvider extends BaseProvider
         $this->fixBinaryContent($media);
         $this->fixFilename($media);
 
-        if ($media->getBinaryContent()->getClientSize() == 0) {
+        if ($media->getBinaryContent() instanceof UploadedFile && $media->getBinaryContent()->getClientSize() == 0) {
             $media->setProviderReference(sha1($media->getName() . rand(11111, 99999)));
             $media->setProviderStatus(MediaInterface::STATUS_ERROR);
             throw new UploadException('The uploaded file is not found');


### PR DESCRIPTION
Hi.

I found a way to fix the issue when you upload a file bigger than the upload_max_filesize, and also on invalid mimetypes.

I added an exception if the clientsize is at  zero bytes, i'm guessing that it's not uploaded because of upload_max_filesize value. I had to set a providerReference because there is a validation on this field: can't be null or blank  (if there is no providerReference set, on top of the form it displays: this field cant be null, this field cant be blank).  I am catching this exception in the BaseProvider. I added in the validate method an error violation for the client size at zero bytes. The wrong mimetypes already had an error violation related, the issue was exception not being caught. I had to modify the last if statement so when the file isn't uploaded there is no check on the non existing file mimetypes.

Might not be the prettiest way to do it, but there is no more 500 errors.

Screenshot of file bigger than the upload_max_filesize:
![capture decran 2014-07-24 a 17 21 42 2](https://cloud.githubusercontent.com/assets/520893/3690340/b42c0d40-1347-11e4-8d53-a500e38f53f6.png)

Screenshot of wrong mimetypes:
![capture decran 2014-07-24 a 17 22 03 2](https://cloud.githubusercontent.com/assets/520893/3690344/c36703dc-1347-11e4-8e77-82db53befc21.png)