### PR TITLE
Delete assets on media removal

### DIFF
--- a/Model/Media.php
+++ b/Model/Media.php
@@ -143,6 +143,11 @@ abstract class Media implements MediaInterface
      */
     protected $category;
 
+    /**
+     * @var array
+     */
+    protected $assetPaths = array();
+
     public function prePersist()
     {
         $this->setCreatedAt(new \DateTime());
@@ -646,5 +651,21 @@ abstract class Media implements MediaInterface
     public function setCategory(CategoryInterface $category = null)
     {
         $this->category = $category;
+    }
+
+    /**
+     * @param array $paths
+     */
+    public function setAssetPaths($paths)
+    {
+        $this->assetPaths = $paths;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAssetPaths()
+    {
+        return $this->assetPaths;
     }
 }

--- a/Provider/BaseProvider.php
+++ b/Provider/BaseProvider.php
@@ -186,15 +186,14 @@ abstract class BaseProvider implements MediaProviderInterface
      */
     public function preRemove(MediaInterface $media)
     {
-        $path = $this->getReferenceImage($media);
-
-        if ($this->getFilesystem()->has($path)) {
-            $this->getFilesystem()->delete($path);
-        }
-
+        $assetPaths[] = $this->getReferenceImage($media);
         if ($this->requireThumbnails()) {
-            $this->thumbnail->delete($this, $media);
+            foreach ($this->getFormats() as $format => $definition) {
+                $assetPaths[] = $this->generatePrivateUrl($media, $format);
+            }
         }
+
+        $media->setAssetPaths($assetPaths);
     }
 
     /**
@@ -202,6 +201,11 @@ abstract class BaseProvider implements MediaProviderInterface
      */
     public function postRemove(MediaInterface $media)
     {
+        foreach ($media->getAssetPaths() as $path) {
+            if ($this->getFilesystem()->has($path)) {
+                $this->getFilesystem()->delete($path);
+            }
+        }
     }
 
     /**

--- a/Provider/BaseVideoProvider.php
+++ b/Provider/BaseVideoProvider.php
@@ -173,13 +173,6 @@ abstract class BaseVideoProvider extends BaseProvider
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function postRemove(MediaInterface $media)
-    {
-    }
-
-    /**
      * @throws \RuntimeException
      *
      * @param MediaInterface $media
@@ -227,5 +220,20 @@ abstract class BaseVideoProvider extends BaseProvider
         }
 
         return $this->resizer->getBox($media, $settings);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function preRemove(MediaInterface $media)
+    {
+        $assetPaths[] = $this->generatePrivateUrl($media, 'reference');
+        if ($this->requireThumbnails()) {
+            foreach ($this->getFormats() as $format => $definition) {
+                $assetPaths[] = $this->generatePrivateUrl($media, $format);
+            }
+        }
+
+        $media->setAssetPaths($assetPaths);
     }
 }

--- a/Tests/Provider/DailyMotionProviderTest.php
+++ b/Tests/Provider/DailyMotionProviderTest.php
@@ -98,6 +98,17 @@ class DailyMotionProviderTest extends \PHPUnit_Framework_TestCase
         $provider->generateThumbnails($media);
 
         $this->assertSame('default/0011/24/thumb_1023458_big.jpg', $provider->generatePrivateUrl($media, 'big'));
+
+        $provider->preRemove($media);
+        $this->assertSame(
+            array(
+                'default/0011/24/thumb_1023458_reference.jpg',
+                'default/0011/24/thumb_1023458_big.jpg',
+            ),
+            $media->getAssetPaths(),
+            'Media::getAssetPaths() return the correct paths to delete'
+        );
+        $provider->postRemove($media);
     }
 
     public function testTransformWithSig()

--- a/Tests/Provider/FileProviderTest.php
+++ b/Tests/Provider/FileProviderTest.php
@@ -61,6 +61,16 @@ class FileProviderTest extends \PHPUnit_Framework_TestCase
 
         // default icon image
         $this->assertSame('/uploads/media/sonatamedia/files/big/file.png', $provider->generatePublicUrl($media, 'big'));
+
+        $provider->preRemove($media);
+        $this->assertSame(
+            array(
+                'default/0011/24/ASDASD.txt',
+            ),
+            $media->getAssetPaths(),
+            'Media::getAssetPaths() return the correct paths to delete'
+        );
+        $provider->postRemove($media);
     }
 
     public function testHelperProperies()

--- a/Tests/Provider/ImageProviderTest.php
+++ b/Tests/Provider/ImageProviderTest.php
@@ -118,6 +118,17 @@ class ImageProviderTest extends \PHPUnit_Framework_TestCase
         $provider->generateThumbnails($media);
 
         $this->assertSame('default/0011/24/thumb_1023456_big.png', $provider->generatePrivateUrl($media, 'big'));
+
+        $provider->preRemove($media);
+        $this->assertSame(
+            array(
+                'default/0011/24/ASDASDAS.png',
+                'default/0011/24/thumb_1023456_big.png',
+            ),
+            $media->getAssetPaths(),
+            'Media::getAssetPaths() return the correct paths to delete'
+        );
+        $provider->postRemove($media);
     }
 
     public function testEvent()

--- a/Tests/Provider/VimeoProviderTest.php
+++ b/Tests/Provider/VimeoProviderTest.php
@@ -97,6 +97,17 @@ class VimeoProviderTest extends \PHPUnit_Framework_TestCase
         $provider->generateThumbnails($media);
 
         $this->assertSame('default/0011/24/thumb_1023457_big.jpg', $provider->generatePrivateUrl($media, 'big'));
+
+        $provider->preRemove($media);
+        $this->assertSame(
+            array(
+                'default/0011/24/thumb_1023457_reference.jpg',
+                'default/0011/24/thumb_1023457_big.jpg',
+            ),
+            $media->getAssetPaths(),
+            'Media::getAssetPaths() return the correct paths to delete'
+        );
+        $provider->postRemove($media);
     }
 
     public function testTransformWithSig()

--- a/Tests/Provider/YouTubeProviderTest.php
+++ b/Tests/Provider/YouTubeProviderTest.php
@@ -97,6 +97,17 @@ class YouTubeProviderTest extends \PHPUnit_Framework_TestCase
         $provider->generateThumbnails($media);
 
         $this->assertSame('default/0011/24/thumb_1023457_big.jpg', $provider->generatePrivateUrl($media, 'big'));
+
+        $provider->preRemove($media);
+        $this->assertSame(
+            array(
+                'default/0011/24/thumb_1023457_reference.jpg',
+                'default/0011/24/thumb_1023457_big.jpg',
+            ),
+            $media->getAssetPaths(),
+            'Media::getAssetPaths() return the correct paths to delete'
+        );
+        $provider->postRemove($media);
     }
 
     public function testTransformWithSig()


### PR DESCRIPTION
Another similar solution for #504.

Ensures all media files are deleted on media removal.

@rande Hope this gets merged, as at the moment both the reference and the thumbnails are left in place after media removal.