### PR TITLE
Make REST Bundle optional

### DIFF
--- a/DependencyInjection/SonataMediaExtension.php
+++ b/DependencyInjection/SonataMediaExtension.php
@@ -55,12 +55,14 @@ class SonataMediaExtension extends Extension
             throw new \InvalidArgumentException(sprintf('SonataMediaBundle - Invalid db driver "%s".', $config['db_driver']));
         }
 
-        $loader->load(sprintf('api_form_%s.xml', $config['db_driver']));
-
         $bundles = $container->getParameter('kernel.bundles');
 
-        if ('doctrine_orm' == $config['db_driver'] && isset($bundles['FOSRestBundle']) && isset($bundles['NelmioApiDocBundle'])) {
-            $loader->load('api_controllers.xml');
+        if (isset($bundles['FOSRestBundle']) && isset($bundles['NelmioApiDocBundle'])) {
+            $loader->load(sprintf('api_form_%s.xml', $config['db_driver']));
+
+            if ('doctrine_orm' == $config['db_driver']) {
+                $loader->load('api_controllers.xml');
+            }
         }
 
         if (isset($bundles['SonataNotificationBundle'])) {

--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,7 @@
         "knplabs/gaufrette": "^0.1.6",
         "imagine/imagine": "~0.3",
         "kriswallsmith/buzz": "~0.6",
-        "friendsofsymfony/rest-bundle": "~1.1",
         "jms/serializer-bundle": "~0.11|~1.0",
-        "nelmio/api-doc-bundle": "~2.4",
         "sonata-project/intl-bundle": "~2.2"
     },
     "require-dev": {
@@ -40,7 +38,9 @@
         "aws/aws-sdk-php": "~2.7",
         "doctrine/mongodb-odm": "~1.0",
         "jackalope/jackalope-doctrine-dbal": "~1.1",
-        "symfony/phpunit-bridge": "~2.7|~3.0"
+        "symfony/phpunit-bridge": "~2.7|~3.0",
+        "friendsofsymfony/rest-bundle": "~1.1",
+        "nelmio/api-doc-bundle": "~2.4"
     },
     "suggest": {
         "sonata-project/doctrine-orm-admin-bundle": "~2.3",


### PR DESCRIPTION
As the REST bundle is not required for the this bundle, the api form and controllers definitions should only be loaded, when the bundles are used.