### PR TITLE
fix double gallery edit form sections

### DIFF
--- a/Admin/GalleryAdmin.php
+++ b/Admin/GalleryAdmin.php
@@ -41,8 +41,8 @@ class GalleryAdmin extends Admin
     {
         // define group zoning
         $formMapper
-            ->with($this->trans('Gallery'), array('class' => 'col-md-9'))
-            ->with($this->trans('Options'), array('class' => 'col-md-3'))
+            ->with('Gallery', array('class' => 'col-md-9'))
+            ->with('Options', array('class' => 'col-md-3'))
         ;
 
         $context = $this->getPersistentParameter('context');


### PR DESCRIPTION
This pull request eliminates double translation on gallery edit form sections, which results in doubled sections (because first it was added as translated and second as untranslated). Translation on 'formMapper' level is not necessary because it's done later on template level.