### PR TITLE
Remove 'wrap' property from GalleryBlock

### DIFF
--- a/Block/GalleryBlockService.php
+++ b/Block/GalleryBlockService.php
@@ -90,7 +90,6 @@ class GalleryBlockService extends BaseBlockService
             'format' => false,
             'pauseTime' => 3000,
             'startPaused' => false,
-            'wrap' => true,
             'template' => 'SonataMediaBundle:Block:block_gallery.html.twig',
             'galleryId' => null,
         ));
@@ -158,10 +157,6 @@ class GalleryBlockService extends BaseBlockService
                 array('startPaused', 'checkbox', array(
                     'required' => false,
                     'label' => 'form.label_start_paused',
-                )),
-                array('wrap', 'checkbox', array(
-                    'required' => false,
-                    'label' => 'form.label_wrap',
                 )),
             ),
             'translation_domain' => 'SonataMediaBundle',

--- a/Resources/translations/SonataMediaBundle.bg.xliff
+++ b/Resources/translations/SonataMediaBundle.bg.xliff
@@ -481,10 +481,6 @@
                 <source>form.label_start_paused</source>
                 <target>form.label_start_paused</target>
             </trans-unit>
-            <trans-unit id="form.label_wrap">
-                <source>form.label_wrap</source>
-                <target>form.label_wrap</target>
-            </trans-unit>
             <trans-unit id="form.label_orientation_left">
                 <source>form.label_orientation_left</source>
                 <target>form.label_orientation_left</target>

--- a/Resources/translations/SonataMediaBundle.de.xliff
+++ b/Resources/translations/SonataMediaBundle.de.xliff
@@ -489,10 +489,6 @@
                 <source>form.label_start_paused</source>
                 <target>Pausiert starten</target>
             </trans-unit>
-            <trans-unit id="form.label_wrap">
-                <source>form.label_wrap</source>
-                <target>Umbrechen</target>
-            </trans-unit>
             <trans-unit id="form.label_orientation_left">
                 <source>form.label_orientation_left</source>
                 <target>Linksbündig</target>

--- a/Resources/translations/SonataMediaBundle.en.xliff
+++ b/Resources/translations/SonataMediaBundle.en.xliff
@@ -489,10 +489,6 @@
                 <source>form.label_start_paused</source>
                 <target>Start paused</target>
             </trans-unit>
-            <trans-unit id="form.label_wrap">
-                <source>form.label_wrap</source>
-                <target>Wrap</target>
-            </trans-unit>
             <trans-unit id="form.label_orientation_left">
                 <source>form.label_orientation_left</source>
                 <target>Left</target>

--- a/Resources/translations/SonataMediaBundle.es.xliff
+++ b/Resources/translations/SonataMediaBundle.es.xliff
@@ -461,10 +461,6 @@
                 <source>form.label_start_paused</source>
                 <target>form.label_start_paused</target>
             </trans-unit>
-            <trans-unit id="form.label_wrap">
-                <source>form.label_wrap</source>
-                <target>form.label_wrap</target>
-            </trans-unit>
             <trans-unit id="form.label_orientation_left">
                 <source>form.label_orientation_left</source>
                 <target>form.label_orientation_left</target>

--- a/Resources/translations/SonataMediaBundle.fa.xliff
+++ b/Resources/translations/SonataMediaBundle.fa.xliff
@@ -485,10 +485,6 @@
                 <source>form.label_start_paused</source>
                 <target>form.label_start_paused</target>
             </trans-unit>
-            <trans-unit id="form.label_wrap">
-                <source>form.label_wrap</source>
-                <target>form.label_wrap</target>
-            </trans-unit>
             <trans-unit id="form.label_orientation_left">
                 <source>form.label_orientation_left</source>
                 <target>form.label_orientation_left</target>

--- a/Resources/translations/SonataMediaBundle.fi.xliff
+++ b/Resources/translations/SonataMediaBundle.fi.xliff
@@ -489,10 +489,6 @@
                 <source>form.label_start_paused</source>
                 <target>form.label_start_paused</target>
             </trans-unit>
-            <trans-unit id="form.label_wrap">
-                <source>form.label_wrap</source>
-                <target>form.label_wrap</target>
-            </trans-unit>
             <trans-unit id="form.label_orientation_left">
                 <source>form.label_orientation_left</source>
                 <target>form.label_orientation_left</target>

--- a/Resources/translations/SonataMediaBundle.fr.xliff
+++ b/Resources/translations/SonataMediaBundle.fr.xliff
@@ -489,10 +489,6 @@
                 <source>form.label_start_paused</source>
                 <target>Démarrer en pause</target>
             </trans-unit>
-            <trans-unit id="form.label_wrap">
-                <source>form.label_wrap</source>
-                <target>Encapsuleur HTML</target>
-            </trans-unit>
             <trans-unit id="form.label_orientation_left">
                 <source>form.label_orientation_left</source>
                 <target>Gauche</target>

--- a/Resources/translations/SonataMediaBundle.hu.xliff
+++ b/Resources/translations/SonataMediaBundle.hu.xliff
@@ -489,10 +489,6 @@
                 <source>form.label_start_paused</source>
                 <target>form.label_start_paused</target>
             </trans-unit>
-            <trans-unit id="form.label_wrap">
-                <source>form.label_wrap</source>
-                <target>form.label_wrap</target>
-            </trans-unit>
             <trans-unit id="form.label_orientation_left">
                 <source>form.label_orientation_left</source>
                 <target>form.label_orientation_left</target>

--- a/Resources/translations/SonataMediaBundle.it.xliff
+++ b/Resources/translations/SonataMediaBundle.it.xliff
@@ -489,10 +489,6 @@
                 <source>form.label_start_paused</source>
                 <target>form.label_start_paused</target>
             </trans-unit>
-            <trans-unit id="form.label_wrap">
-                <source>form.label_wrap</source>
-                <target>form.label_wrap</target>
-            </trans-unit>
             <trans-unit id="form.label_orientation_left">
                 <source>form.label_orientation_left</source>
                 <target>form.label_orientation_left</target>

--- a/Resources/translations/SonataMediaBundle.ja.xliff
+++ b/Resources/translations/SonataMediaBundle.ja.xliff
@@ -457,10 +457,6 @@
                 <source>form.label_start_paused</source>
                 <target>form.label_start_paused</target>
             </trans-unit>
-            <trans-unit id="form.label_wrap">
-                <source>form.label_wrap</source>
-                <target>form.label_wrap</target>
-            </trans-unit>
             <trans-unit id="form.label_orientation_left">
                 <source>form.label_orientation_left</source>
                 <target>form.label_orientation_left</target>

--- a/Resources/translations/SonataMediaBundle.lt.xliff
+++ b/Resources/translations/SonataMediaBundle.lt.xliff
@@ -461,10 +461,6 @@
                 <source>form.label_start_paused</source>
                 <target>form.label_start_paused</target>
             </trans-unit>
-            <trans-unit id="form.label_wrap">
-                <source>form.label_wrap</source>
-                <target>form.label_wrap</target>
-            </trans-unit>
             <trans-unit id="form.label_orientation_left">
                 <source>form.label_orientation_left</source>
                 <target>form.label_orientation_left</target>

--- a/Resources/translations/SonataMediaBundle.nl.xliff
+++ b/Resources/translations/SonataMediaBundle.nl.xliff
@@ -489,10 +489,6 @@
                 <source>form.label_start_paused</source>
                 <target>form.label_start_paused</target>
             </trans-unit>
-            <trans-unit id="form.label_wrap">
-                <source>form.label_wrap</source>
-                <target>form.label_wrap</target>
-            </trans-unit>
             <trans-unit id="form.label_orientation_left">
                 <source>form.label_orientation_left</source>
                 <target>form.label_orientation_left</target>

--- a/Resources/translations/SonataMediaBundle.pl.xliff
+++ b/Resources/translations/SonataMediaBundle.pl.xliff
@@ -461,10 +461,6 @@
                 <source>form.label_start_paused</source>
                 <target>form.label_start_paused</target>
             </trans-unit>
-            <trans-unit id="form.label_wrap">
-                <source>form.label_wrap</source>
-                <target>form.label_wrap</target>
-            </trans-unit>
             <trans-unit id="form.label_orientation_left">
                 <source>form.label_orientation_left</source>
                 <target>form.label_orientation_left</target>

--- a/Resources/translations/SonataMediaBundle.pt_BR.xliff
+++ b/Resources/translations/SonataMediaBundle.pt_BR.xliff
@@ -453,10 +453,6 @@
                 <source>form.label_start_paused</source>
                 <target>form.label_start_paused</target>
             </trans-unit>
-            <trans-unit id="form.label_wrap">
-                <source>form.label_wrap</source>
-                <target>form.label_wrap</target>
-            </trans-unit>
             <trans-unit id="form.label_orientation_left">
                 <source>form.label_orientation_left</source>
                 <target>form.label_orientation_left</target>

--- a/Resources/translations/SonataMediaBundle.ro.xliff
+++ b/Resources/translations/SonataMediaBundle.ro.xliff
@@ -489,10 +489,6 @@
                 <source>form.label_start_paused</source>
                 <target>form.label_start_paused</target>
             </trans-unit>
-            <trans-unit id="form.label_wrap">
-                <source>form.label_wrap</source>
-                <target>form.label_wrap</target>
-            </trans-unit>
             <trans-unit id="form.label_orientation_left">
                 <source>form.label_orientation_left</source>
                 <target>form.label_orientation_left</target>

--- a/Resources/translations/SonataMediaBundle.ru.xliff
+++ b/Resources/translations/SonataMediaBundle.ru.xliff
@@ -461,10 +461,6 @@
                 <source>form.label_start_paused</source>
                 <target>form.label_start_paused</target>
             </trans-unit>
-            <trans-unit id="form.label_wrap">
-                <source>form.label_wrap</source>
-                <target>form.label_wrap</target>
-            </trans-unit>
             <trans-unit id="form.label_orientation_left">
                 <source>form.label_orientation_left</source>
                 <target>form.label_orientation_left</target>

--- a/Resources/translations/SonataMediaBundle.sl.xliff
+++ b/Resources/translations/SonataMediaBundle.sl.xliff
@@ -461,10 +461,6 @@
                 <source>form.label_start_paused</source>
                 <target>form.label_start_paused</target>
             </trans-unit>
-            <trans-unit id="form.label_wrap">
-                <source>form.label_wrap</source>
-                <target>form.label_wrap</target>
-            </trans-unit>
             <trans-unit id="form.label_orientation_left">
                 <source>form.label_orientation_left</source>
                 <target>form.label_orientation_left</target>

--- a/Resources/translations/SonataMediaBundle.uk.xliff
+++ b/Resources/translations/SonataMediaBundle.uk.xliff
@@ -425,10 +425,6 @@
                 <source>form.label_start_paused</source>
                 <target>form.label_start_paused</target>
             </trans-unit>
-            <trans-unit id="form.label_wrap">
-                <source>form.label_wrap</source>
-                <target>form.label_wrap</target>
-            </trans-unit>
             <trans-unit id="form.label_orientation_left">
                 <source>form.label_orientation_left</source>
                 <target>form.label_orientation_left</target>

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -8,3 +8,7 @@ All the deprecated code introduced on 3.x is removed on 4.0.
 Please read [3.x](https://github.com/sonata-project/SonataMediaBundle/tree/3.x) upgrade guides for more information.
 
 See also the [diff code](https://github.com/sonata-project/SonataMediaBundle/compare/3.x...4.0.0).
+
+## Blocks
+
+The property `wrap` in `GalleryBlockService` was removed. You must create a custom block, if you still want to use ist.


### PR DESCRIPTION
### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Removed
 * Removed `wrap` property from `GalleryBlockService`
```

### Subject
Removes an unused property form `GalleryBlockService`.

### To do

- [x] Add an upgrade note
