### PR TITLE
fix youtube thubmbnail url witout https

### DIFF
--- a/Provider/YouTubeProvider.php
+++ b/Provider/YouTubeProvider.php
@@ -54,6 +54,14 @@ class YouTubeProvider extends BaseVideoProvider
     /**
      * {@inheritdoc}
      */
+    public function getReferenceImage(MediaInterface $media)
+    {
+        return sprintf('http://i.ytimg.com/vi/%s/hqdefault.jpg', $media->getProviderReference());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getHelperProperties(MediaInterface $media, $format, $options = array())
     {
 


### PR DESCRIPTION
override the https thubmbnail url rendred by youtube api. 

file_get_contents used by buzz connector don't allow https see https://github.com/kriswallsmith/Buzz/issues/67