### PR TITLE
Updated Media::getExtension()

### DIFF
--- a/Model/Media.php
+++ b/Model/Media.php
@@ -522,7 +522,8 @@ abstract class Media implements MediaInterface
      */
     public function getExtension()
     {
-        return pathinfo($this->getProviderReference(), PATHINFO_EXTENSION);
+        // strips off query strings or hashes, which are common in URIs remote references
+        return preg_replace('{(\?|#).*}', '', pathinfo($this->getProviderReference(), PATHINFO_EXTENSION));
     }
 
     /**

--- a/Tests/Entity/MediaTest.php
+++ b/Tests/Entity/MediaTest.php
@@ -64,4 +64,18 @@ class MediaTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($media->getMetadataValue('foo'));
     }
+
+    public function testGetMediaFileExtension()
+    {
+        $media = new Media();
+
+        $media->setProviderReference('https://sonata-project.org/bundles/sonatageneral/images/logo-small.png?some-query-string=1');
+        $this->assertSame('png', $media->getExtension(), 'extension should not contain query strings');
+
+        $media->setProviderReference('https://sonata-project.org/bundles/sonatageneral/images/logo-small.png#some-hash');
+        $this->assertSame('png', $media->getExtension(), 'extension should not contain hashes');
+
+        $media->setProviderReference('https://sonata-project.org/bundles/sonatageneral/images/logo-small.png?some-query-string=1#with-some-hash');
+        $this->assertSame('png', $media->getExtension(), 'extension should not contain query strings or hashes');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Updated ```Media::getExtension()``` in order to strip off query strings and hashes
from remote filenames.

Before:
```php
$media->setProviderReference('https://sonata-project.org/bundles/sonatageneral/images/logo-small.png?some-query-string=1#with-some-hash');
$media->getExtension(); // returns "png?some-query-string=1#with-some-hash"
```

After:
```php
$media->setProviderReference('https://sonata-project.org/bundles/sonatageneral/images/logo-small.png?some-query-string=1#with-some-hash');
$media->getExtension(); // returns "png"
```