### PR TITLE
images with 1px height or width could not be computed

### DIFF
--- a/Resizer/SimpleResizer.php
+++ b/Resizer/SimpleResizer.php
@@ -105,6 +105,9 @@ class SimpleResizer implements ResizerInterface
             $ratio = max($ratios);
         }
 
-        return $size->scale($ratio);
+        return new Box(
+            ceil($ratio * $settings['width']),
+            ceil($ratio * $settings['height'])
+        );
     }
 }


### PR DESCRIPTION
as the scale method of box uses ```round()``` instead of ```scale()```, we use the logic from the ```scale()``` method and return the ```Box()```-object directly

this is the refrence of the ```scale()``` method:
```php
    /**
     * {@inheritdoc}
     */
    public function scale($ratio)
    {
        return new Box(round($ratio * $this->width), round($ratio * $this->height));
    }
```

so ```ceil()``` keep us safe!!