### PR TITLE
Ensure element unlink exist

### DIFF
--- a/Form/Type/MediaType.php
+++ b/Form/Type/MediaType.php
@@ -52,7 +52,7 @@ class MediaType extends AbstractType
         )));
 
         $builder->addEventListener(FormEvents::BIND, function(FormEvent $event) {
-            if ($event->getForm()->get('unlink')->getData()) {
+            if ($event->getForm()->has('unlink') && $event->getForm()->get('unlink')->getData()) {
                 $event->setData(null);
             }
         });


### PR DESCRIPTION
The form type media_type can be manipulated with events, inherits etc 

Now we can remove element unlink without have 

Child "unlink" does not exist. - 500 Internal Server Error - OutOfBoundsException