### PR TITLE
Adding a new option to sonata_media_type

### DIFF
--- a/Form/Type/MediaType.php
+++ b/Form/Type/MediaType.php
@@ -59,11 +59,14 @@ class MediaType extends AbstractType
 
         $this->pool->getProvider($options['provider'])->buildMediaType($builder);
 
-        $builder->add('unlink', 'checkbox', array(
-            'mapped'   => false,
-            'data'     => false,
-            'required' => false
-        ));
+        // We add a new option to the form for adding or not the unlink checkbox
+        if ($options['unlink_enabled']) {
+            $builder->add('unlink', 'checkbox', array(
+                'mapped'   => false,
+                'data'     => false,
+                'required' => false
+            ));
+        }
     }
 
     /**
@@ -86,6 +89,7 @@ class MediaType extends AbstractType
             'context'       => null,
             'empty_on_new'  => true,
             'new_on_update' => true,
+            'unlink_enabled'=> true,
         ));
     }
 


### PR DESCRIPTION
The idea is to be give the developer the chance to use or not the unlink checkbox of the sonata_media_type without overriding the entire type. For that, we can pass to the admin the option 'unlink_enabled' (true by default). Changing it to false, will not add that checkbox to the form.