### PR TITLE
Wrong parameter in sonata.media.admin.media.manager.

### DIFF
--- a/Resources/config/doctrine_mongodb_admin.xml
+++ b/Resources/config/doctrine_mongodb_admin.xml
@@ -45,7 +45,7 @@
         </service>
 
         <service id="sonata.media.admin.media.manager" class="Sonata\MediaBundle\Admin\Manager\DoctrineMongoDBManager">
-            <argument type="service" id="doctrine_mongodb.odm.document_manager" />
+            <argument type="service" id="doctrine_mongodb" />
             <argument type="service" id="sonata.media.manager.media" />
         </service>
 


### PR DESCRIPTION
The commit will fix the following error:
[ErrorException] Catchable Fatal Error: Argument 1 passed to Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager::__construct() must be an instance of Symfony\Bridge\Doctrine\ManagerRegistry, instance of Doctrine\ODM\MongoDB\DocumentManager given, called in ../vendor/sonata-project/media-bundle/Admin/Manager/DoctrineMongoDBManager.php on line 22 and defined in /Users/interrobang/Sites/aag/vendor/sonata-project/doctrine-mongodb-admin-bundle/Sonata/DoctrineMongoDBAdminBundle/Model/ModelManager.php line 39
