### PR TITLE
Fix PHPCR repository class: "Sonata\MediaBundle\PHPCR\GalleryHasMediaRepository" is declared twice

### DIFF
--- a/PHPCR/BaseGalleryHasMediaRepository.php
+++ b/PHPCR/BaseGalleryHasMediaRepository.php
@@ -12,4 +12,3 @@ class GalleryHasMediaRepository extends DocumentRepository implements Repository
         return '/cms/gallery-has-media/'  . uniqid();
     }
 }
-

--- a/PHPCR/BaseGalleryRepository.php
+++ b/PHPCR/BaseGalleryRepository.php
@@ -5,10 +5,10 @@ namespace Sonata\MediaBundle\PHPCR;
 use Doctrine\ODM\PHPCR\DocumentRepository;
 use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
 
-class GalleryHasMediaRepository extends DocumentRepository implements RepositoryIdInterface
+class GalleryRepository extends DocumentRepository implements RepositoryIdInterface
 {
     public function generateId($document, $parent = null)
     {
-        return '/cms/gallery-has-media/'  . uniqid();
+        return '/cms/gallery/'  . uniqid();
     }
 }


### PR DESCRIPTION
Hello,

I have the following warning since: https://github.com/sonata-project/SonataMediaBundle/commit/0c27e4fff161667f5b0243a16fb867d0f4297fe2

Warning: Ambiguous class resolution, "Sonata\MediaBundle\PHPCR\GalleryHasMediaRepository" was found in both "/var/lib/jenkins/workspace/monclubbusiness/vendor/sonata-project/media-bundle/PHPCR/BaseGalleryHasMediaRepository.php" and "/var/lib/jenkins/workspace/monclubbusiness/vendor/sonata-project/media-bundle/PHPCR/BaseGalleryRepository.php", the first will be used.

Effectively the class "Sonata\MediaBundle\PHPCR\GalleryHasMediaRepository" is declared twice.
