### PR TITLE
publish job on kernel.finish_request

### DIFF
--- a/Resources/config/consumer.xml
+++ b/Resources/config/consumer.xml
@@ -17,6 +17,7 @@
             <argument>sonata.media.thumbnail.format</argument>
             <argument type="service" id="sonata.media.thumbnail.format"/>
             <argument type="service" id="sonata.notification.backend" />
+            <argument type="service" id="event_dispatcher" />
         </service>
     </services>
 </container>

--- a/Thumbnail/ConsumerThumbnail.php
+++ b/Thumbnail/ConsumerThumbnail.php
@@ -14,6 +14,7 @@ namespace Sonata\MediaBundle\Thumbnail;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\NotificationBundle\Backend\BackendInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ConsumerThumbnail implements ThumbnailInterface
 {
@@ -33,15 +34,22 @@ class ConsumerThumbnail implements ThumbnailInterface
     protected $backend;
 
     /**
-     * @param string             $id
-     * @param ThumbnailInterface $thumbnail
-     * @param BackendInterface   $backend
+     * @var EventDispatcherInterface
      */
-    public function __construct($id, ThumbnailInterface $thumbnail, BackendInterface $backend)
+    protected $dispatcher;
+
+    /**
+     * @param string                   $id
+     * @param ThumbnailInterface       $thumbnail
+     * @param BackendInterface         $backend
+     * @param EventDispatcherInterface $dispatcher
+     */
+    public function __construct($id, ThumbnailInterface $thumbnail, BackendInterface $backend, EventDispatcherInterface $dispatcher = null)
     {
-        $this->id        = $id;
-        $this->thumbnail = $thumbnail;
-        $this->backend   = $backend;
+        $this->id           = $id;
+        $this->thumbnail    = $thumbnail;
+        $this->backend      = $backend;
+        $this->dispatcher   = $dispatcher;
     }
 
     /**
@@ -65,14 +73,27 @@ class ConsumerThumbnail implements ThumbnailInterface
      */
     public function generate(MediaProviderInterface $provider, MediaInterface $media)
     {
-        $this->backend->createAndPublish('sonata.media.create_thumbnail', array(
-            'thumbnailId'       => $this->id,
-            'mediaId'           => $media->getId(),
+        $backend = $this->backend;
+        $id      = $this->id;
 
-            // force this value as the message is sent inside a transaction,
-            // so we have a race condition
-            'providerReference' => $media->getProviderReference(),
-        ));
+        $publish = function () use ($backend, $media, $id) {
+            $backend->createAndPublish('sonata.media.create_thumbnail', array(
+                'thumbnailId'       => $id,
+                'mediaId'           => $media->getId(),
+
+                // force this value as the message is sent inside a transaction,
+                // so we have a race condition
+                'providerReference' => $media->getProviderReference(),
+            ));
+        };
+
+        // BC compatibility for missing EventDispatcher
+        if (null === $this->dispatcher) {
+            trigger_error('Since version 2.3.3, passing an empty parameter in argument 4 for __construct() in '.__CLASS__.' is deprecated and the workaround for it will be removed in 3.0.', E_USER_DEPRECATED);
+            $publish();
+        } else {
+            $this->dispatcher->addListener('kernel.finish_request', $publish);
+        }
     }
 
     /**


### PR DESCRIPTION
when using rabbitmq, there is a race condition because of the database transaction. In our case the worker was too fast and the database entry didn't exist at the time the consumer was processed.
Our solution was to use the event dispatcher and publish the job just at the end of the request (``kernel.finish_request``). This even works if used with sonata-notification-bundle strategy postpone which uses the kernel.terminate event. 