### PR TITLE
Created new command for creating default categories

### DIFF
--- a/Command/FixMediaContextCommand.php
+++ b/Command/FixMediaContextCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Command;
+
+use Sonata\ClassificationBundle\Model\ContextInterface;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class FixMediaContextCommand extends ContainerAwareCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configure()
+    {
+        $this->setName('sonata:media:fix-media-context');
+        $this->setDescription('Generate the default category for each media context');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $pool           = $this->getContainer()->get('sonata.media.pool');
+        $contextManager = $this->getContainer()->get('sonata.classification.manager.context');
+        $cateoryManager = $this->getContainer()->get('sonata.classification.manager.category');
+
+        foreach ($pool->getContexts() as $context => $contextAttrs) {
+            /** @var ContextInterface $defaultContext */
+            $defaultContext = $contextManager->findOneBy(array(
+                'id' => $context,
+            ));
+
+            if (!$defaultContext) {
+                $output->writeln(sprintf(" > default context for '%s' is missing, creating one", $context));
+                $defaultContext = $contextManager->create();
+                $defaultContext->setId($context);
+                $defaultContext->setName(ucfirst($context));
+                $defaultContext->setEnabled(true);
+
+                $contextManager->save($defaultContext);
+            }
+
+            $defaultCategory = $cateoryManager->getRootCategory($defaultContext);
+
+            if (!$defaultCategory) {
+                $output->writeln(sprintf(" > default category for '%s' is missing, creating one", $context));
+                $defaultCategory = $cateoryManager->create();
+                $defaultCategory->setContext($defaultContext);
+                $defaultCategory->setName(ucfirst($context));
+                $defaultCategory->setEnabled(true);
+                $defaultCategory->setPosition(0);
+
+                $cateoryManager->save($defaultCategory);
+            }
+        }
+
+        $output->writeln('Done!');
+    }
+}

--- a/Resources/doc/reference/command_line.rst
+++ b/Resources/doc/reference/command_line.rst
@@ -93,3 +93,12 @@ The medias.csv file contains the following lines::
    sonata.media.provider.dailymotion,default,http://www.dailymotion.com/video/xqziut_tutoriel-video-symfony-2-twig_lifestyle
    sonata.media.provider.dailymotion,default,http://www.dailymotion.com/video/x9bgxs_php-tv-4-magento-mysql-symfony-zend_tech
    sonata.media.provider.dailymotion,default,http://www.dailymotion.com/video/xhq4c5_slyblog-tutoriel-video-symfony-1-4-partie-2-2_tech
+
+Fix missing root categories
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Creates default root categories for the ``SonataClassificationBundle`` if they don't exist. This command should be executed when creating a new context under the ``contexts`` config tree.
+
+.. code-block:: bash
+
+   php app/console sonata:media:fix-media-context

--- a/Tests/Command/FixMediaContextCommandTest.php
+++ b/Tests/Command/FixMediaContextCommandTest.php
@@ -1,0 +1,176 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\Command;
+
+use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
+use Sonata\ClassificationBundle\Model\ContextManagerInterface;
+use Sonata\MediaBundle\Command\FixMediaContextCommand;
+use Sonata\MediaBundle\Provider\Pool;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Tests\Command\CommandTest;
+
+class FixMediaContextCommandTest extends CommandTest
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * @var Application
+     */
+    protected $application;
+
+    /**
+     * @var ContainerAwareCommand
+     */
+    protected $command;
+
+    /**
+     * @var CommandTester
+     */
+    protected $tester;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|Pool
+     */
+    private $pool;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|ContextManagerInterface
+     */
+    private $contextManger;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|CategoryManagerInterface
+     */
+    private $categoryManger;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+
+        $this->command = new FixMediaContextCommand();
+        $this->command->setContainer($this->container);
+
+        $this->application = new Application();
+        $this->application->add($this->command);
+
+        $this->tester = new CommandTester($this->application->find('sonata:media:fix-media-context'));
+
+        $this->pool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
+
+        $this->contextManger = $this->getMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+
+        $this->categoryManger = $this->getMockBuilder('Sonata\ClassificationBundle\Entity\CategoryManager')->disableOriginalConstructor()->getMock();
+
+        $this->container->expects($this->any())
+            ->method('get')
+            ->will($this->returnCallback(function ($id) {
+                switch ($id) {
+                    case 'sonata.media.pool':
+                        return $this->pool;
+                    case 'sonata.classification.manager.context':
+                        return $this->contextManger;
+                    case 'sonata.classification.manager.category':
+                        return $this->categoryManger;
+                }
+
+                return;
+            }));
+    }
+
+    public function testExecuteWithExisting()
+    {
+        $context = array(
+            'providers' => array(),
+            'formats'   => array(),
+            'download'  => array(),
+        );
+
+        $this->pool->expects($this->any())->method('getContexts')->will($this->returnValue(array('foo' => $context)));
+
+        $contextModel = $this->getMock('Sonata\ClassificationBundle\Model\ContextInterface');
+
+        $this->contextManger->expects($this->once())->method('findOneBy')->with($this->equalTo(array('id' => 'foo')))->will($this->returnValue($contextModel));
+
+        $category = $this->getMock('Sonata\ClassificationBundle\Model\CategoryInterface');
+
+        $this->categoryManger->expects($this->once())->method('getRootCategory')->with($this->equalTo($contextModel))->will($this->returnValue($category));
+
+        $output = $this->tester->execute(array());
+
+        $this->assertRegExp('@Done!@', $this->tester->getDisplay());
+
+        $this->assertSame(0, $output);
+    }
+
+    public function testExecuteWithEmptyRoot()
+    {
+        $context = array(
+            'providers' => array(),
+            'formats'   => array(),
+            'download'  => array(),
+        );
+
+        $this->pool->expects($this->any())->method('getContexts')->will($this->returnValue(array('foo' => $context)));
+
+        $contextModel = $this->getMock('Sonata\ClassificationBundle\Model\ContextInterface');
+
+        $this->contextManger->expects($this->once())->method('findOneBy')->with($this->equalTo(array('id' => 'foo')))->will($this->returnValue($contextModel));
+
+        $category = $this->getMock('Sonata\ClassificationBundle\Model\CategoryInterface');
+
+        $this->categoryManger->expects($this->once())->method('getRootCategory')->with($this->equalTo($contextModel))->will($this->returnValue(null));
+        $this->categoryManger->expects($this->once())->method('create')->will($this->returnValue($category));
+        $this->categoryManger->expects($this->once())->method('save')->with($this->equalTo($category));
+
+        $output = $this->tester->execute(array());
+
+        $this->assertRegExp('@ > default category for \'foo\' is missing, creating one\s+Done!@', $this->tester->getDisplay());
+
+        $this->assertSame(0, $output);
+    }
+
+    public function testExecuteWithNew()
+    {
+        $context = array(
+            'providers' => array(),
+            'formats'   => array(),
+            'download'  => array(),
+        );
+
+        $this->pool->expects($this->any())->method('getContexts')->will($this->returnValue(array('foo' => $context)));
+
+        $contextModel = $this->getMock('Sonata\ClassificationBundle\Model\ContextInterface');
+
+        $this->contextManger->expects($this->once())->method('findOneBy')->with($this->equalTo(array('id' => 'foo')))->will($this->returnValue(null));
+        $this->contextManger->expects($this->once())->method('create')->will($this->returnValue($contextModel));
+        $this->contextManger->expects($this->once())->method('save')->with($this->equalTo($contextModel));
+
+        $category = $this->getMock('Sonata\ClassificationBundle\Model\CategoryInterface');
+
+        $this->categoryManger->expects($this->once())->method('getRootCategory')->with($this->equalTo($contextModel))->will($this->returnValue(null));
+        $this->categoryManger->expects($this->once())->method('create')->will($this->returnValue($category));
+        $this->categoryManger->expects($this->once())->method('save')->with($this->equalTo($category));
+
+        $output = $this->tester->execute(array());
+
+        $this->assertRegExp('@ > default category for \'foo\' is missing, creating one\s+Done!@', $this->tester->getDisplay());
+
+        $this->assertSame(0, $output);
+    }
+}


### PR DESCRIPTION
This command is based on https://github.com/sonata-project/SonataClassificationBundle/blob/master/Command/FixContextCommand.php to create default categories defined under ``sonata_media => contexts`` in the configuration.