### PR TITLE
Extended regexp for Vimeo provider

### DIFF
--- a/Provider/VimeoProvider.php
+++ b/Provider/VimeoProvider.php
@@ -88,8 +88,8 @@ class VimeoProvider extends BaseVideoProvider
             return;
         }
 
-        if (preg_match("/vimeo\.com\/(\d+)/", $media->getBinaryContent(), $matches)) {
-            $media->setBinaryContent($matches[1]);
+        if (preg_match("/vimeo\.com\/(video\/|)(\d+)/", $media->getBinaryContent(), $matches)) {
+            $media->setBinaryContent($matches[2]);
         }
     }
 

--- a/Tests/Provider/VimeoProviderTest.php
+++ b/Tests/Provider/VimeoProviderTest.php
@@ -123,7 +123,10 @@ class VimeoProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('BDYAbAtaDzA', $media->getProviderReference(), '::getProviderReference() is set');
     }
 
-    public function testTransformWithUrl()
+    /**
+     * @dataProvider getTransformWithUrlMedia
+     */
+    public function testTransformWithUrl($media)
     {
         $response = new Response();
         $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_vimeo.txt'));
@@ -135,16 +138,28 @@ class VimeoProviderTest extends \PHPUnit_Framework_TestCase
 
         $provider->addFormat('big', array('width' => 200, 'height' => 100, 'constraint' => true));
 
-        $media = new Media();
-        $media->setBinaryContent('http://vimeo.com/012341231');
-        $media->setId(1023456);
-
         // pre persist the media
         $provider->transform($media);
         $provider->prePersist($media);
 
         $this->assertEquals('Blinky™', $media->getName(), '::getName() return the file name');
         $this->assertEquals('012341231', $media->getProviderReference(), '::getProviderReference() is set');
+    }
+
+    public function getTransformWithUrlMedia()
+    {
+        $mediaWebsite = new Media();
+        $mediaWebsite->setBinaryContent('http://vimeo.com/012341231');
+        $mediaWebsite->setId(1023456);
+
+        $mediaPlayer = new Media();
+        $mediaPlayer->setBinaryContent('http://player.vimeo.com/video/012341231');
+        $mediaPlayer->setId(1023456);
+
+        return array(
+            'transform with website url'   => array($mediaWebsite),
+            'transform with player url'    => array($mediaPlayer),
+        );
     }
 
     public function testForm()


### PR DESCRIPTION
I've extended the Vimeo provider, because links like 'player.vimeo.com/video/123456' do not get properly parsed. With this regexp both 'vimeo.com/123456' and 'player.vimeo.com/123456' work