### PR TITLE
Added missing deprecation warnings in MediaManager::save() methods

### DIFF
--- a/Document/MediaManager.php
+++ b/Document/MediaManager.php
@@ -22,11 +22,13 @@ class MediaManager extends BaseDocumentManager
     {
         // BC compatibility for $context parameter
         if ($andFlush && is_string($andFlush)) {
+            @trigger_error(sprintf('Since version 2.2.7, passing context in argument 2 for %s() is deprecated and support for it will be removed in 3.0. Use %s::setContext() instead.', __METHOD__, $this->class), E_USER_DEPRECATED);
             $entity->setContext($andFlush);
         }
 
         // BC compatibility for $providerName parameter
         if (3 == func_num_args()) {
+            @trigger_error(sprintf('Since version 2.2.7, passing provider name in argument 3 for %s() is deprecated and support for it will be removed in 3.0. Use %s::setProviderName() instead.', __METHOD__, $this->class), E_USER_DEPRECATED);
             $entity->setProviderName(func_get_arg(2));
         }
 

--- a/Entity/MediaManager.php
+++ b/Entity/MediaManager.php
@@ -29,11 +29,13 @@ class MediaManager extends BaseEntityManager implements MediaManagerInterface
 
         // BC compatibility for $context parameter
         if ($andFlush && is_string($andFlush)) {
+            @trigger_error(sprintf('Since version 2.2.7, passing context in argument 2 for %s() is deprecated and support for it will be removed in 3.0. Use %s::setContext() instead.', __METHOD__, $this->class), E_USER_DEPRECATED);
             $media->setContext($andFlush);
         }
 
         // BC compatibility for $providerName parameter
         if (3 == func_num_args()) {
+            @trigger_error(sprintf('Since version 2.2.7, passing provider name in argument 3 for %s() is deprecated and support for it will be removed in 3.0. Use %s::setProviderName() instead.', __METHOD__, $this->class), E_USER_DEPRECATED);
             $media->setProviderName(func_get_arg(2));
         }
 

--- a/PHPCR/MediaManager.php
+++ b/PHPCR/MediaManager.php
@@ -22,11 +22,13 @@ class MediaManager extends BasePHPCRManager
     {
         // BC compatibility for $context parameter
         if ($andFlush && is_string($andFlush)) {
+            @trigger_error(sprintf('Since version 2.2.7, passing context in argument 2 for %s() is deprecated and support for it will be removed in 3.0. Use %s::setContext() instead.', __METHOD__, $this->class), E_USER_DEPRECATED);
             $entity->setContext($andFlush);
         }
 
         // BC compatibility for $providerName parameter
         if (3 == func_num_args()) {
+            @trigger_error(sprintf('Since version 2.2.7, passing provider name in argument 3 for %s() is deprecated and support for it will be removed in 3.0. Use %s::setProviderName() instead.', __METHOD__, $this->class), E_USER_DEPRECATED);
             $entity->setProviderName(func_get_arg(2));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Added missing deprecation warnings in ```MediaManager::save()``` methods. When called with deprecated signature, it emits the following messages:

**Passing context in 2nd argument:**
```
Since version 2.2.7, passing context in argument 2 for Sonata\MediaBundle\Entity\MediaManager::save() is deprecated and support for it will be removed in 3.0. Use AppBundle\Entity\Media::setContext() instead.
```

**Passing provider name in 3rd argument:**
```
Since version 2.2.7, passing provider name in argument 3 for Sonata\MediaBundle\Entity\MediaManager::save() is deprecated and support for it will be removed in 3.0. Use AppBundle\Entity\Media::setProviderName() instead.
```