### PR TITLE
Removed not callable MediaProviderInterface::transform from test

### DIFF
--- a/Tests/Controller/Api/MediaControllerTest.php
+++ b/Tests/Controller/Api/MediaControllerTest.php
@@ -231,7 +231,6 @@ class MediaControllerTest extends \PHPUnit_Framework_TestCase
         $manager->expects($this->once())->method('findOneBy')->will($this->returnValue($media));
 
         $provider = $this->getMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
-        $provider->expects($this->once())->method('transform');
 
         $pool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
         $pool->expects($this->once())->method('getProvider')->will($this->returnValue($provider));


### PR DESCRIPTION
Removed not callable MediaProviderInterface::transform from test

fix for #722 **Bug in testPutMediumBinaryContentAction**