### PR TITLE
Update BaseGalleryHasMedia.phpcr.xml

### DIFF
--- a/Resources/config/doctrine/BaseGalleryHasMedia.phpcr.xml
+++ b/Resources/config/doctrine/BaseGalleryHasMedia.phpcr.xml
@@ -7,7 +7,8 @@
 
     <mapped-superclass name="Sonata\MediaBundle\PHPCR\BaseGalleryHasMedia" referenceable="true" >
 
-        <parentdocument name="gallery" />
+        <parent-document name="gallery" />
+        <nodename name="nodename"/>
 
         <field name="enabled"        type="boolean" />
 


### PR DESCRIPTION
`parentdocument` has a typo, it needs a `-` between words.
Added nodename field as it was being used by galleryhasmedias but not mapped. 

This change makes media available to being used inside a Gallery using with my other PR on this bundle.
