### PR TITLE
Make media form field not required

### DIFF
--- a/Provider/FileProvider.php
+++ b/Provider/FileProvider.php
@@ -119,7 +119,7 @@ class FileProvider extends BaseProvider
      */
     public function buildMediaType(FormBuilder $formBuilder)
     {
-        $formBuilder->add('binaryContent', 'file');
+        $formBuilder->add('binaryContent', 'file', array('required' => false));
     }
 
     /**


### PR DESCRIPTION
There's no need for this file to be required and it's required by default on Symfony.