### PR TITLE
Sync thumbnails command optimization

### DIFF
--- a/Command/SyncThumbsCommand.php
+++ b/Command/SyncThumbsCommand.php
@@ -38,7 +38,7 @@ class SyncThumbsCommand extends BaseCommand
             ->setDefinition(array(
                 new InputArgument('providerName', InputArgument::OPTIONAL, 'The provider'),
                 new InputArgument('context', InputArgument::OPTIONAL, 'The context'),
-                new InputOption('batchSize', null, InputOption::VALUE_REQUIRED, 'Media batch size', 100)
+                new InputOption('batchSize', null, InputOption::VALUE_REQUIRED, 'Media batch size (100 by default)', 100)
             )
         );
     }

--- a/Command/SyncThumbsCommand.php
+++ b/Command/SyncThumbsCommand.php
@@ -13,6 +13,7 @@ namespace Sonata\MediaBundle\Command;
 
 use Symfony\Component\Console\Input\InputArgument;
 
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputInterface;
 
@@ -37,6 +38,7 @@ class SyncThumbsCommand extends BaseCommand
             ->setDefinition(array(
                 new InputArgument('providerName', InputArgument::OPTIONAL, 'The provider'),
                 new InputArgument('context', InputArgument::OPTIONAL, 'The context'),
+                new InputOption('batchSize', null, InputOption::VALUE_REQUIRED, 'Media batch size', 100)
             )
         );
     }
@@ -46,11 +48,11 @@ class SyncThumbsCommand extends BaseCommand
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $provider = $input->getArgument('providerName');
-        if (null === $provider) {
+        $providerName = $input->getArgument('providerName');
+        if (null === $providerName) {
             $providers = array_keys($this->getMediaPool()->getProviders());
             $providerKey = $this->getHelperSet()->get('dialog')->select($output, 'Please select the provider', $providers);
-            $provider = $providers[$providerKey];
+            $providerName = $providers[$providerKey];
         }
 
         $context  = $input->getArgument('context');
@@ -63,34 +65,68 @@ class SyncThumbsCommand extends BaseCommand
         $this->quiet = $input->getOption('quiet');
         $this->output = $output;
 
-        $medias = $this->getMediaManager()->findBy(array(
-            'providerName' => $provider,
-            'context'      => $context
-        ));
+        $provider = $this->getMediaPool()->getProvider($providerName);
 
-        $this->log(sprintf("Loaded %s medias for generating thumbs (provider: %s, context: %s)", count($medias), $provider, $context));
-
-        foreach ($medias as $media) {
-            $provider = $this->getMediaPool()->getProvider($media->getProviderName());
-
-            $this->log("Generating thumbs for " . $media->getName() . ' - ' . $media->getId());
-
+        $batchCounter = 0;
+        $batchSize = intval($input->getOption('batchSize'));
+        $totalMediasCount = 0;
+        do {
+            $batchCounter++;
             try {
-                $provider->removeThumbnails($media);
+                $medias = $this->getMediaManager()->findBy(
+                    array(
+                        'providerName' => $providerName,
+                        'context' => $context
+                    ),
+                    array(
+                        'id' => 'ASC'
+                    ),
+                    $batchSize,
+                    ($batchCounter - 1) * $batchSize
+                );
             } catch (\Exception $e) {
-                $this->log(sprintf("<error>Unable to remove old thumbnails, media: %s - %s </error>", $media->getId(), $e->getMessage()));
-                continue;
+                $this->log('Error: ' . $e->getMessage());
+                break;
             }
 
-            try {
-                $provider->generateThumbnails($media);
-            } catch (\Exception $e) {
-                $this->log(sprintf("<error>Unable to generated new thumbnails, media: %s - %s </error>", $media->getId(), $e->getMessage()));
-                continue;
+            $batchMediasCount = count($medias);
+            if ($batchMediasCount === 0) {
+                break;
             }
-        }
 
-        $this->log('Done.');
+            $totalMediasCount += $batchMediasCount;
+            $this->log(
+                sprintf(
+                    "Loaded %s medias (batch #%d) for generating thumbs (provider: %s, context: %s)",
+                    $batchMediasCount,
+                    $batchCounter,
+                    $providerName,
+                    $context
+                )
+            );
+
+            foreach ($medias as $media) {
+                $this->log("Generating thumbs for " . $media->getName() . ' - ' . $media->getId());
+
+                try {
+                    $provider->removeThumbnails($media);
+                } catch (\Exception $e) {
+                    $this->log(sprintf("<error>Unable to remove old thumbnails, media: %s - %s </error>",
+                        $media->getId(), $e->getMessage()));
+                    continue;
+                }
+
+                try {
+                    $provider->generateThumbnails($media);
+                } catch (\Exception $e) {
+                    $this->log(sprintf("<error>Unable to generated new thumbnails, media: %s - %s </error>",
+                        $media->getId(), $e->getMessage()));
+                    continue;
+                }
+            }
+        } while (true);
+
+        $this->log("Done (total medias processed: {$totalMediasCount}).");
     }
 
     /**

--- a/Command/SyncThumbsCommand.php
+++ b/Command/SyncThumbsCommand.php
@@ -156,7 +156,7 @@ class SyncThumbsCommand extends BaseCommand
         try {
             $provider->generateThumbnails($media);
         } catch (\Exception $e) {
-            $this->log(sprintf("<error>Unable to generated new thumbnails, media: %s - %s </error>",
+            $this->log(sprintf("<error>Unable to generate new thumbnails, media: %s - %s </error>",
                 $media->getId(), $e->getMessage()));
             return false;
         }


### PR DESCRIPTION
I encountered such problem - when trying to sync large amount of thumbnails (6000+) command gets aborted by memory limit, cause it fetches all medias at once in one batch. This PR introduces medias processing in batches (batch size can be changed via --batchSize option and equals to 100 by default). So now this command can process as many thumbnails, as we have.