### PR TITLE
[2.3] [MediaType] Made form options "provider" and "context" required

### DIFF
--- a/Form/Type/MediaType.php
+++ b/Form/Type/MediaType.php
@@ -18,6 +18,7 @@ use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 use Sonata\MediaBundle\Provider\Pool;
@@ -80,13 +81,31 @@ class MediaType extends AbstractType
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        $resolver->setDefaults(array(
-            'data_class'    => $this->class,
-            'provider'      => null,
-            'context'       => null,
-            'empty_on_new'  => true,
-            'new_on_update' => true,
-        ));
+        $resolver
+            ->setDefaults(array(
+                'data_class'    => $this->class,
+                'empty_on_new'  => true,
+                'new_on_update' => true,
+            ))
+            ->setRequired(array('provider', 'context'))
+            ->setAllowedTypes(array(
+                'provider' => 'string',
+                'context'  => 'string',
+            ))
+        ;
+
+        // Use proper syntax based on Symfony version
+        if (version_compare(Kernel::VERSION, '2.6.0') >= 0) {
+            $resolver
+                ->setAllowedValues('provider', $this->pool->getProviderList())
+                ->setAllowedValues('context', array_keys($this->pool->getContexts()))
+            ;
+        } else {
+            $resolver->setAllowedValues(array(
+                array('provider' => $this->pool->getProviderList()),
+                array('context' => array_keys($this->pool->getContexts())),
+            ));
+        }
     }
 
     /**

--- a/Tests/Form/Type/MediaTypeTest.php
+++ b/Tests/Form/Type/MediaTypeTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\Form\Type;
+
+use Sonata\MediaBundle\Form\Type\MediaType;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+/**
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+class MediaTypeTest extends TypeTestCase
+{
+    /**
+     * @expectedException        \Symfony\Component\OptionsResolver\Exception\MissingOptionsException
+     * @expectedExceptionMessage The required options "context", "provider" are missing.
+     */
+    public function testMissingFormOptions()
+    {
+        $mediaPool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
+        $mediaPool->expects($this->any())->method('getProviderList')->will($this->returnValue(array(
+            'provider_a' => 'provider_a',
+            'provider_b' => 'provider_b',
+        )));
+        $mediaPool->expects($this->any())->method('getContexts')->will($this->returnValue(array(
+            'video' => array(),
+            'pic' => array(),
+        )));
+        $type = new MediaType($mediaPool, 'testClass');
+        $this->factory->create($type);
+    }
+
+    /**
+     * @expectedException        \Symfony\Component\OptionsResolver\Exception\MissingOptionsException
+     * @expectedExceptionMessage The required option "context" is missing.
+     */
+    public function testMissingFormContextOption()
+    {
+        $mediaPool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
+        $mediaPool->expects($this->any())->method('getProviderList')->will($this->returnValue(array(
+            'provider_a' => 'provider_a',
+            'provider_b' => 'provider_b',
+        )));
+        $mediaPool->expects($this->any())->method('getContexts')->will($this->returnValue(array(
+            'video' => array(),
+            'pic' => array(),
+        )));
+        $type = new MediaType($mediaPool, 'testClass');
+        $this->factory->create($type, null, array('provider' => 'sonata.media.provider.image'));
+    }
+
+    /**
+     * @expectedException        \Symfony\Component\OptionsResolver\Exception\MissingOptionsException
+     * @expectedExceptionMessage The required option "provider" is missing.
+     */
+    public function testMissingFormProviderOption()
+    {
+        $mediaPool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
+        $mediaPool->expects($this->any())->method('getProviderList')->will($this->returnValue(array(
+            'provider_a' => 'provider_a',
+            'provider_b' => 'provider_b',
+        )));
+        $mediaPool->expects($this->any())->method('getContexts')->will($this->returnValue(array(
+            'video' => array(),
+            'pic' => array(),
+        )));
+        $type = new MediaType($mediaPool, 'testClass');
+        $this->factory->create($type, null, array('context' => 'photo'));
+    }
+
+    /**
+     * @expectedException        \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedExceptionMessage The option "provider" with value "provider_c" is invalid. Accepted values are: "provider_a", "provider_b".
+     */
+    public function testInvalidFormProviderOption()
+    {
+        $mediaPool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
+        $mediaPool->expects($this->any())->method('getProviderList')->will($this->returnValue(array(
+            'provider_a' => 'provider_a',
+            'provider_b' => 'provider_b',
+        )));
+        $mediaPool->expects($this->any())->method('getContexts')->will($this->returnValue(array(
+            'video' => array(),
+            'pic' => array(),
+        )));
+        $type = new MediaType($mediaPool, 'testClass');
+        $this->factory->create($type, null, array('provider' => 'provider_c', 'context' => 'photo'));
+    }
+
+    /**
+     * @expectedException        \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedExceptionMessage The option "context" with value "photo" is invalid. Accepted values are: "video", "pic".
+     */
+    public function testInvalidFormContextOption()
+    {
+        $mediaPool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
+        $mediaPool->expects($this->any())->method('getProviderList')->will($this->returnValue(array(
+            'provider_a' => 'provider_a',
+            'provider_b' => 'provider_b',
+        )));
+        $mediaPool->expects($this->any())->method('getContexts')->will($this->returnValue(array(
+            'video' => array(),
+            'pic' => array(),
+        )));
+        $type = new MediaType($mediaPool, 'testClass');
+        $this->factory->create($type, null, array('provider' => 'provider_b', 'context' => 'photo'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #805 
| License       | MIT
| Doc PR        |

Closes #805.

Given the following example:
```php
$builder->add('media', 'sonata_media_type');
```
**Before:**
```
unable to retrieve the provider named : ``
```
**After:**
```
The required option "provider" is missing.
```

**TODO**:
- [x] Check given ```provider``` value against ```Pool::getProviderList()```