### PR TITLE
[2.3] Updated references to "Buzz\Message\MessageInterface" in tests

### DIFF
--- a/Tests/Provider/DailyMotionProviderTest.php
+++ b/Tests/Provider/DailyMotionProviderTest.php
@@ -71,7 +71,7 @@ class DailyMotionProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testThumbnail()
     {
-        $response = $this->getMock('Buzz\Message\MessageInterface');
+        $response = $this->getMock('Buzz\Message\AbstractMessage');
         $response->expects($this->once())->method('getContent')->will($this->returnValue('content'));
 
         $browser = $this->getMockBuilder('Buzz\Browser')->getMock();

--- a/Tests/Provider/VimeoProviderTest.php
+++ b/Tests/Provider/VimeoProviderTest.php
@@ -70,7 +70,7 @@ class VimeoProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testThumbnail()
     {
-        $response = $this->getMock('Buzz\Message\MessageInterface');
+        $response = $this->getMock('Buzz\Message\AbstractMessage');
         $response->expects($this->once())->method('getContent')->will($this->returnValue('content'));
 
         $browser = $this->getMockBuilder('Buzz\Browser')->getMock();

--- a/Tests/Provider/YouTubeProviderTest.php
+++ b/Tests/Provider/YouTubeProviderTest.php
@@ -71,7 +71,7 @@ class YouTubeProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testThumbnail()
     {
-        $response = $this->getMock('Buzz\Message\MessageInterface');
+        $response = $this->getMock('Buzz\Message\AbstractMessage');
         $response->expects($this->once())->method('getContent')->will($this->returnValue('content'));
 
         $browser = $this->getMockBuilder('Buzz\Browser')->getMock();

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "sonata-project/doctrine-extensions": "~1.0",
         "knplabs/gaufrette": ">=0.1.4",
         "imagine/Imagine": "~0.3",
-        "kriswallsmith/buzz": "0.*",
+        "kriswallsmith/buzz": "~0.1",
         "friendsofsymfony/rest-bundle": "~1.1",
         "jms/serializer-bundle": "~0.11|~1.0",
         "nelmio/api-doc-bundle": "~2.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #819
| License       | MIT
| Doc PR        |

Replaced by ```Buzz\Message\AbstractMessage``` since ```Buzz\Message\MessageInterface```
is available from ```kriswallsmith/buzz: 0.6``` and the lowest resolved version
is 0.3.

Closes #819.