### PR TITLE
request the sonata classification root categories mapped by context name...

### DIFF
--- a/Listener/ORM/MediaEventSubscriber.php
+++ b/Listener/ORM/MediaEventSubscriber.php
@@ -75,7 +75,7 @@ class MediaEventSubscriber extends BaseMediaEventSubscriber
     protected function getRootCategory(MediaInterface $media)
     {
         if (!$this->rootCategories) {
-            $this->rootCategories = $this->container->get('sonata.classification.manager.category')->getRootCategories(false);
+            $this->rootCategories = $this->container->get('sonata.classification.manager.category')->getRootCategories(false, 'contextName');
         }
 
         if (!array_key_exists($media->getContext(), $this->rootCategories)) {


### PR DESCRIPTION
... instead of the default, that is id, as the context for each media item is set by name and this causes incompatibility between the two bundles.

this PR is tightly associated with the Rl of Sonata Classification Bundle https://github.com/sonata-project/SonataClassificationBundle/pull/98 as both bundles have to be amended to solve the issue