### PR TITLE
Type checking to avoid fatal error

### DIFF
--- a/Provider/FileProvider.php
+++ b/Provider/FileProvider.php
@@ -192,6 +192,11 @@ class FileProvider extends BaseProvider
             return;
         }
 
+        // is_file will cause a fatal error if binary content is not a string
+        if (!is_string($media->getBinaryContent())) {
+            throw new \RuntimeException(sprintf('Invalid data provided for binary content, choose among: string, %s, %s', File::class, Request::class));
+        }
+
         // if the binary content is a filename => convert to a valid File
         if (!is_file($media->getBinaryContent())) {
             throw new \RuntimeException('The file does not exist : '.$media->getBinaryContent());

--- a/Provider/FileProvider.php
+++ b/Provider/FileProvider.php
@@ -194,7 +194,11 @@ class FileProvider extends BaseProvider
 
         // is_file will cause a fatal error if binary content is not a string
         if (!is_string($media->getBinaryContent())) {
-            throw new \RuntimeException(sprintf('Invalid data provided for binary content, choose among: string, %s, %s', File::class, Request::class));
+            throw new \RuntimeException(sprintf(
+                'Invalid data provided for binary content, choose among: string, %s, %s',
+                'Symfony\Component\HttpFoundation\File\File',
+                'Symfony\Component\HttpFoundation\Request'
+            ));
         }
 
         // if the binary content is a filename => convert to a valid File


### PR DESCRIPTION
Some of my users had fatal errors while using the API because they made mistake in the Media Form.
This check allow to return a clear description of the problem.