### PR TITLE
Fixed andFlush parameter in MediaManager never being used

### DIFF
--- a/Document/MediaManager.php
+++ b/Document/MediaManager.php
@@ -30,7 +30,7 @@ class MediaManager extends BaseDocumentManager
             $entity->setProviderName(func_get_arg(2));
         }
 
-        if ($andFlush && is_bool($andFlush)) {
+        if (is_bool($andFlush)) {
             parent::save($entity, $andFlush);
         } else {
             // BC compatibility with previous signature

--- a/Entity/MediaManager.php
+++ b/Entity/MediaManager.php
@@ -37,7 +37,7 @@ class MediaManager extends BaseEntityManager implements MediaManagerInterface
             $media->setProviderName(func_get_arg(2));
         }
 
-        if ($andFlush && is_bool($andFlush)) {
+        if (is_bool($andFlush)) {
             parent::save($media, $andFlush);
         } else {
             // BC compatibility with previous signature

--- a/PHPCR/MediaManager.php
+++ b/PHPCR/MediaManager.php
@@ -30,7 +30,7 @@ class MediaManager extends BasePHPCRManager
             $entity->setProviderName(func_get_arg(2));
         }
 
-        if ($andFlush && is_bool($andFlush)) {
+        if (is_bool($andFlush)) {
             parent::save($entity, $andFlush);
         } else {
             // BC compatibility with previous signature

--- a/Tests/Document/MediaManagerTest.php
+++ b/Tests/Document/MediaManagerTest.php
@@ -28,6 +28,15 @@ class MediaManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($media->getProviderName());
     }
 
+    public function testSaveFlushesProperlyUsingNewInterface()
+    {
+        $this->manager->getObjectManager()->expects($this->once())->method('flush');
+        $this->manager->save(new Media());
+
+        $this->manager->getObjectManager()->expects($this->never())->method('flush');
+        $this->manager->save(new Media(), false);
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      */

--- a/Tests/Entity/MediaManagerTest.php
+++ b/Tests/Entity/MediaManagerTest.php
@@ -13,6 +13,7 @@ namespace Sonata\MediaBundle\Test\Entity;
 
 use Sonata\CoreBundle\Test\EntityManagerMockFactory;
 use Sonata\MediaBundle\Entity\MediaManager;
+use Sonata\MediaBundle\Tests\Entity\Media;
 
 /**
  * Class MediaManagerTest.
@@ -103,5 +104,18 @@ class MediaManagerTest extends \PHPUnit_Framework_TestCase
                 $qb->expects($self->once())->method('setParameters')->with($self->equalTo(array('enabled' => false)));
             })
             ->getPager(array('enabled' => false), 1);
+    }
+
+    public function testSaveFlushesProperlyUsingNewInterface()
+    {
+        $manager = $this->getMediaManager(function () {
+        });
+        $manager->getEntityManager()->expects($this->once())->method('flush');
+        $manager->save(new Media());
+
+        $manager = $this->getMediaManager(function () {
+        });
+        $manager->getEntityManager()->expects($this->never())->method('flush');
+        $manager->save(new Media(), false);
     }
 }

--- a/Tests/PHPCR/MediaManagerTest.php
+++ b/Tests/PHPCR/MediaManagerTest.php
@@ -28,6 +28,15 @@ class MediaManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($media->getProviderName());
     }
 
+    public function testSaveFlushesProperlyUsingNewInterface()
+    {
+        $this->manager->getObjectManager()->expects($this->once())->method('flush');
+        $this->manager->save(new Media());
+
+        $this->manager->getObjectManager()->expects($this->never())->method('flush');
+        $this->manager->save(new Media(), false);
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      */


### PR DESCRIPTION
Rebased changes of  PR #537 
Added tests compared to PR #796