### PR TITLE
[Thumbnail] Fix thumbnail URL for reference format

### DIFF
--- a/Tests/Provider/ImageProviderTest.php
+++ b/Tests/Provider/ImageProviderTest.php
@@ -69,6 +69,9 @@ class ImageProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('default/0011/24', $provider->generatePath($media));
         $this->assertEquals('/uploads/media/default/0011/24/thumb_1023456_big.png', $provider->generatePublicUrl($media, 'big'));
         $this->assertEquals('/uploads/media/default/0011/24/ASDASDAS.png', $provider->generatePublicUrl($media, 'reference'));
+
+        $this->assertEquals('default/0011/24/ASDASDAS.png', $provider->generatePrivateUrl($media, 'reference'));
+        $this->assertEquals('default/0011/24/thumb_1023456_big.png', $provider->generatePrivateUrl($media, 'big'));
     }
 
     public function testHelperProperies()

--- a/Thumbnail/FormatThumbnail.php
+++ b/Thumbnail/FormatThumbnail.php
@@ -45,7 +45,12 @@ class FormatThumbnail implements ThumbnailInterface
      */
     public function generatePrivateUrl(MediaProviderInterface $provider, MediaInterface $media, $format)
     {
-        return sprintf('%s/thumb_%s_%s.%s',
+        if ('reference' === $format) {
+            return $provider->getReferenceImage($media);
+        }
+
+        return sprintf(
+            '%s/thumb_%s_%s.%s',
             $provider->generatePath($media),
             $media->getId(),
             $format,


### PR DESCRIPTION
Fixes a bug in [Sonata\MediaBundle\Thumbnail\FormatThumbnail](https://github.com/sonata-project/SonataMediaBundle/blob/master/Thumbnail/FormatThumbnail.php) that causes an incorrect file name to be returned when "reference" format is requested. This fix is a follow-up to #232 and #277. #277 fixed the issue in FileProvider but left a similar bug in ImageProvider. Credit should go to @tiagojsag for bringing up the original problem and for suggesting a similar fix.

The source of the problem is in [Sonata\MediaBundle\Thumbnail\FormatThumbnail::generatePrivateUrl()](https://github.com/sonata-project/SonataMediaBundle/blob/master/Thumbnail/FormatThumbnail.php#L46), which does not take the format into account when generating a thumbnail URL (see discussion below -- thanks to @phansys for suggesting the move). Because of this, requesting the "reference" format results in an incorrectly named thumbnail. This then causes a `NotFoundHttpException` to be thrown. This bug also prevents an image from being downloaded using X-Sendfile and X-Accel-Redirect as the incorrectly named image cannot be found.

**Note:** The fix I've applied to `Sonata\MediaBundle\Thumbnail\FormatThumbnail::generatePrivateUrl()` results in the function being functionally identical to `Sonata\MediaBundle\Thumbnail\FormatThumbnail::generatePublicUrl()`. The results of these functions are manipulated differently in ImageProvider but they otherwise behave exactly the same. I implemented it this way to prevent `generatePrivateUrl()` from relying on `generatePublicUrl()`. This can be easily changed and I'm willing to make that change if desired.

(Revamped description and title to match the most recent version of the pull request. Unfortunately, I'm unable to change the branch name due to GitHub restrictions.)