### PR TITLE
Refactor thumbnail Twig helper

### DIFF
--- a/Provider/MediaProviderInterface.php
+++ b/Provider/MediaProviderInterface.php
@@ -131,8 +131,9 @@ interface MediaProviderInterface
     /**
      * @param MediaInterface $media
      * @param string         $format
+     * @param array          $options
      */
-    public function getHelperProperties(MediaInterface $media, $format);
+    public function getHelperProperties(MediaInterface $media, $format, $options = array());
 
     /**
      * Generate the media path.

--- a/Tests/Provider/BaseProviderTest.php
+++ b/Tests/Provider/BaseProviderTest.php
@@ -91,7 +91,7 @@ class TestProvider extends BaseProvider
     /**
      * {@inheritdoc}
      */
-    public function getHelperProperties(MediaInterface $media, $format)
+    public function getHelperProperties(MediaInterface $media, $format, $options = array())
     {
         // TODO: Implement getHelperProperties() method.
     }

--- a/Tests/Twig/Extension/MediaExtensionTest.php
+++ b/Tests/Twig/Extension/MediaExtensionTest.php
@@ -1,0 +1,126 @@
+<?php
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Twig\Extension\MediaExtension;
+
+/**
+ * Class MediaExtensionTest.
+ *
+ * Unit test of MediaExtension class.
+ *
+ * @author Geza Buza <bghome@gmail.com>
+ */
+class MediaExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Sonata\MediaBundle\Provider\MediaProviderInterface
+     */
+    private $provider;
+
+    /**
+     * @var Twig_TemplateInterface
+     */
+    private $template;
+
+    /**
+     * @var Twig_Environment
+     */
+    private $environment;
+
+    /**
+     * @var Sonata\MediaBundle\Model\Media
+     */
+    private $media;
+
+    public function testThumbnailCanRenderHtmlAttributesGivenByTheProvider()
+    {
+        $mediaExtension = new MediaExtension($this->getMediaService(), $this->getMediaManager());
+        $mediaExtension->initRuntime($this->getEnvironment());
+
+        $media = $this->getMedia();
+        $format = 'png';
+        $options = array('title' => 'Test title');
+
+        $provider = $this->getProvider();
+        $provider->expects($this->once())->method('getHelperProperties')->with($media, $format, $options)
+            ->willReturn(array('title' => 'Test title', 'data-custom' => 'foo'));
+
+        $template = $this->getTemplate();
+        $template->expects($this->once())
+            ->method('render')
+            ->with(
+                $this->equalTo(
+                    array(
+                        'media'   => $media,
+                        'options' => array('title' => 'Test title', 'data-custom' => 'foo'),
+                    )
+                )
+            );
+
+        $mediaExtension->thumbnail($media, $format, $options);
+    }
+
+    public function getMediaService()
+    {
+        $mediaService = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mediaService->method('getProvider')->willReturn($this->getProvider());
+
+        return $mediaService;
+    }
+
+    public function getMediaManager()
+    {
+        return $this->getMock('Sonata\CoreBundle\Model\ManagerInterface');
+    }
+
+    public function getProvider()
+    {
+        if (is_null($this->provider)) {
+            $this->provider = $this->getMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+            $this->provider->method('getFormatName')->will($this->returnArgument(1));
+        }
+
+        return $this->provider;
+    }
+
+    public function getTemplate()
+    {
+        if (is_null($this->template)) {
+            $this->template = $this->getMock('Twig_TemplateInterface');
+        }
+
+        return $this->template;
+    }
+
+    public function getEnvironment()
+    {
+        if (is_null($this->environment)) {
+            $this->environment = $this->getMockBuilder('Twig_Environment')
+                ->disableOriginalConstructor()
+                ->getMock();
+            $this->environment->method('loadTemplate')->willReturn($this->getTemplate());
+        }
+
+        return $this->environment;
+    }
+
+    public function getMedia()
+    {
+        if (is_null($this->media)) {
+            $this->media = $this->getMock('Sonata\MediaBundle\Model\Media');
+            $this->media->method('getProviderStatus')->willReturn(MediaInterface::STATUS_OK);
+        }
+
+        return $this->media;
+    }
+}

--- a/Twig/Extension/MediaExtension.php
+++ b/Twig/Extension/MediaExtension.php
@@ -169,7 +169,7 @@ class MediaExtension extends \Twig_Extension
 
         $options = array_merge($defaultOptions, $options);
 
-        $options['src'] = $provider->generatePublicUrl($media, $format);
+        $options = $provider->getHelperProperties($media, $format, $options);
 
         return $this->render($provider->getTemplate('helper_thumbnail'), array(
             'media'    => $media,


### PR DESCRIPTION
Delegate the responsibility of populating the options to the provider object.
That way the provider can add new items to the options array, making the media extension
more extendable.