### PR TITLE
fixed sync command when using consumer as thumbnail service

### DIFF
--- a/Thumbnail/ConsumerThumbnail.php
+++ b/Thumbnail/ConsumerThumbnail.php
@@ -87,8 +87,9 @@ class ConsumerThumbnail implements ThumbnailInterface
             ));
         };
 
-        // BC compatibility for missing EventDispatcher
-        if (null === $this->dispatcher) {
+        if (php_sapi_name() === 'cli') {
+            $this->thumbnail->generate($provider, $media);
+        } elseif (null === $this->dispatcher) { // BC compatibility for missing EventDispatcher
             trigger_error('Since version 2.3.3, passing an empty parameter in argument 4 for __construct() in '.__CLASS__.' is deprecated and the workaround for it will be removed in 3.0.', E_USER_DEPRECATED);
             $publish();
         } else {


### PR DESCRIPTION
# Issue with the sync-command
When using `sonata.media.thumbnail.consumer.format` as thumbnail service I recently fixed an issue where the job was sent too early resulting in a race condition. The solution was to postpone firing of the event with the `event_dispatcher` until the event `kernel.finish_request` is thrown.
This resulted in an other issue where the sync command was not working anymore because there is no `kernel.finish_request` event being fired. First I thought that the solution might be to add another listener on the `console.terminate` command. But this would be resulting in a strange behavior of the sync command (The jobs would be published until the command was run completely).
An other issue would have been that the deletion was not made through a notification, but the generation might. This would have been a problem on production environments because of the duration between deleting and creating.

This PR might not be very "sexy" but I really don't know what else to do. I am open to discuss alternatives.