### PR TITLE
[Doc] [Security] Added note about required Admin for "sonata_media_download" route

### DIFF
--- a/Resources/doc/reference/security.rst
+++ b/Resources/doc/reference/security.rst
@@ -56,6 +56,10 @@ The related download route name is ``sonata_media_download``.
 
     <a href="{{ path('sonata_media_download', {'id': media|sonata_urlsafeid }) }}">Download file</a>
 
+.. note::
+
+    You must have an admin registered for the media object in order to work with this route.
+
 Creating your own Security Download Strategy
 --------------------------------------------
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Added note about required Admin for ```sonata_mediadownload``` route.