### PR TITLE
Update BaseMediaRepository.php

### DIFF
--- a/PHPCR/BaseMediaRepository.php
+++ b/PHPCR/BaseMediaRepository.php
@@ -5,7 +5,7 @@ namespace Sonata\MediaBundle\PHPCR;
 use Doctrine\ODM\PHPCR\DocumentRepository;
 use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
 
-class MediaRepository extends DocumentRepository implements RepositoryIdInterface
+class BaseMediaRepository extends DocumentRepository implements RepositoryIdInterface
 {
     public function generateId($document, $parent = null)
     {


### PR DESCRIPTION
Class is named `MediaRepository` but file is named `BaseMediaRepository` which is extended by `Application\Sonata\MediaBundle\PHPCR\Media` so it throws an error saying that class exists but file was not found.
