### PR TITLE
fixed aws cache-control metadata

### DIFF
--- a/Metadata/AmazonMetadataBuilder.php
+++ b/Metadata/AmazonMetadataBuilder.php
@@ -69,7 +69,7 @@ class AmazonMetadataBuilder implements MetadataBuilderInterface
 
         //merge cache control header
         if (isset($this->settings['cache_control']) && !empty($this->settings['cache_control'])) {
-            $output['headers']['Cache-Control'] = $this->settings['cache_control'];
+            $output['CacheControl'] = $this->settings['cache_control'];
         }
 
         //merge encryption

--- a/Tests/Metadata/AmazonMetadataBuilderTest.php
+++ b/Tests/Metadata/AmazonMetadataBuilderTest.php
@@ -50,10 +50,10 @@ class AmazonMetadataBuilderTest extends \PHPUnit_Framework_TestCase
             array(array('acl' => 'owner_full_control'), array('ACL' => CannedAcl::BUCKET_OWNER_FULL_CONTROL, 'contentType' => 'image/png')),
             array(array('storage' => 'standard'), array('storage' => Storage::STANDARD, 'contentType' => 'image/png')),
             array(array('storage' => 'reduced'), array('storage' => Storage::REDUCED, 'contentType' => 'image/png')),
-            array(array('cache_control' => 'max-age=86400'), array('headers' => array('Cache-Control' => 'max-age=86400'), 'contentType' => 'image/png')),
+            array(array('cache_control' => 'max-age=86400'), array('CacheControl' => 'max-age=86400', 'contentType' => 'image/png')),
             array(array('encryption' => 'aes256'), array('encryption' => 'AES256', 'contentType' => 'image/png')),
             array(array('meta' => array('key' => 'value')), array('meta' => array('key' => 'value'), 'contentType' => 'image/png')),
-            array(array('acl' => 'public', 'storage' => 'standard', 'cache_control' => 'max-age=86400', 'encryption' => 'aes256', 'meta' => array('key' => 'value')), array('ACL' => CannedAcl::PUBLIC_READ, 'contentType' => 'image/png', 'storage' => Storage::STANDARD, 'headers' => array('Cache-Control' => 'max-age=86400'), 'encryption' => 'AES256', 'meta' => array('key' => 'value')))
+            array(array('acl' => 'public', 'storage' => 'standard', 'cache_control' => 'max-age=86400', 'encryption' => 'aes256', 'meta' => array('key' => 'value')), array('ACL' => CannedAcl::PUBLIC_READ, 'contentType' => 'image/png', 'storage' => Storage::STANDARD, 'CacheControl' => 'max-age=86400', 'encryption' => 'AES256', 'meta' => array('key' => 'value')))
         );
     }
 }


### PR DESCRIPTION
S3Client does accept CacheControl as option instead of headers - Cache-Control.

before:
![image](https://cloud.githubusercontent.com/assets/241080/7007160/712993b4-dc87-11e4-9520-4660db3f1985.png)

after:
![image](https://cloud.githubusercontent.com/assets/241080/7007155/64fc3e8e-dc87-11e4-9bda-dab066b3fa23.png)
