### PR TITLE
[ConsoleCommand] Added path of generated thumbnails to sonata:media:sync-thumbnails

### DIFF
--- a/Command/SyncThumbsCommand.php
+++ b/Command/SyncThumbsCommand.php
@@ -153,7 +153,16 @@ class SyncThumbsCommand extends BaseCommand
         }
 
         try {
-            $provider->generateThumbnails($media);
+            $thumbnailSet = $provider->generateThumbnails($media);
+
+            if (OutputInterface::VERBOSITY_VERBOSE <= $output->getVerbosity() &&
+                !empty($thumbnailSet)
+            ) {
+                foreach ($thumbnailSet as $format => $thumbnail) {
+                    $this->log(sprintf('[%s] => %s', $format, $thumbnail->getName()));
+                }
+                $this->log('');
+            }
         } catch (\Exception $e) {
             $this->log(sprintf('<error>Unable to generate new thumbnails, media: %s - %s </error>',
                 $media->getId(), $e->getMessage()));

--- a/Provider/BaseProvider.php
+++ b/Provider/BaseProvider.php
@@ -123,7 +123,7 @@ abstract class BaseProvider implements MediaProviderInterface
      */
     public function generateThumbnails(MediaInterface $media)
     {
-        $this->thumbnail->generate($this, $media);
+        return $this->thumbnail->generate($this, $media);
     }
 
     /**

--- a/Provider/MediaProviderInterface.php
+++ b/Provider/MediaProviderInterface.php
@@ -47,6 +47,8 @@ interface MediaProviderInterface
      * Generated thumbnails linked to the media, a thumbnail is a format used on the website.
      *
      * @param MediaInterface $media
+     *
+     * @return \Gaufrette\File[]
      */
     public function generateThumbnails(MediaInterface $media);
 

--- a/Thumbnail/ConsumerThumbnail.php
+++ b/Thumbnail/ConsumerThumbnail.php
@@ -64,6 +64,8 @@ class ConsumerThumbnail implements ThumbnailInterface
             // so we have a race condition
             'providerReference' => $media->getProviderReference(),
         ));
+
+        return array();
     }
 
     /**

--- a/Thumbnail/FormatThumbnail.php
+++ b/Thumbnail/FormatThumbnail.php
@@ -58,27 +58,33 @@ class FormatThumbnail implements ThumbnailInterface
      */
     public function generate(MediaProviderInterface $provider, MediaInterface $media)
     {
+        $thumbnailSet = array();
+
         if (!$provider->requireThumbnails()) {
-            return;
+            return $thumbnailSet;
         }
 
         $referenceFile = $provider->getReferenceFile($media);
 
         if (!$referenceFile->exists()) {
-            return;
+            return $thumbnailSet;
         }
 
         foreach ($provider->getFormats() as $format => $settings) {
             if (substr($format, 0, strlen($media->getContext())) == $media->getContext() || $format === 'admin') {
+                $thumbnail = $provider->getFilesystem()->get($provider->generatePrivateUrl($media, $format), true);
+                $thumbnailSet[$format] = $thumbnail;
                 $provider->getResizer()->resize(
                     $media,
                     $referenceFile,
-                    $provider->getFilesystem()->get($provider->generatePrivateUrl($media, $format), true),
+                    $thumbnail,
                     $this->getExtension($media),
                     $settings
                 );
             }
         }
+
+        return $thumbnailSet;
     }
 
     /**

--- a/Thumbnail/LiipImagineThumbnail.php
+++ b/Thumbnail/LiipImagineThumbnail.php
@@ -67,7 +67,7 @@ class LiipImagineThumbnail implements ThumbnailInterface
     public function generate(MediaProviderInterface $provider, MediaInterface $media)
     {
         // nothing to generate, as generated on demand
-        return;
+        return array();
     }
 
     /**

--- a/Thumbnail/ThumbnailInterface.php
+++ b/Thumbnail/ThumbnailInterface.php
@@ -33,6 +33,8 @@ interface ThumbnailInterface
     /**
      * @param \Sonata\MediaBundle\Provider\MediaProviderInterface $provider
      * @param \Sonata\MediaBundle\Model\MediaInterface            $media
+     *
+     * @return \Gaufrette\File[]
      */
     public function generate(MediaProviderInterface $provider, MediaInterface $media);
 


### PR DESCRIPTION
Added path of generated thumbnails to ```sonata:media:sync-thumbnails``` command's output when verbosity level is at least 2 (executed with ```-v``` option).

Before:
```
$ app/console sonata:media:sync-thumbnails sonata.media.provider.youtube video -v
Loaded 300 medias for generating thumbs (provider: sonata.media.provider.youtube, context: video)
Generating thumbs for My awesome video - 150
Generating thumbs for Another video - 152
...
```

After:
```
$ app/console sonata:media:sync-thumbnails sonata.media.provider.youtube video -v
Loaded 300 medias for generating thumbs (provider: sonata.media.provider.youtube, context: video)
Generating thumbs for My awesome video - 150
[video_preview] => video/0001/01/thumb_150_video_preview.jpg
[video_small] => video/0001/01/thumb_150_video_small.jpg
[video_large] => video/0001/01/thumb_150_video_large.jpg
[admin] => video/0001/01/thumb_150_admin.jpg

Generating thumbs for Another video - 152
[video_preview] => video/0001/01/thumb_152_video_preview.jpg
[video_small] => video/0001/01/thumb_152_video_small.jpg
[video_large] => video/0001/01/thumb_152_video_large.jpg
[admin] => video/0001/01/thumb_152_admin.jpg
...
```

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT