### PR TITLE
[2.3][Thumbnail] Fix thumbnail URL for reference format

### DIFF
--- a/Tests/Provider/ImageProviderTest.php
+++ b/Tests/Provider/ImageProviderTest.php
@@ -70,6 +70,9 @@ class ImageProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('default/0011/24', $provider->generatePath($media));
         $this->assertEquals('/uploads/media/default/0011/24/thumb_1023456_big.png', $provider->generatePublicUrl($media, 'big'));
         $this->assertEquals('/uploads/media/default/0011/24/ASDASDAS.png', $provider->generatePublicUrl($media, 'reference'));
+
+        $this->assertEquals('default/0011/24/ASDASDAS.png', $provider->generatePrivateUrl($media, 'reference'));
+        $this->assertEquals('default/0011/24/thumb_1023456_big.png', $provider->generatePrivateUrl($media, 'big'));
     }
 
     public function testHelperProperies()

--- a/Thumbnail/FormatThumbnail.php
+++ b/Thumbnail/FormatThumbnail.php
@@ -45,7 +45,12 @@ class FormatThumbnail implements ThumbnailInterface
      */
     public function generatePrivateUrl(MediaProviderInterface $provider, MediaInterface $media, $format)
     {
-        return sprintf('%s/thumb_%s_%s.%s',
+        if ('reference' === $format) {
+            return $provider->getReferenceImage($media);
+        }
+
+        return sprintf(
+            '%s/thumb_%s_%s.%s',
             $provider->generatePath($media),
             $media->getId(),
             $format,


### PR DESCRIPTION
This fixes a bug in [Sonata\MediaBundle\Thumbnail\FormatThumbnail::generatePrivateUrl()](https://github.com/sonata-project/SonataMediaBundle/blob/2.3/Thumbnail/FormatThumbnail.php#L46) that causes an incorrect file name to be returned when the "reference" format is requested. The bug impacts X-Sendfile and X-Accel-Redirect send modes. This is a follow-up to #232 and #277. Additional discussion can be found in #787.