### PR TITLE
Fix 2.3 tests

### DIFF
--- a/Tests/Provider/BaseProviderTest.php
+++ b/Tests/Provider/BaseProviderTest.php
@@ -80,7 +80,7 @@ class BaseProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('test', $provider->getProviderMetadata()->getTitle());
         $this->assertEquals('test.description', $provider->getProviderMetadata()->getDescription());
-        $this->assertNull($provider->getProviderMetadata()->getImage());
+        $this->assertFalse($provider->getProviderMetadata()->getImage());
         $this->assertEquals('fa fa-file', $provider->getProviderMetadata()->getOption('class'));
         $this->assertEquals('SonataMediaBundle', $provider->getProviderMetadata()->getDomain());
     }

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
     ],
     "require": {
         "symfony/symfony": "~2.3",
-        "sonata-project/core-bundle": "~2.2",
+        "sonata-project/core-bundle": "^2.2.6",
         "sonata-project/notification-bundle": "~2.2",
         "sonata-project/easy-extends-bundle": "~2.1",
         "sonata-project/doctrine-extensions": "~1.0",
         "knplabs/gaufrette": ">=0.1.4",
-        "imagine/Imagine": "*@stable",
+        "imagine/Imagine": "~0.3",
         "kriswallsmith/buzz": "0.*",
         "friendsofsymfony/rest-bundle": "~1.1",
         "jms/serializer-bundle": "~0.11|~1.0",
@@ -32,9 +32,8 @@
     },
     "require-dev": {
         "sonata-project/doctrine-orm-admin-bundle": "~2.3@dev",
-        "sonata-project/admin-bundle": "~2.3@dev",
+        "sonata-project/admin-bundle": "~2.3,<2.4",
         "sonata-project/formatter-bundle": "~2.2@dev",
-        "sonata-project/core-bundle": "~2.2@dev",
         "amazonwebservices/aws-sdk-for-php": "~1.5",
         "sonata-project/seo-bundle": "~1.1",
         "doctrine/mongodb-odm": "~1.0@dev",
@@ -49,6 +48,11 @@
         "rackspace/php-opencloud": "~1.6",
         "sonata-project/seo-bundle": "~1.1",
         "tilleuls/ckeditor-sonata-mediabundle": "~1.0"
+    },
+    "conflict": {
+        "jms/serializer": "<0.13",
+        "sonata-project/seo-bundle": "<1.1.5",
+        "sonata-project/block-bundle": "<2.2.8"
     },
     "autoload": {
         "psr-4": { "Sonata\\MediaBundle\\": "" }


### PR DESCRIPTION
Basically, we have to lock sonata-admin 2.3 version because of BC break change in 2.4 (ErrorElement).

dev-master version of media-bundle should be used to works with sonata-admin 2.4.