### PR TITLE
Extract validator from AdminBundle

### DIFF
--- a/Resources/config/validation.xml
+++ b/Resources/config/validation.xml
@@ -10,7 +10,7 @@
                 <value>isStatusErroneous</value>
             </option>
         </constraint>
-        <constraint name="Sonata\AdminBundle\Validator\Constraints\InlineConstraint">
+        <constraint name="Sonata\CoreBundle\Validator\Constraints\InlineConstraint" >
             <option name="service">sonata.media.pool</option>
             <option name="method">validate</option>
         </constraint>

--- a/Tests/Validator/FormatValidatorTest.php
+++ b/Tests/Validator/FormatValidatorTest.php
@@ -26,7 +26,14 @@ class FormatValidatorTest extends \PHPUnit_Framework_TestCase
         $gallery->expects($this->once())->method('getDefaultFormat')->will($this->returnValue('format1'));
         $gallery->expects($this->once())->method('getContext')->will($this->returnValue('test'));
 
-        $context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
+        // Prefer the Symfony 2.5+ API if available
+        if (class_exists('Symfony\Component\Validator\Context\ExecutionContext')) {
+            $contextClass = 'Symfony\Component\Validator\Context\ExecutionContext';
+        } else {
+            $contextClass = 'Symfony\Component\Validator\ExecutionContext';
+        }
+
+        $context = $this->getMock($contextClass, array(), array(), '', false);
         $context->expects($this->never())->method('addViolation');
 
         $validator = new FormatValidator($pool);
@@ -44,7 +51,14 @@ class FormatValidatorTest extends \PHPUnit_Framework_TestCase
         $gallery->expects($this->once())->method('getDefaultFormat')->will($this->returnValue('format1'));
         $gallery->expects($this->once())->method('getContext')->will($this->returnValue('test'));
 
-        $context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
+        // Prefer the Symfony 2.5+ API if available
+        if (class_exists('Symfony\Component\Validator\Context\ExecutionContext')) {
+            $contextClass = 'Symfony\Component\Validator\Context\ExecutionContext';
+        } else {
+            $contextClass = 'Symfony\Component\Validator\ExecutionContext';
+        }
+
+        $context = $this->getMock($contextClass, array(), array(), '', false);
         $context->expects($this->once())->method('addViolation');
 
         $validator = new FormatValidator($pool);

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "symfony/symfony": "~2.3",
-        "sonata-project/core-bundle": "^2.2.6",
+        "sonata-project/core-bundle": "~2.3",
         "sonata-project/notification-bundle": "~2.2",
         "sonata-project/easy-extends-bundle": "~2.1",
         "sonata-project/doctrine-extensions": "~1.0",


### PR DESCRIPTION
Hello guys.

Could you please, merge this pull request into 2.3 stable branch? It will be awesome if you will do that for us.

This PR help many people to resolve issue with wrong namespace in the validation.xml.

p.s. I tried to get around this problem and set my own validation.xml in the Application\Sonata\MediaBundle. I tried to add validation groups on this constraint but it didn't help.
