### PR TITLE
Add BaseVideoProvider::getReferenceUrl() method

### DIFF
--- a/Provider/BaseVideoProvider.php
+++ b/Provider/BaseVideoProvider.php
@@ -158,6 +158,15 @@ abstract class BaseVideoProvider extends BaseProvider
     }
 
     /**
+     * Get provider reference url
+     *
+     * @param MediaInterface $media
+     *
+     * @return string
+     */
+    abstract public function getReferenceUrl(MediaInterface $media);
+
+    /**
      * @throws \RuntimeException
      *
      * @param \Sonata\MediaBundle\Model\MediaInterface $media

--- a/Provider/DailyMotionProvider.php
+++ b/Provider/DailyMotionProvider.php
@@ -121,7 +121,7 @@ class DailyMotionProvider extends BaseVideoProvider
      */
     public function updateMetadata(MediaInterface $media, $force = false)
     {
-        $url = sprintf('http://www.dailymotion.com/services/oembed?url=http://www.dailymotion.com/video/%s&format=json', $media->getProviderReference());
+        $url = sprintf('http://www.dailymotion.com/services/oembed?url=%s&format=json', $this->getReferenceUrl($media));
 
         try {
             $metadata = $this->getMetadata($media, $url);
@@ -148,6 +148,14 @@ class DailyMotionProvider extends BaseVideoProvider
      */
     public function getDownloadResponse(MediaInterface $media, $format, $mode, array $headers = array())
     {
-        return new RedirectResponse(sprintf('http://www.dailymotion.com/video/%s', $media->getProviderReference()), 302, $headers);
+        return new RedirectResponse($this->getReferenceUrl($media), 302, $headers);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getReferenceUrl(MediaInterface $media)
+    {
+        return sprintf('http://www.dailymotion.com/video/%s', $media->getProviderReference());
     }
 }

--- a/Provider/VimeoProvider.php
+++ b/Provider/VimeoProvider.php
@@ -108,7 +108,7 @@ class VimeoProvider extends BaseVideoProvider
      */
     public function updateMetadata(MediaInterface $media, $force = false)
     {
-        $url = sprintf('http://vimeo.com/api/oembed.json?url=http://vimeo.com/%s', $media->getProviderReference());
+        $url = sprintf('http://vimeo.com/api/oembed.json?url=%s', $this->getReferenceUrl($media));
 
         try {
             $metadata = $this->getMetadata($media, $url);
@@ -140,6 +140,14 @@ class VimeoProvider extends BaseVideoProvider
      */
     public function getDownloadResponse(MediaInterface $media, $format, $mode, array $headers = array())
     {
-        return new RedirectResponse(sprintf('http://vimeo.com/%s', $media->getProviderReference()), 302, $headers);
+        return new RedirectResponse($this->getReferenceUrl($media), 302, $headers);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getReferenceUrl(MediaInterface $media)
+    {
+        return sprintf('http://vimeo.com/%s', $media->getProviderReference());
     }
 }

--- a/Provider/YouTubeProvider.php
+++ b/Provider/YouTubeProvider.php
@@ -229,7 +229,7 @@ class YouTubeProvider extends BaseVideoProvider
      */
     public function updateMetadata(MediaInterface $media, $force = false)
     {
-        $url = sprintf('http://www.youtube.com/oembed?url=http://www.youtube.com/watch?v=%s&format=json', $media->getProviderReference());
+        $url = sprintf('http://www.youtube.com/oembed?url=%s&format=json', $this->getReferenceUrl($media));
 
         try {
             $metadata = $this->getMetadata($media, $url);
@@ -257,6 +257,14 @@ class YouTubeProvider extends BaseVideoProvider
      */
     public function getDownloadResponse(MediaInterface $media, $format, $mode, array $headers = array())
     {
-        return new RedirectResponse(sprintf('http://www.youtube.com/watch?v=%s', $media->getProviderReference()), 302, $headers);
+        return new RedirectResponse($this->getReferenceUrl($media), 302, $headers);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getReferenceUrl(MediaInterface $media)
+    {
+        return sprintf('http://www.youtube.com/watch?v=%s', $media->getProviderReference());
     }
 }

--- a/Tests/Provider/DailyMotionProviderTest.php
+++ b/Tests/Provider/DailyMotionProviderTest.php
@@ -54,7 +54,7 @@ class DailyMotionProviderTest extends \PHPUnit_Framework_TestCase
     {
         $provider = $this->getProvider();
 
-        $media = new Media;
+        $media = new Media();
         $media->setName('les tests fonctionnels - Symfony Live 2009');
         $media->setProviderName('dailymotion');
         $media->setProviderReference('x9wjql');
@@ -186,5 +186,13 @@ class DailyMotionProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('array', $properties);
         $this->assertEquals(100, $properties['height']);
         $this->assertEquals(100, $properties['width']);
+    }
+
+    public function testGetReferenceUrl()
+    {
+        $media = new Media();
+        $media->setProviderReference('123456');
+
+        $this->assertEquals('http://www.dailymotion.com/video/123456', $this->getProvider()->getReferenceUrl($media));
     }
 }

--- a/Tests/Provider/VimeoProviderTest.php
+++ b/Tests/Provider/VimeoProviderTest.php
@@ -54,7 +54,7 @@ class VimeoProviderTest extends \PHPUnit_Framework_TestCase
     {
         $provider = $this->getProvider();
 
-        $media = new Media;
+        $media = new Media();
         $media->setName('Blinky™');
         $media->setProviderName('vimeo');
         $media->setProviderReference('21216091');
@@ -188,5 +188,13 @@ class VimeoProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(100, $properties['height']);
         $this->assertEquals(100, $properties['width']);
 
+    }
+
+    public function testGetReferenceUrl()
+    {
+        $media = new Media();
+        $media->setProviderReference('123456');
+
+        $this->assertEquals('http://vimeo.com/123456', $this->getProvider()->getReferenceUrl($media));
     }
 }

--- a/Tests/Provider/YouTubeProviderTest.php
+++ b/Tests/Provider/YouTubeProviderTest.php
@@ -54,7 +54,7 @@ class YoutubeProviderTest extends \PHPUnit_Framework_TestCase
     {
         $provider = $this->getProvider();
 
-        $media = new Media;
+        $media = new Media();
         $media->setName('Nono le petit robot');
         $media->setProviderName('youtube');
         $media->setProviderReference('BDYAbAtaDzA');
@@ -185,5 +185,13 @@ class YoutubeProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('array', $properties);
         $this->assertEquals(100, $properties['player_parameters']['height']);
         $this->assertEquals(100, $properties['player_parameters']['width']);
+    }
+
+    public function testGetReferenceUrl()
+    {
+        $media = new Media();
+        $media->setProviderReference('123456');
+
+        $this->assertEquals('http://www.youtube.com/watch?v=123456', $this->getProvider()->getReferenceUrl($media));
     }
 }


### PR DESCRIPTION
This PR add a ``BaseVideoProvider::getReferenceUrl()`` public abstract method, just to easily get the original URL.