### PR TITLE
Mac OS X specific filesystem test fix

### DIFF
--- a/Tests/Filesystem/LocalTest.php
+++ b/Tests/Filesystem/LocalTest.php
@@ -19,6 +19,9 @@ class LocalTest extends \PHPUnit_Framework_TestCase
     {
         $local = new Local('/tmp');
 
-        $this->assertEquals('/tmp', $local->getDirectory());
+        // check if OS is Mac OS X where /tmp is a symlink to /private/tmp
+        $result = php_uname('s') == 'Darwin' ? '/private/tmp' : '/tmp';
+
+        $this->assertEquals($result, $local->getDirectory());
     }
 }


### PR DESCRIPTION
Fixes an annoying test failure due to /tmp being a symlink to /private/tmp on Mac Os X systems.