### PR TITLE
Prevent "undefined index: context" error for batch delete action

### DIFF
--- a/Admin/BaseMediaAdmin.php
+++ b/Admin/BaseMediaAdmin.php
@@ -114,7 +114,7 @@ abstract class BaseMediaAdmin extends Admin
             return $parameters;
         }
 
-        if ($filter = $this->getRequest()->get('filter')) {
+        if ($filter = $this->getRequest()->get('filter')  && array_key_exists('context', $this->getRequest()->get('filter'))) {
             $context = $filter['context']['value'];
         } else {
             $context   = $this->getRequest()->get('context', $this->pool->getDefaultContext());

--- a/Controller/MediaAdminController.php
+++ b/Controller/MediaAdminController.php
@@ -68,7 +68,7 @@ class MediaAdminController extends Controller
         $filters = $this->getRequest()->get('filter');
 
         // set the default context
-        if (!$filters) {
+        if (!$filters || !array_key_exists('context', $filters)) {
             $context = $this->admin->getPersistentParameter('context',  $this->get('sonata.media.pool')->getDefaultContext());
         } else {
             $context = $filters['context']['value'];


### PR DESCRIPTION
Check if key 'context' exists in filter to prevent "undefined index: context" error from appearing when deleting several media at a time in admin.