### PR TITLE
Allow resizer per format

### DIFF
--- a/DependencyInjection/Compiler/AddProviderCompilerPass.php
+++ b/DependencyInjection/Compiler/AddProviderCompilerPass.php
@@ -122,6 +122,7 @@ class AddProviderCompilerPass implements CompilerPassInterface
                     $config['format']       = isset($config['format'])  ? $config['format'] : 'jpg';
                     $config['height']       = isset($config['height'])  ? $config['height'] : false;
                     $config['constraint']   = isset($config['constraint'])  ? $config['constraint'] : true;
+                    $config['resizer']      = isset($config['resizer']) ? $config['resizer'] : false;
 
                     $formatName = sprintf('%s_%s', $name, $format);
                     $definition->addMethodCall('addFormat', array($formatName, $config));

--- a/DependencyInjection/Compiler/ThumbnailCompilerPass.php
+++ b/DependencyInjection/Compiler/ThumbnailCompilerPass.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class ThumbnailCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('sonata.media.thumbnail.format')) {
+            return;
+        }
+
+        $definition = $container->getDefinition(
+            'sonata.media.thumbnail.format'
+        );
+
+        $taggedServices = $container->findTaggedServiceIds(
+            'sonata.media.resizer'
+        );
+        foreach ($taggedServices as $id => $tags) {
+            $definition->addMethodCall(
+                'addResizer',
+                array($id, new Reference($id))
+            );
+        }
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -93,6 +93,7 @@ class Configuration implements ConfigurationInterface
                                         ->scalarNode('quality')->defaultValue(80)->end()
                                         ->scalarNode('format')->defaultValue('jpg')->end()
                                         ->scalarNode('constraint')->defaultValue(true)->end()
+                                        ->scalarNode('resizer')->defaultFalse()->end()
                                     ->end()
                                 ->end()
                             ->end()

--- a/Resources/config/media.xml
+++ b/Resources/config/media.xml
@@ -15,12 +15,14 @@
         <service id="sonata.media.adapter.image.gmagick" class="Imagine\Gmagick\Imagine" />
 
         <service id="sonata.media.resizer.simple" class="%sonata.media.resizer.simple.class%">
+            <tag name="sonata.media.resizer" />
             <argument type="service" id="sonata.media.adapter.image.gd" />
             <argument>%sonata.media.resizer.simple.adapter.mode%</argument>
             <argument type="service" id="sonata.media.metadata.proxy" />
         </service>
 
         <service id="sonata.media.resizer.square" class="%sonata.media.resizer.square.class%">
+            <tag name="sonata.media.resizer" />
             <argument type="service" id="sonata.media.adapter.image.gd" />
             <argument>%sonata.media.resizer.square.adapter.mode%</argument>
             <argument type="service" id="sonata.media.metadata.proxy" />

--- a/Resources/doc/reference/advanced_configuration.rst
+++ b/Resources/doc/reference/advanced_configuration.rst
@@ -28,7 +28,7 @@ Full configuration options:
 
                 formats:
                     small: { width: 100 , quality: 70}
-                    big:   { width: 500 , quality: 70}
+                    big:   { width: 500 , quality: 70, resizer: sonata.media.resizer.square }
 
             tv:
                 download:

--- a/Resources/doc/reference/media_context.rst
+++ b/Resources/doc/reference/media_context.rst
@@ -8,7 +8,10 @@ features: resize, cdn and database relationship with entities.
 The ``MediaBundle`` tries to solve this situation by introducing ``context``:
 a context has its own set of media providers and its own set of formats.
 That means you can have a ``small`` user picture format and a ``small`` news
-picture format with different sizes and providers. For example:
+picture format with different sizes and providers.
+
+Also each format allows to use a custom resizer instead of the default one
+configured in the provider. For example:
 
 .. code-block:: yaml
 
@@ -22,7 +25,7 @@ picture format with different sizes and providers. For example:
 
             formats:
                 small: { width: 100 , quality: 70}
-                big:   { width: 500 , quality: 70}
+                big:   { width: 500 , quality: 70, resizer: sonata.media.resizer.square }
 
         news:
             providers:
@@ -31,7 +34,7 @@ picture format with different sizes and providers. For example:
 
             formats:
                 small: { width: 150 , quality: 95}
-                big:   { width: 500 , quality: 90}
+                big:   { width: 500 , quality: 90, resizer: sonata.media.resizer.simple }
 
 ``AdminBundle`` Integration
 ---------------------------

--- a/SonataMediaBundle.php
+++ b/SonataMediaBundle.php
@@ -15,6 +15,7 @@ use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\MediaBundle\DependencyInjection\Compiler\AddProviderCompilerPass;
 use Sonata\MediaBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass;
 use Sonata\MediaBundle\DependencyInjection\Compiler\SecurityContextCompilerPass;
+use Sonata\MediaBundle\DependencyInjection\Compiler\ThumbnailCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -28,6 +29,7 @@ class SonataMediaBundle extends Bundle
         $container->addCompilerPass(new AddProviderCompilerPass());
         $container->addCompilerPass(new GlobalVariablesCompilerPass());
         $container->addCompilerPass(new SecurityContextCompilerPass());
+        $container->addCompilerPass(new ThumbnailCompilerPass());
 
         $this->registerFormMapping();
     }

--- a/Tests/Thumbnail/FormatThumbnailTest.php
+++ b/Tests/Thumbnail/FormatThumbnailTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sonata\MediaBundle\Tests\Security;
+namespace Sonata\MediaBundle\Tests\Thumbnail;
 
 use Gaufrette\Adapter\InMemory;
 use Gaufrette\File;
@@ -26,25 +26,31 @@ class FormatThumbnailTest extends \PHPUnit_Framework_TestCase
         $referenceFile = new File('myfile', $filesystem);
 
         $formats = array(
-           'admin'                => array('height' => 50, 'width' => 50, 'quality' => 100),
-           'mycontext_medium'     => array('height' => 500, 'width' => 500, 'quality' => 100),
-           'anothercontext_large' => array('height' => 500, 'width' => 500, 'quality' => 100),
+           'admin'                 => array('height' => 50, 'width' => 50, 'quality' => 100),
+           'mycontext_medium'      => array('height' => 500, 'width' => 500, 'quality' => 100),
+           'mycontext_large'       => array('height' => 500, 'width' => 500, 'quality' => 100, 'resizer' => 'some.other.resizer'),
+           'anothercontext_larger' => array('height' => 500, 'width' => 500, 'quality' => 100),
         );
 
         $resizer = $this->getMock('Sonata\MediaBundle\Resizer\ResizerInterface');
         $resizer->expects($this->exactly(2))->method('resize')->will($this->returnValue(true));
+
+        $customResizer = $this->getMock('Sonata\MediaBundle\Resizer\ResizerInterface');
+        $customResizer->expects($this->exactly(1))->method('resize')->will($this->returnValue(true));
 
         $provider = $this->getMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
         $provider->expects($this->once())->method('requireThumbnails')->will($this->returnValue(true));
         $provider->expects($this->once())->method('getReferenceFile')->will($this->returnValue($referenceFile));
         $provider->expects($this->once())->method('getFormats')->will($this->returnValue($formats));
         $provider->expects($this->exactly(2))->method('getResizer')->will($this->returnValue($resizer));
-        $provider->expects($this->exactly(2))->method('generatePrivateUrl')->will($this->returnValue('/my/private/path'));
-        $provider->expects($this->exactly(2))->method('getFilesystem')->will($this->returnValue($filesystem));
+        $provider->expects($this->exactly(3))->method('generatePrivateUrl')->will($this->returnValue('/my/private/path'));
+        $provider->expects($this->exactly(3))->method('getFilesystem')->will($this->returnValue($filesystem));
 
         $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
-        $media->expects($this->exactly(6))->method('getContext')->will($this->returnValue('mycontext'));
-        $media->expects($this->exactly(2))->method('getExtension')->will($this->returnValue('png'));
+        $media->expects($this->exactly(8))->method('getContext')->will($this->returnValue('mycontext'));
+        $media->expects($this->exactly(3))->method('getExtension')->will($this->returnValue('png'));
+
+        $thumbnail->addResizer('some.other.resizer', $customResizer);
 
         $thumbnail->generate($provider, $media);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #370 

This PR allows configuring a custom resizer per format, instead of the default resizer configured for the provider.