### PR TITLE
[MediaType] Made form options "provider" and "context" required

### DIFF
--- a/Form/Type/MediaType.php
+++ b/Form/Type/MediaType.php
@@ -89,13 +89,18 @@ class MediaType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
-            'data_class'    => $this->class,
-            'provider'      => null,
-            'context'       => null,
-            'empty_on_new'  => true,
-            'new_on_update' => true,
-        ));
+        $resolver
+            ->setDefaults(array(
+                'data_class'    => $this->class,
+                'empty_on_new'  => true,
+                'new_on_update' => true,
+            ))
+            ->setRequired(array('provider', 'context'))
+            ->setAllowedTypes(array(
+                'provider' => 'string',
+                'context' => 'string',
+            ))
+        ;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Given the following example:
```php
$builder->add('media', 'sonata_media_type');
```
**Before:**
```
unable to retrieve the provider named : ``
```
**After:**
```
The required option "provider" is missing.
```