### PR TITLE
Implement remove-thumbnails command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ A [BC BREAK] means the update will break the project for many reasons:
 * new dependencies
 * class refactoring
 
+### 2015-04-03
+
+* [BC BREAK] Add `formats` param to `removeThumbnails` method of `MediaProviderInterface`
+* [BC BREAK] Add `formats` param to `delete` method of `ThumbnailInterface`
+
 
 ### 2014-09-01
 

--- a/Command/RemoveThumbsCommand.php
+++ b/Command/RemoveThumbsCommand.php
@@ -1,0 +1,241 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+*
+* (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+namespace Sonata\MediaBundle\Command;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Sonata\MediaBundle\Provider\MediaProviderInterface;
+use Sonata\MediaBundle\Model\MediaInterface;
+
+/**
+ * This command can be used to re-generate the thumbnails for all uploaded medias.
+ *
+ * Useful if you have existing media content and added new formats.
+ *
+ */
+class RemoveThumbsCommand extends BaseCommand
+{
+    /**
+     * @var bool
+     */
+    protected $quiet = false;
+
+    /**
+     * @var InputInterface
+     */
+    protected $input;
+
+    /**
+     * @var OutputInterface
+     */
+    protected $output;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure()
+    {
+        $this->setName('sonata:media:remove-thumbnails')
+            ->setDescription('Remove uploaded image thumbs')
+            ->setDefinition(array(
+                new InputArgument('providerName', InputArgument::OPTIONAL, 'The provider'),
+                new InputArgument('context', InputArgument::OPTIONAL, 'The context'),
+                new InputArgument('format', InputArgument::OPTIONAL, 'The format (pass `all` to delete all thumbs)'),
+                new InputOption('batchSize', null, InputOption::VALUE_REQUIRED, 'Media batch size (100 by default)', 100),
+                new InputOption('batchesLimit', null, InputOption::VALUE_REQUIRED, 'Media batches limit (0 by default)', 0),
+                new InputOption('startOffset', null, InputOption::VALUE_REQUIRED, 'Medias start offset (0 by default)', 0)
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->input = $input;
+        $this->output = $output;
+
+        $this->quiet = $input->getOption('quiet');
+
+        $provider = $this->getProvider();
+        $context = $this->getContext();
+
+        $format = $this->getFormat($provider, $context);
+
+        $filesystem = $provider->getFilesystem();
+        $fsReflection = new \ReflectionClass($filesystem);
+        $fsRegister = $fsReflection->getProperty('fileRegister');
+        $fsRegister->setAccessible(true);
+
+        $batchCounter = 0;
+        $batchSize = intval($input->getOption('batchSize'));
+        $batchesLimit = intval($input->getOption('batchesLimit'));
+        $startOffset = intval($input->getOption('startOffset'));
+        $totalMediasCount = 0;
+        do {
+            $batchCounter++;
+            try {
+                $batchOffset = $startOffset + ($batchCounter - 1) * $batchSize;
+                $medias = $this->getMediaManager()->findBy(
+                    array(
+                        'providerName' => $provider->getName(),
+                        'context' => $context
+                    ),
+                    array(
+                        'id' => 'ASC'
+                    ),
+                    $batchSize,
+                    $batchOffset
+                );
+            } catch (\Exception $e) {
+                $this->log('Error: ' . $e->getMessage());
+                break;
+            }
+
+            $batchMediasCount = count($medias);
+            if ($batchMediasCount === 0) {
+                break;
+            }
+
+            $totalMediasCount += $batchMediasCount;
+            $this->log(
+                sprintf(
+                    "Loaded %s medias (batch #%d, offset %d) for removing thumbs (provider: %s, format: %s)",
+                    $batchMediasCount,
+                    $batchCounter,
+                    $batchOffset,
+                    $provider->getName(),
+                    $format
+                )
+            );
+
+            foreach ($medias as $media) {
+                if (!$this->processMedia($media, $provider, $context, $format)) {
+                    continue;
+                }
+                //clean filesystem registry for saving memory
+                $fsRegister->setValue($filesystem, array());
+            }
+
+            //clear entity manager for saving memory
+            $this->getMediaManager()->getEntityManager()->clear();
+
+            if ($batchesLimit > 0 && $batchCounter == $batchesLimit) {
+                break;
+            }
+        } while (true);
+
+        $this->log("Done (total medias processed: {$totalMediasCount}).");
+    }
+
+    /**
+     * @return MediaProviderInterface
+     */
+    public function getProvider()
+    {
+        $providerName = $this->input->getArgument('providerName');
+        if (null === $providerName) {
+            $providers = array_keys($this->getMediaPool()->getProviders());
+            $dialog = $this->getHelperSet()->get('dialog');
+            $providerKey = $dialog->select($this->output, 'Please select the provider', $providers);
+            $providerName = $providers[$providerKey];
+        }
+
+        return $this->getMediaPool()->getProvider($providerName);
+    }
+
+    /**
+     * @return string
+     */
+    public function getContext()
+    {
+        $context = $this->input->getArgument('context');
+        if (null === $context) {
+            $contexts = array_keys($this->getMediaPool()->getContexts());
+            $dialog = $this->getHelperSet()->get('dialog');
+            $contextKey = $dialog->select($this->output, 'Please select the context', $contexts);
+            $context = $contexts[$contextKey];
+        }
+
+        return $context;
+    }
+
+    /**
+     * @param MediaProviderInterface $provider
+     * @param string $context
+     *
+     * @return mixed|string
+     */
+    public function getFormat(MediaProviderInterface $provider, $context)
+    {
+        $format = $this->input->getArgument('format');
+        if (null === $format) {
+            $formats = array_keys($provider->getFormats());
+            $formats[] = '<ALL THUMBNAILS>';
+
+            $dialog = $this->getHelperSet()->get('dialog');
+            $formatKey = $dialog->select($this->output, 'Please select the format', $formats);
+            $format = $formats[$formatKey];
+            if ($format === '<ALL THUMBNAILS>') {
+                $format = $context . '_all';
+            }
+        } else {
+            $format = $context . '_' . $format;
+        }
+
+        return $format;
+    }
+
+    /**
+     * @param MediaInterface         $media
+     * @param MediaProviderInterface $provider
+     * @param string                 $context
+     * @param string                 $format
+     *
+     * @return bool
+     */
+    protected function processMedia(MediaInterface $media, MediaProviderInterface $provider, $context, $format)
+    {
+        $this->log("Deleting thumbs for " . $media->getName() . ' - ' . $media->getId());
+
+        try {
+            if ($format === $context . '_all') {
+                $format = null;
+            }
+
+            $provider->removeThumbnails($media, $format);
+        } catch (\Exception $e) {
+            $this->log(sprintf("<error>Unable to remove thumbnails, media: %s - %s </error>",
+                $media->getId(), $e->getMessage()));
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Write a message to the output
+     *
+     * @param string $message
+     *
+     * @return void
+     */
+    protected function log($message)
+    {
+        if (false === $this->quiet) {
+            $this->output->writeln($message);
+        }
+    }
+}

--- a/Provider/BaseProvider.php
+++ b/Provider/BaseProvider.php
@@ -109,9 +109,9 @@ abstract class BaseProvider implements MediaProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function removeThumbnails(MediaInterface $media)
+    public function removeThumbnails(MediaInterface $media, $formats = null)
     {
-        $this->thumbnail->delete($this, $media);
+        $this->thumbnail->delete($this, $media, $formats);
     }
 
     /**

--- a/Provider/MediaProviderInterface.php
+++ b/Provider/MediaProviderInterface.php
@@ -54,13 +54,14 @@ interface MediaProviderInterface
     public function generateThumbnails(MediaInterface $media);
 
     /**
-     * remove all linked thumbnails
+     * remove linked thumbnails
      *
      * @param MediaInterface $media
+     * @param string|array $formats
      *
      * @return void
      */
-    public function removeThumbnails(MediaInterface $media);
+    public function removeThumbnails(MediaInterface $media, $formats = null);
 
     /**
      * @param MediaInterface $media

--- a/Resources/doc/reference/command_line.rst
+++ b/Resources/doc/reference/command_line.rst
@@ -4,18 +4,31 @@ Command Line Tools
 Media commands
 --------------
 
-Synchronize
-^^^^^^^^^^^
+Synchronize thumbnails
+^^^^^^^^^^^^^^^^^^^^^^
 
-Synchronize thumbnail for the provider ``sonata.media.provider.image`` with the ``default`` context.
+Synchronize thumbnails for the provider ``sonata.media.provider.image`` in the ``default`` context.
 
 .. note::
 
-   There is also an interactive shell for the parameter.
+   There is also an interactive shell for parameters.
 
 .. code-block:: bash
 
    php app/console sonata:media:sync-thumbnails sonata.media.provider.image default
+
+Remove thumbnails
+^^^^^^^^^^^^^^^^^
+
+Remove thumbnails for the provider ``sonata.media.provider.image`` in the ``default`` context and ``small`` format.
+
+.. note::
+
+   There is also an interactive shell for parameters.
+
+.. code-block:: bash
+
+   php app/console sonata:media:remove-thumbnails sonata.media.provider.image default small
 
 Update metadata
 ^^^^^^^^^^^^^^^
@@ -24,7 +37,7 @@ Update metadata for a set of media for the provider ``sonata.media.provider.yout
 
 .. note::
 
-   There is also an interactive shell for the parameter.
+   There is also an interactive shell for parameters.
 
 .. code-block:: bash
 

--- a/Thumbnail/ConsumerThumbnail.php
+++ b/Thumbnail/ConsumerThumbnail.php
@@ -69,8 +69,8 @@ class ConsumerThumbnail implements ThumbnailInterface
     /**
      * {@inheritdoc}
      */
-    public function delete(MediaProviderInterface $provider, MediaInterface $media)
+    public function delete(MediaProviderInterface $provider, MediaInterface $media, $formats = null)
     {
-        return $this->thumbnail->delete($provider, $media);
+        return $this->thumbnail->delete($provider, $media, $formats);
     }
 }

--- a/Thumbnail/FormatThumbnail.php
+++ b/Thumbnail/FormatThumbnail.php
@@ -84,10 +84,19 @@ class FormatThumbnail implements ThumbnailInterface
     /**
      * {@inheritdoc}
      */
-    public function delete(MediaProviderInterface $provider, MediaInterface $media)
+    public function delete(MediaProviderInterface $provider, MediaInterface $media, $formats = null)
     {
-        // delete the differents formats
-        foreach ($provider->getFormats() as $format => $definition) {
+        if (is_null($formats)) {
+            $formats = array_keys($provider->getFormats());
+        } elseif (is_string($formats)) {
+            $formats = array($formats);
+        }
+
+        if (!is_array($formats)) {
+            throw new \InvalidArgumentException('"Formats" argument should be string or array');
+        }
+
+        foreach ($formats as $format) {
             $path = $provider->generatePrivateUrl($media, $format);
             if ($path && $provider->getFilesystem()->has($path)) {
                 $provider->getFilesystem()->delete($path);

--- a/Thumbnail/LiipImagineThumbnail.php
+++ b/Thumbnail/LiipImagineThumbnail.php
@@ -73,7 +73,7 @@ class LiipImagineThumbnail implements ThumbnailInterface
     /**
      * {@inheritdoc}
      */
-    public function delete(MediaProviderInterface $provider, MediaInterface $media)
+    public function delete(MediaProviderInterface $provider, MediaInterface $media, $formats = null)
     {
         // feature not available
         return;

--- a/Thumbnail/ThumbnailInterface.php
+++ b/Thumbnail/ThumbnailInterface.php
@@ -39,6 +39,7 @@ interface ThumbnailInterface
     /**
      * @param \Sonata\MediaBundle\Provider\MediaProviderInterface $provider
      * @param \Sonata\MediaBundle\Model\MediaInterface            $media
+     * @param string|array                                        $formats
      */
-    public function delete(MediaProviderInterface $provider, MediaInterface $media);
+    public function delete(MediaProviderInterface $provider, MediaInterface $media, $formats = null);
 }


### PR DESCRIPTION
With this command we can remove thumbnails of specified format or even all thumbnails.
This one will remove all thumbs of `small` format from `default` context:
```bash
app/console sonata:media:remove-thumbnails sonata.media.provider.image default small
```
This one will remove all thumbs from `default` context:
```bash
app/console sonata:media:remove-thumbnails sonata.media.provider.image default all
```
Also, command gives ability to choose provider, context and format, if any of them are not specifed in command line.