### PR TITLE
Revert "streamlined sentence. removed whitespace."

### DIFF
--- a/Resources/translations/SonataMediaBundle.en.xliff
+++ b/Resources/translations/SonataMediaBundle.en.xliff
@@ -68,7 +68,7 @@
             </trans-unit>
             <trans-unit id="description.roles_download_strategy">
                 <source>description.roles_download_strategy</source>
-                <target>The media can be retrieved by users with the following roles: %roles%.</target>
+                <target>The media can be retrieved by users with the following roles : %roles%.</target>
             </trans-unit>
             <trans-unit id="description.public_download_strategy">
                 <source>description.public_download_strategy</source>

--- a/Resources/translations/SonataMediaBundle.es.xliff
+++ b/Resources/translations/SonataMediaBundle.es.xliff
@@ -68,7 +68,7 @@
             </trans-unit>
             <trans-unit id="description.roles_download_strategy">
                 <source>description.roles_download_strategy</source>
-                <target>El archivo multimedia se puede descargar solamente por los usuarios con los siguientes roles: %roles%.</target>
+                <target>El archivo multimedia se puede descargar solamente por los usuarios con los siguientes roles : %roles%.</target>
             </trans-unit>
             <trans-unit id="description.public_download_strategy">
                 <source>description.public_download_strategy</source>

--- a/Resources/translations/SonataMediaBundle.fr.xliff
+++ b/Resources/translations/SonataMediaBundle.fr.xliff
@@ -68,7 +68,7 @@
             </trans-unit>
             <trans-unit id="description.roles_download_strategy">
                 <source>description.roles_download_strategy</source>
-                <target>Le média peut être récupéré par les utilisateurs avec une des permissions suivantes: %roles%.</target>
+                <target>Le média peut être récupéré par les utilisateurs avec une des permissions suivantes : %roles%.</target>
             </trans-unit>
             <trans-unit id="description.public_download_strategy">
                 <source>description.public_download_strategy</source>

--- a/Resources/translations/SonataMediaBundle.it.xliff
+++ b/Resources/translations/SonataMediaBundle.it.xliff
@@ -68,7 +68,7 @@
             </trans-unit>
             <trans-unit id="description.roles_download_strategy">
                 <source>description.roles_download_strategy</source>
-                <target>The media can be retrieved by users with the following roles: %roles%.</target>
+                <target>The media can be retrieved by users with the following roles : %roles%.</target>
             </trans-unit>
             <trans-unit id="description.public_download_strategy">
                 <source>description.public_download_strategy</source>

--- a/Resources/translations/SonataMediaBundle.lt.xliff
+++ b/Resources/translations/SonataMediaBundle.lt.xliff
@@ -68,7 +68,7 @@
             </trans-unit>
             <trans-unit id="description.roles_download_strategy">
                 <source>description.roles_download_strategy</source>
-                <target>Media gali būti pasiekiamas turint šiuos vaidmenis: %roles%.</target>
+                <target>Media gali būti pasiekiamas turint šiuos vaidmenis : %roles%.</target>
             </trans-unit>
             <trans-unit id="description.public_download_strategy">
                 <source>description.public_download_strategy</source>

--- a/Resources/translations/SonataMediaBundle.pl.xliff
+++ b/Resources/translations/SonataMediaBundle.pl.xliff
@@ -68,7 +68,7 @@
             </trans-unit>
             <trans-unit id="description.roles_download_strategy">
                 <source>description.roles_download_strategy</source>
-                <target>Media mogą być pobrane przez użytkowników z tymi rolami: %roles%.</target>
+                <target>Media mogą być pobrane przez użytkowników z tymi rolami : %roles%.</target>
             </trans-unit>
             <trans-unit id="description.public_download_strategy">
                 <source>description.public_download_strategy</source>

--- a/Resources/translations/SonataMediaBundle.ro.xliff
+++ b/Resources/translations/SonataMediaBundle.ro.xliff
@@ -68,7 +68,7 @@
             </trans-unit>
             <trans-unit id="description.roles_download_strategy">
                 <source>description.roles_download_strategy</source>
-                <target>Media este disponibil pentru utilizatorii cu următoarele roluri: %roles%.</target>
+                <target>Media este disponibil pentru utilizatorii cu următoarele roluri : %roles%.</target>
             </trans-unit>
             <trans-unit id="description.public_download_strategy">
                 <source>description.public_download_strategy</source>

--- a/Resources/translations/SonataMediaBundle.ru.xliff
+++ b/Resources/translations/SonataMediaBundle.ru.xliff
@@ -68,7 +68,7 @@
             </trans-unit>
             <trans-unit id="description.roles_download_strategy">
                 <source>description.roles_download_strategy</source>
-                <target>Медиа может быть доступен пользователю со следующими ролями: %roles%.</target>
+                <target>Медиа может быть доступен пользователю со следующими ролями : %roles%.</target>
             </trans-unit>
             <trans-unit id="description.public_download_strategy">
                 <source>description.public_download_strategy</source>

--- a/Resources/translations/SonataMediaBundle.uk.xliff
+++ b/Resources/translations/SonataMediaBundle.uk.xliff
@@ -68,7 +68,7 @@
             </trans-unit>
             <trans-unit id="description.roles_download_strategy">
                 <source>description.roles_download_strategy</source>
-                <target>Медіа може бути доступний користувачеві з наступними ролями: %roles%.</target>
+                <target>Медіа може бути доступний користувачеві з наступними ролями : %roles%.</target>
             </trans-unit>
             <trans-unit id="description.public_download_strategy">
                 <source>description.public_download_strategy</source>


### PR DESCRIPTION
Reverts sonata-project/SonataMediaBundle#844

This PR should be review deeper.

For sample, FR language need a space before `:`. Possibly the same for another.

@OskarStark Please fix only English and your language if you think it's a typo on a new PR.