### PR TITLE
Sonata\AdminBundle\Validator\ErrorElement do not exist

### DIFF
--- a/Block/GalleryBlockService.php
+++ b/Block/GalleryBlockService.php
@@ -11,7 +11,7 @@
 namespace Sonata\MediaBundle\Block;
 
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\AdminBundle\Validator\ErrorElement;
+use Sonata\CoreBundle\Validator\ErrorElement;
 
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;


### PR DESCRIPTION
I think this should be correct. Or just remove the validateBlock function...