### PR TITLE
renamed GalleryHasMedia to GalleryItem

### DIFF
--- a/Admin/GalleryAdmin.php
+++ b/Admin/GalleryAdmin.php
@@ -47,7 +47,7 @@ class GalleryAdmin extends AbstractAdmin
         $gallery->setContext($parameters['context']);
 
         // fix weird bug with setter object not being call
-        $gallery->setGalleryHasMedias($gallery->getGalleryHasMedias());
+        $gallery->setGalleryItems($gallery->getGalleryItems());
     }
 
     /**
@@ -56,7 +56,7 @@ class GalleryAdmin extends AbstractAdmin
     public function preUpdate($gallery)
     {
         // fix weird bug with setter object not being call
-        $gallery->setGalleryHasMedias($gallery->getGalleryHasMedias());
+        $gallery->setGalleryItems($gallery->getGalleryItems());
     }
 
     /**
@@ -127,14 +127,14 @@ class GalleryAdmin extends AbstractAdmin
                 ->add('defaultFormat', 'choice', array('choices' => $formats))
             ->end()
             ->with('Gallery')
-                ->add('galleryHasMedias', 'sonata_type_collection', array(
+                ->add('galleryItems', 'sonata_type_collection', array(
                         'cascade_validation' => true,
                     ), array(
                         'edit' => 'inline',
                         'inline' => 'table',
                         'sortable' => 'position',
                         'link_parameters' => array('context' => $context),
-                        'admin_code' => 'sonata.media.admin.gallery_has_media',
+                        'admin_code' => 'sonata.media.admin.gallery_item',
                     )
                 )
             ->end()

--- a/Admin/GalleryItemAdmin.php
+++ b/Admin/GalleryItemAdmin.php
@@ -15,7 +15,7 @@ use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 
-class GalleryHasMediaAdmin extends AbstractAdmin
+class GalleryItemAdmin extends AbstractAdmin
 {
     /**
      * {@inheritdoc}

--- a/Block/GalleryBlockService.php
+++ b/Block/GalleryBlockService.php
@@ -226,22 +226,22 @@ class GalleryBlockService extends BaseBlockService
     private function buildElements(GalleryInterface $gallery)
     {
         $elements = array();
-        foreach ($gallery->getGalleryHasMedias() as $galleryHasMedia) {
-            if (!$galleryHasMedia->getEnabled()) {
+        foreach ($gallery->getGalleryItems() as $galleryItem) {
+            if (!$galleryItem->getEnabled()) {
                 continue;
             }
 
-            $type = $this->getMediaType($galleryHasMedia->getMedia());
+            $type = $this->getMediaType($galleryItem->getMedia());
 
             if (!$type) {
                 continue;
             }
 
             $elements[] = array(
-                'title' => $galleryHasMedia->getMedia()->getName(),
-                'caption' => $galleryHasMedia->getMedia()->getDescription(),
+                'title' => $galleryItem->getMedia()->getName(),
+                'caption' => $galleryItem->getMedia()->getDescription(),
                 'type' => $type,
-                'media' => $galleryHasMedia->getMedia(),
+                'media' => $galleryItem->getMedia(),
             );
         }
 

--- a/Controller/Api/GalleryController.php
+++ b/Controller/Api/GalleryController.php
@@ -18,8 +18,8 @@ use FOS\RestBundle\View\View as FOSRestView;
 use JMS\Serializer\SerializationContext;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Sonata\DatagridBundle\Pager\PagerInterface;
-use Sonata\MediaBundle\Model\GalleryHasMediaInterface;
 use Sonata\MediaBundle\Model\GalleryInterface;
+use Sonata\MediaBundle\Model\GalleryItemInterface;
 use Sonata\MediaBundle\Model\GalleryManagerInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Model\MediaManagerInterface;
@@ -53,7 +53,7 @@ class GalleryController
     /**
      * @var string
      */
-    protected $galleryHasMediaClass;
+    protected $galleryItemClass;
 
     /**
      * Constructor.
@@ -61,14 +61,14 @@ class GalleryController
      * @param GalleryManagerInterface $galleryManager
      * @param MediaManagerInterface   $mediaManager
      * @param FormFactoryInterface    $formFactory
-     * @param string                  $galleryHasMediaClass
+     * @param string                  $galleryItemClass
      */
-    public function __construct(GalleryManagerInterface $galleryManager, MediaManagerInterface $mediaManager, FormFactoryInterface $formFactory, $galleryHasMediaClass)
+    public function __construct(GalleryManagerInterface $galleryManager, MediaManagerInterface $mediaManager, FormFactoryInterface $formFactory, $galleryItemClass)
     {
         $this->galleryManager = $galleryManager;
         $this->mediaManager = $mediaManager;
         $this->formFactory = $formFactory;
-        $this->galleryHasMediaClass = $galleryHasMediaClass;
+        $this->galleryItemClass = $galleryItemClass;
     }
 
     /**
@@ -79,10 +79,33 @@ class GalleryController
      *  output={"class"="Sonata\DatagridBundle\Pager\PagerInterface", "groups"="sonata_api_read"}
      * )
      *
-     * @QueryParam(name="page", requirements="\d+", default="1", description="Page for gallery list pagination")
-     * @QueryParam(name="count", requirements="\d+", default="10", description="Number of galleries by page")
-     * @QueryParam(name="enabled", requirements="0|1", nullable=true, strict=true, description="Enabled/Disabled galleries filter")
-     * @QueryParam(name="orderBy", array=true, requirements="ASC|DESC", nullable=true, strict=true, description="Order by array (key is field, value is direction)")
+     * @QueryParam(
+     *     name="page",
+     *     requirements="\d+",
+     *     default="1",
+     *     description="Page for gallery list pagination"
+     * )
+     * @QueryParam(
+     *     name="count",
+     *     requirements="\d+",
+     *     default="10",
+     *     description="Number of galleries by page"
+     * )
+     * @QueryParam(
+     *     name="enabled",
+     *     requirements="0|1",
+     *     nullable=true,
+     *     strict=true,
+     *     description="Enabled/Disabled galleries filter"
+     * )
+     * @QueryParam(
+     *     name="orderBy",
+     *     array=true,
+     *     requirements="ASC|DESC",
+     *     nullable=true,
+     *     strict=true,
+     *     description="Order by array (key is field, value is direction)"
+     * )
      *
      * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
      *
@@ -163,24 +186,24 @@ class GalleryController
      */
     public function getGalleryMediasAction($id)
     {
-        $ghms = $this->getGallery($id)->getGalleryHasMedias();
+        $galleryItems = $this->getGallery($id)->getGalleryItems();
 
         $media = array();
-        foreach ($ghms as $ghm) {
-            $media[] = $ghm->getMedia();
+        foreach ($galleryItems as $galleryItem) {
+            $media[] = $galleryItem->getMedia();
         }
 
         return $media;
     }
 
     /**
-     * Retrieves the galleryhasmedias of specified gallery.
+     * Retrieves the gallery items of specified gallery.
      *
      * @ApiDoc(
      *  requirements={
      *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="gallery id"}
      *  },
-     *  output={"class"="Sonata\MediaBundle\Model\GalleryHasMedia", "groups"="sonata_api_read"},
+     *  output={"class"="Sonata\MediaBundle\Model\GalleryItem", "groups"="sonata_api_read"},
      *  statusCodes={
      *      200="Returned when successful",
      *      404="Returned when gallery is not found"
@@ -191,11 +214,11 @@ class GalleryController
      *
      * @param $id
      *
-     * @return GalleryHasMediaInterface[]
+     * @return GalleryItemInterface[]
      */
-    public function getGalleryGalleryhasmediasAction($id)
+    public function getGalleryGalleryItemAction($id)
     {
-        return $this->getGallery($id)->getGalleryHasMedias();
+        return $this->getGallery($id)->getGalleryItems();
     }
 
     /**
@@ -257,7 +280,7 @@ class GalleryController
      *      {"name"="galleryId", "dataType"="integer", "requirement"="\d+", "description"="gallery identifier"},
      *      {"name"="mediaId", "dataType"="integer", "requirement"="\d+", "description"="media identifier"}
      *  },
-     *  input={"class"="sonata_media_api_form_gallery_has_media", "name"="", "groups"={"sonata_api_write"}},
+     *  input={"class"="sonata_media_api_form_gallery_item", "name"="", "groups"={"sonata_api_write"}},
      *  output={"class"="sonata_media_api_form_gallery", "groups"={"sonata_api_read"}},
      *  statusCodes={
      *      200="Returned when successful",
@@ -273,20 +296,20 @@ class GalleryController
      *
      * @throws NotFoundHttpException
      */
-    public function postGalleryMediaGalleryhasmediaAction($galleryId, $mediaId, Request $request)
+    public function postGalleryMediaGalleryItemAction($galleryId, $mediaId, Request $request)
     {
         $gallery = $this->getGallery($galleryId);
         $media = $this->getMedia($mediaId);
 
-        foreach ($gallery->getGalleryHasMedias() as $galleryHasMedia) {
-            if ($galleryHasMedia->getMedia()->getId() == $media->getId()) {
+        foreach ($gallery->getGalleryItems() as $galleryItem) {
+            if ($galleryItem->getMedia()->getId() == $media->getId()) {
                 return FOSRestView::create(array(
                     'error' => sprintf('Gallery "%s" already has media "%s"', $galleryId, $mediaId),
                 ), 400);
             }
         }
 
-        return $this->handleWriteGalleryhasmedia($gallery, $media, null, $request);
+        return $this->handleWriteGalleryItem($gallery, $media, null, $request);
     }
 
     /**
@@ -297,7 +320,7 @@ class GalleryController
      *      {"name"="galleryId", "dataType"="integer", "requirement"="\d+", "description"="gallery identifier"},
      *      {"name"="mediaId", "dataType"="integer", "requirement"="\d+", "description"="media identifier"}
      *  },
-     *  input={"class"="sonata_media_api_form_gallery_has_media", "name"="", "groups"={"sonata_api_write"}},
+     *  input={"class"="sonata_media_api_form_gallery_item", "name"="", "groups"={"sonata_api_write"}},
      *  output={"class"="sonata_media_api_form_gallery", "groups"={"sonata_api_read"}},
      *  statusCodes={
      *      200="Returned when successful",
@@ -313,14 +336,14 @@ class GalleryController
      *
      * @throws NotFoundHttpException
      */
-    public function putGalleryMediaGalleryhasmediaAction($galleryId, $mediaId, Request $request)
+    public function putGalleryMediaGalleryItemAction($galleryId, $mediaId, Request $request)
     {
         $gallery = $this->getGallery($galleryId);
         $media = $this->getMedia($mediaId);
 
-        foreach ($gallery->getGalleryHasMedias() as $galleryHasMedia) {
-            if ($galleryHasMedia->getMedia()->getId() == $media->getId()) {
-                return $this->handleWriteGalleryhasmedia($gallery, $media, $galleryHasMedia, $request);
+        foreach ($gallery->getGalleryItems() as $galleryItem) {
+            if ($galleryItem->getMedia()->getId() == $media->getId()) {
+                return $this->handleWriteGalleryItem($gallery, $media, $galleryItem, $request);
             }
         }
 
@@ -349,14 +372,14 @@ class GalleryController
      *
      * @throws NotFoundHttpException
      */
-    public function deleteGalleryMediaGalleryhasmediaAction($galleryId, $mediaId)
+    public function deleteGalleryMediaGalleryItemAction($galleryId, $mediaId)
     {
         $gallery = $this->getGallery($galleryId);
         $media = $this->getMedia($mediaId);
 
-        foreach ($gallery->getGalleryHasMedias() as $key => $galleryHasMedia) {
-            if ($galleryHasMedia->getMedia()->getId() == $media->getId()) {
-                $gallery->getGalleryHasMedias()->remove($key);
+        foreach ($gallery->getGalleryItems() as $key => $galleryItem) {
+            if ($galleryItem->getMedia()->getId() == $media->getId()) {
+                $gallery->getGalleryItems()->remove($key);
                 $this->getGalleryManager()->save($gallery);
 
                 return array('deleted' => true);
@@ -398,31 +421,31 @@ class GalleryController
     }
 
     /**
-     * Write a GalleryHasMedia, this method is used by both POST and PUT action methods.
+     * Write a GalleryItem, this method is used by both POST and PUT action methods.
      *
-     * @param GalleryInterface         $gallery
-     * @param MediaInterface           $media
-     * @param GalleryHasMediaInterface $galleryHasMedia
-     * @param Request                  $request
+     * @param GalleryInterface     $gallery
+     * @param MediaInterface       $media
+     * @param GalleryItemInterface $galleryItem
+     * @param Request              $request
      *
      * @return FormInterface
      */
-    protected function handleWriteGalleryhasmedia(GalleryInterface $gallery, MediaInterface $media, GalleryHasMediaInterface $galleryHasMedia = null, Request $request)
+    protected function handleWriteGalleryItem(GalleryInterface $gallery, MediaInterface $media, GalleryItemInterface $galleryItem = null, Request $request)
     {
-        $form = $this->formFactory->createNamed(null, 'sonata_media_api_form_gallery_has_media', $galleryHasMedia, array(
+        $form = $this->formFactory->createNamed(null, 'sonata_media_api_form_gallery_item', $galleryItem, array(
             'csrf_protection' => false,
         ));
 
         $form->handleRequest($request);
 
         if ($form->isValid()) {
-            $galleryHasMedia = $form->getData();
-            $galleryHasMedia->setMedia($media);
+            $galleryItem = $form->getData();
+            $galleryItem->setMedia($media);
 
-            $gallery->addGalleryHasMedias($galleryHasMedia);
+            $gallery->addGalleryItem($galleryItem);
             $this->galleryManager->save($gallery);
 
-            $view = FOSRestView::create($galleryHasMedia);
+            $view = FOSRestView::create($galleryItem);
             $serializationContext = SerializationContext::create();
             $serializationContext->setGroups(array('sonata_api_read'));
             $serializationContext->enableMaxDepthChecks();

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -417,7 +417,7 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->scalarNode('media')->defaultValue('Application\\Sonata\\MediaBundle\\Entity\\Media')->end()
                         ->scalarNode('gallery')->defaultValue('Application\\Sonata\\MediaBundle\\Entity\\Gallery')->end()
-                        ->scalarNode('gallery_has_media')->defaultValue('Application\\Sonata\\MediaBundle\\Entity\\GalleryHasMedia')->end()
+                        ->scalarNode('gallery_item')->defaultValue('Application\\Sonata\\MediaBundle\\Entity\\GalleryItem')->end()
                         ->scalarNode('category')->defaultValue('Application\\Sonata\\ClassificationBundle\\Entity\\Category')->end()
                     ->end()
                 ->end()

--- a/DependencyInjection/SonataMediaExtension.php
+++ b/DependencyInjection/SonataMediaExtension.php
@@ -201,7 +201,7 @@ class SonataMediaExtension extends Extension
     {
         $container->setParameter('sonata.media.admin.media.entity', $config['class']['media']);
         $container->setParameter('sonata.media.admin.gallery.entity', $config['class']['gallery']);
-        $container->setParameter('sonata.media.admin.gallery_has_media.entity', $config['class']['gallery_has_media']);
+        $container->setParameter('sonata.media.admin.gallery_item.entity', $config['class']['gallery_item']);
 
         $container->setParameter('sonata.media.media.class', $config['class']['media']);
         $container->setParameter('sonata.media.gallery.class', $config['class']['gallery']);
@@ -217,8 +217,8 @@ class SonataMediaExtension extends Extension
         $collector = DoctrineCollector::getInstance();
 
         $collector->addAssociation($config['class']['media'], 'mapOneToMany', array(
-            'fieldName' => 'galleryHasMedias',
-            'targetEntity' => $config['class']['gallery_has_media'],
+            'fieldName' => 'galleryItems',
+            'targetEntity' => $config['class']['gallery_item'],
             'cascade' => array(
                 'persist',
             ),
@@ -226,14 +226,14 @@ class SonataMediaExtension extends Extension
             'orphanRemoval' => false,
         ));
 
-        $collector->addAssociation($config['class']['gallery_has_media'], 'mapManyToOne', array(
+        $collector->addAssociation($config['class']['gallery_item'], 'mapManyToOne', array(
             'fieldName' => 'gallery',
             'targetEntity' => $config['class']['gallery'],
             'cascade' => array(
                 'persist',
             ),
             'mappedBy' => null,
-            'inversedBy' => 'galleryHasMedias',
+            'inversedBy' => 'galleryItems',
             'joinColumns' => array(
                 array(
                     'name' => 'gallery_id',
@@ -243,14 +243,14 @@ class SonataMediaExtension extends Extension
             'orphanRemoval' => false,
         ));
 
-        $collector->addAssociation($config['class']['gallery_has_media'], 'mapManyToOne', array(
+        $collector->addAssociation($config['class']['gallery_item'], 'mapManyToOne', array(
             'fieldName' => 'media',
             'targetEntity' => $config['class']['media'],
             'cascade' => array(
                  'persist',
             ),
             'mappedBy' => null,
-            'inversedBy' => 'galleryHasMedias',
+            'inversedBy' => 'galleryItems',
             'joinColumns' => array(
                 array(
                     'name' => 'media_id',
@@ -261,8 +261,8 @@ class SonataMediaExtension extends Extension
         ));
 
         $collector->addAssociation($config['class']['gallery'], 'mapOneToMany', array(
-            'fieldName' => 'galleryHasMedias',
-            'targetEntity' => $config['class']['gallery_has_media'],
+            'fieldName' => 'galleryItems',
+            'targetEntity' => $config['class']['gallery_item'],
             'cascade' => array(
                 'persist',
             ),
@@ -495,8 +495,8 @@ class SonataMediaExtension extends Extension
             'Sonata\\MediaBundle\\Metadata\\NoopMetadataBuilder',
             'Sonata\\MediaBundle\\Metadata\\ProxyMetadataBuilder',
             'Sonata\\MediaBundle\\Model\\Gallery',
-            'Sonata\\MediaBundle\\Model\\GalleryHasMedia',
-            'Sonata\\MediaBundle\\Model\\GalleryHasMediaInterface',
+            'Sonata\\MediaBundle\\Model\\GalleryItem',
+            'Sonata\\MediaBundle\\Model\\GalleryItemInterface',
             'Sonata\\MediaBundle\\Model\\GalleryInterface',
             'Sonata\\MediaBundle\\Model\\GalleryManager',
             'Sonata\\MediaBundle\\Model\\GalleryManagerInterface',

--- a/Document/BaseGallery.php
+++ b/Document/BaseGallery.php
@@ -24,7 +24,7 @@ abstract class BaseGallery extends Gallery
      */
     public function __construct()
     {
-        $this->galleryHasMedias = new ArrayCollection();
+        $this->galleryItems = new ArrayCollection();
     }
 
     /**

--- a/Document/BaseGalleryItem.php
+++ b/Document/BaseGalleryItem.php
@@ -11,9 +11,9 @@
 
 namespace Sonata\MediaBundle\Document;
 
-use Sonata\MediaBundle\Model\GalleryHasMedia;
+use Sonata\MediaBundle\Model\GalleryItem;
 
-abstract class BaseGalleryHasMedia extends GalleryHasMedia
+abstract class BaseGalleryItem extends GalleryItem
 {
     public function prePersist()
     {

--- a/Entity/BaseGallery.php
+++ b/Entity/BaseGallery.php
@@ -24,7 +24,7 @@ abstract class BaseGallery extends Gallery
      */
     public function __construct()
     {
-        $this->galleryHasMedias = new ArrayCollection();
+        $this->galleryItems = new ArrayCollection();
     }
 
     /**

--- a/Entity/BaseGalleryItem.php
+++ b/Entity/BaseGalleryItem.php
@@ -11,9 +11,9 @@
 
 namespace Sonata\MediaBundle\Entity;
 
-use Sonata\MediaBundle\Model\GalleryHasMedia;
+use Sonata\MediaBundle\Model\GalleryItem;
 
-abstract class BaseGalleryHasMedia extends GalleryHasMedia
+abstract class BaseGalleryItem extends GalleryItem
 {
     public function prePersist()
     {

--- a/Form/Type/ApiGalleryItemType.php
+++ b/Form/Type/ApiGalleryItemType.php
@@ -13,6 +13,6 @@ namespace Sonata\MediaBundle\Form\Type;
 
 use Sonata\CoreBundle\Form\Type\BaseDoctrineORMSerializationType;
 
-class ApiGalleryHasMediaType extends BaseDoctrineORMSerializationType
+class ApiGalleryItemType extends BaseDoctrineORMSerializationType
 {
 }

--- a/Model/Gallery.php
+++ b/Model/Gallery.php
@@ -46,9 +46,9 @@ abstract class Gallery implements GalleryInterface
     protected $defaultFormat;
 
     /**
-     * @var GalleryHasMediaInterface[]
+     * @var GalleryItemInterface[]
      */
-    protected $galleryHasMedias;
+    protected $galleryItems;
 
     /**
      * {@inheritdoc}
@@ -141,31 +141,31 @@ abstract class Gallery implements GalleryInterface
     /**
      * {@inheritdoc}
      */
-    public function setGalleryHasMedias($galleryHasMedias)
+    public function setGalleryItems($galleryItems)
     {
-        $this->galleryHasMedias = new ArrayCollection();
+        $this->galleryItems = new ArrayCollection();
 
-        foreach ($galleryHasMedias as $galleryHasMedia) {
-            $this->addGalleryHasMedias($galleryHasMedia);
+        foreach ($galleryItems as $galleryItem) {
+            $this->addGalleryItem($galleryItem);
         }
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getGalleryHasMedias()
+    public function getGalleryItems()
     {
-        return $this->galleryHasMedias;
+        return $this->galleryItems;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function addGalleryHasMedias(GalleryHasMediaInterface $galleryHasMedia)
+    public function addGalleryItem(GalleryItemInterface $galleryItem)
     {
-        $galleryHasMedia->setGallery($this);
+        $galleryItem->setGallery($this);
 
-        $this->galleryHasMedias[] = $galleryHasMedia;
+        $this->galleryItems[] = $galleryItem;
     }
 
     /**

--- a/Model/GalleryInterface.php
+++ b/Model/GalleryInterface.php
@@ -102,17 +102,17 @@ interface GalleryInterface
     public function getDefaultFormat();
 
     /**
-     * @param array $galleryHasMedias
+     * @param array $galleryItems
      */
-    public function setGalleryHasMedias($galleryHasMedias);
+    public function setGalleryItems($galleryItems);
 
     /**
-     * @return GalleryHasMediaInterface[]
+     * @return GalleryItemInterface[]
      */
-    public function getGalleryHasMedias();
+    public function getGalleryItems();
 
     /**
-     * @param GalleryHasMediaInterface $galleryHasMedia
+     * @param GalleryItemInterface $galleryItem
      */
-    public function addGalleryHasMedias(GalleryHasMediaInterface $galleryHasMedia);
+    public function addGalleryItem(GalleryItemInterface $galleryItem);
 }

--- a/Model/GalleryItem.php
+++ b/Model/GalleryItem.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\MediaBundle\Model;
 
-abstract class GalleryHasMedia implements GalleryHasMediaInterface
+abstract class GalleryItem implements GalleryItemInterface
 {
     /**
      * @var MediaInterface

--- a/Model/GalleryItemInterface.php
+++ b/Model/GalleryItemInterface.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\MediaBundle\Model;
 
-interface GalleryHasMediaInterface
+interface GalleryItemInterface
 {
     /**
      * @return string

--- a/Model/Media.php
+++ b/Model/Media.php
@@ -134,9 +134,9 @@ abstract class Media implements MediaInterface
     protected $size;
 
     /**
-     * @var GalleryHasMediaInterface[]
+     * @var GalleryItemInterface[]
      */
-    protected $galleryHasMedias;
+    protected $galleryItems;
 
     /**
      * @var CategoryInterface
@@ -590,17 +590,17 @@ abstract class Media implements MediaInterface
     /**
      * {@inheritdoc}
      */
-    public function setGalleryHasMedias($galleryHasMedias)
+    public function setGalleryItems($galleryItems)
     {
-        $this->galleryHasMedias = $galleryHasMedias;
+        $this->galleryItems = $galleryItems;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getGalleryHasMedias()
+    public function getGalleryItems()
     {
-        return $this->galleryHasMedias;
+        return $this->galleryItems;
     }
 
     /**

--- a/Model/MediaInterface.php
+++ b/Model/MediaInterface.php
@@ -367,14 +367,14 @@ interface MediaInterface
     public function getBox();
 
     /**
-     * @param GalleryHasMediaInterface[] $galleryHasMedias
+     * @param GalleryItemInterface[] $galleryItems
      */
-    public function setGalleryHasMedias($galleryHasMedias);
+    public function setGalleryItems($galleryItems);
 
     /**
-     * @return GalleryHasMediaInterface[]
+     * @return GalleryItemInterface[]
      */
-    public function getGalleryHasMedias();
+    public function getGalleryItems();
 
     /**
      * @return string

--- a/PHPCR/BaseGallery.php
+++ b/PHPCR/BaseGallery.php
@@ -12,7 +12,7 @@
 namespace Sonata\MediaBundle\PHPCR;
 
 use Sonata\MediaBundle\Model\Gallery;
-use Sonata\MediaBundle\Model\GalleryHasMediaInterface;
+use Sonata\MediaBundle\Model\GalleryItemInterface;
 
 /**
  * Bundle\MediaBundle\Document\BaseGallery.
@@ -29,7 +29,7 @@ abstract class BaseGallery extends Gallery
      */
     public function __construct()
     {
-        $this->galleryHasMedias = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->galleryItems = new \Doctrine\Common\Collections\ArrayCollection();
     }
 
     /**
@@ -45,18 +45,18 @@ abstract class BaseGallery extends Gallery
     /**
      * {@inheritdoc}
      */
-    public function addGalleryHasMedias(GalleryHasMediaInterface $galleryHasMedia)
+    public function addGalleryItem(GalleryItemInterface $galleryItem)
     {
-        $galleryHasMedia->setGallery($this);
+        $galleryItem->setGallery($this);
 
-        // set nodename of GalleryHasMedia
-        if (!$galleryHasMedia->getNodename()) {
-            $galleryHasMedia->setNodename(
-                'media'.($this->galleryHasMedias->count() + 1)
+        // set nodename of GalleryItem
+        if (!$galleryItem->getNodename()) {
+            $galleryItem->setNodename(
+                'media'.($this->galleryItems->count() + 1)
             );
         }
 
-        $this->galleryHasMedias->set($galleryHasMedia->getNodename(), $galleryHasMedia);
+        $this->galleryItems->set($galleryItem->getNodename(), $galleryItem);
     }
 
     /**
@@ -67,7 +67,7 @@ abstract class BaseGallery extends Gallery
         $this->createdAt = new \DateTime();
         $this->updatedAt = new \DateTime();
 
-        $this->reorderGalleryHasMedia();
+        $this->reorderGalleryItems();
     }
 
     /**
@@ -77,18 +77,18 @@ abstract class BaseGallery extends Gallery
     {
         $this->updatedAt = new \DateTime();
 
-        $this->reorderGalleryHasMedia();
+        $this->reorderGalleryItems();
     }
 
     /**
-     * Reorders $galleryHasMedia items based on their position.
+     * Reorders gallery items based on their position.
      */
-    public function reorderGalleryHasMedia()
+    public function reorderGalleryItems()
     {
-        if ($this->getGalleryHasMedias() && $this->getGalleryHasMedias() instanceof \IteratorAggregate) {
+        if ($this->getGalleryItems() && $this->getGalleryItems() instanceof \IteratorAggregate) {
 
             // reorder
-            $iterator = $this->getGalleryHasMedias()->getIterator();
+            $iterator = $this->getGalleryItems()->getIterator();
 
             $iterator->uasort(function ($a, $b) {
                 if ($a->getPosition() === $b->getPosition()) {
@@ -98,7 +98,7 @@ abstract class BaseGallery extends Gallery
                 return $a->getPosition() > $b->getPosition() ? 1 : -1;
             });
 
-            $this->setGalleryHasMedias($iterator);
+            $this->setGalleryItems($iterator);
         }
     }
 }

--- a/PHPCR/BaseGalleryItem.php
+++ b/PHPCR/BaseGalleryItem.php
@@ -11,9 +11,9 @@
 
 namespace Sonata\MediaBundle\PHPCR;
 
-use Sonata\MediaBundle\Model\GalleryHasMedia;
+use Sonata\MediaBundle\Model\GalleryItem;
 
-abstract class BaseGalleryHasMedia extends GalleryHasMedia
+abstract class BaseGalleryItem extends GalleryItem
 {
     /**
      * @var string

--- a/PHPCR/BaseGalleryItemRepository.php
+++ b/PHPCR/BaseGalleryItemRepository.php
@@ -14,7 +14,7 @@ namespace Sonata\MediaBundle\PHPCR;
 use Doctrine\ODM\PHPCR\DocumentRepository;
 use Doctrine\ODM\PHPCR\Id\RepositoryIdInterface;
 
-class BaseGalleryHasMediaRepository extends DocumentRepository implements RepositoryIdInterface
+class BaseGalleryItemRepository extends DocumentRepository implements RepositoryIdInterface
 {
     /**
      * @param mixed $document

--- a/Resources/config/api_controllers.xml
+++ b/Resources/config/api_controllers.xml
@@ -5,7 +5,7 @@
             <argument type="service" id="sonata.media.manager.gallery"/>
             <argument type="service" id="sonata.media.manager.media"/>
             <argument type="service" id="form.factory"/>
-            <argument>%sonata.media.admin.gallery_has_media.entity%</argument>
+            <argument>%sonata.media.admin.gallery_item.entity%</argument>
         </service>
         <service id="sonata.media.controller.api.media" class="Sonata\MediaBundle\Controller\Api\MediaController">
             <argument type="service" id="sonata.media.manager.media"/>

--- a/Resources/config/api_form_doctrine_mongodb.xml
+++ b/Resources/config/api_form_doctrine_mongodb.xml
@@ -22,12 +22,12 @@
             <argument>%sonata.media.admin.gallery.entity%</argument>
             <argument>sonata_api_write</argument>
         </service>
-        <service id="sonata.media.api.form.type.gallery_has_media" class="Sonata\MediaBundle\Form\Type\ApiGalleryHasMediaType">
-            <tag name="form.type" alias="sonata_media_api_form_gallery_has_media"/>
+        <service id="sonata.media.api.form.type.gallery_item" class="Sonata\MediaBundle\Form\Type\ApiGalleryItemType">
+            <tag name="form.type" alias="sonata_media_api_form_gallery_item"/>
             <argument type="service" id="jms_serializer.metadata_factory"/>
             <argument type="service" id="doctrine_mongodb"/>
-            <argument>sonata_media_api_form_gallery_has_media</argument>
-            <argument>%sonata.media.admin.gallery_has_media.entity%</argument>
+            <argument>sonata_media_api_form_gallery_item</argument>
+            <argument>%sonata.media.admin.gallery_item.entity%</argument>
             <argument>sonata_api_write</argument>
         </service>
     </services>

--- a/Resources/config/api_form_doctrine_orm.xml
+++ b/Resources/config/api_form_doctrine_orm.xml
@@ -22,12 +22,12 @@
             <argument>%sonata.media.admin.gallery.entity%</argument>
             <argument>sonata_api_write</argument>
         </service>
-        <service id="sonata.media.api.form.type.gallery_has_media" class="Sonata\MediaBundle\Form\Type\ApiGalleryHasMediaType">
-            <tag name="form.type" alias="sonata_media_api_form_gallery_has_media"/>
+        <service id="sonata.media.api.form.type.gallery_item" class="Sonata\MediaBundle\Form\Type\ApiGalleryItemType">
+            <tag name="form.type" alias="sonata_media_api_form_gallery_item"/>
             <argument type="service" id="jms_serializer.metadata_factory"/>
             <argument type="service" id="doctrine"/>
-            <argument>sonata_media_api_form_gallery_has_media</argument>
-            <argument>%sonata.media.admin.gallery_has_media.entity%</argument>
+            <argument>sonata_media_api_form_gallery_item</argument>
+            <argument>%sonata.media.admin.gallery_item.entity%</argument>
             <argument>sonata_api_write</argument>
         </service>
     </services>

--- a/Resources/config/api_form_doctrine_phpcr.xml
+++ b/Resources/config/api_form_doctrine_phpcr.xml
@@ -22,12 +22,12 @@
             <argument>%sonata.media.admin.gallery.entity%</argument>
             <argument>sonata_api_write</argument>
         </service>
-        <service id="sonata.media.api.form.type.gallery_has_media" class="Sonata\MediaBundle\Form\Type\ApiGalleryHasMediaType">
-            <tag name="form.type" alias="sonata_media_api_form_gallery_has_media"/>
+        <service id="sonata.media.api.form.type.gallery_item" class="Sonata\MediaBundle\Form\Type\ApiGalleryItemType">
+            <tag name="form.type" alias="sonata_media_api_form_gallery_item"/>
             <argument type="service" id="jms_serializer.metadata_factory"/>
             <argument type="service" id="doctrine_phpcr"/>
-            <argument>sonata_media_api_form_gallery_has_media</argument>
-            <argument>%sonata.media.admin.gallery_has_media.entity%</argument>
+            <argument>sonata_media_api_form_gallery_item</argument>
+            <argument>%sonata.media.admin.gallery_item.entity%</argument>
             <argument>sonata_api_write</argument>
         </service>
     </services>

--- a/Resources/config/doctrine/BaseGallery.phpcr.xml
+++ b/Resources/config/doctrine/BaseGallery.phpcr.xml
@@ -2,7 +2,7 @@
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/phpcr-odm/phpcr-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/phpcr-odm/phpcr-mapping     https://github.com/doctrine/phpcr-odm/raw/master/doctrine-phpcr-odm-mapping.xsd">
     <mapped-superclass name="Sonata\MediaBundle\PHPCR\BaseGallery" referenceable="true">
         <uuid name="uuid"/>
-        <children name="galleryHasMedias"/>
+        <children name="galleryItems"/>
         <field name="name" type="string"/>
         <field name="context" type="string"/>
         <field name="defaultFormat" type="string"/>

--- a/Resources/config/doctrine/BaseGalleryItem.mongodb.xml
+++ b/Resources/config/doctrine/BaseGalleryItem.mongodb.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
-    <mapped-superclass name="Sonata\MediaBundle\Document\BaseGalleryHasMedia">
+    <mapped-superclass name="Sonata\MediaBundle\Document\BaseGalleryItem">
         <field name="position" type="int"/>
         <field name="enabled" type="boolean"/>
         <field name="updatedAt" type="date"/>

--- a/Resources/config/doctrine/BaseGalleryItem.orm.xml
+++ b/Resources/config/doctrine/BaseGalleryItem.orm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xsi="http://www.w3.org/2001/XMLSchema-instance" schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
-    <mapped-superclass name="Sonata\MediaBundle\Entity\BaseGalleryHasMedia">
+    <mapped-superclass name="Sonata\MediaBundle\Entity\BaseGalleryItem">
         <field name="position" type="integer" column="position"/>
         <field name="enabled" type="boolean" column="enabled"/>
         <field name="updatedAt" column="updated_at" type="datetime"/>

--- a/Resources/config/doctrine/BaseGalleryItem.phpcr.xml
+++ b/Resources/config/doctrine/BaseGalleryItem.phpcr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/phpcr-odm/phpcr-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/phpcr-odm/phpcr-mapping     https://github.com/doctrine/phpcr-odm/raw/master/doctrine-phpcr-odm-mapping.xsd">
-    <mapped-superclass name="Sonata\MediaBundle\PHPCR\BaseGalleryHasMedia" referenceable="true">
+    <mapped-superclass name="Sonata\MediaBundle\PHPCR\BaseGalleryItem" referenceable="true">
         <parent-document name="gallery"/>
         <nodename name="nodename"/>
         <field name="enabled" type="boolean"/>

--- a/Resources/config/doctrine/GalleryItem.orm.xml.skeleton
+++ b/Resources/config/doctrine/GalleryItem.orm.xml.skeleton
@@ -9,7 +9,7 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
     <entity
-        name="Application\Sonata\MediaBundle\Entity\GalleryHasMedia"
+        name="Application\Sonata\MediaBundle\Entity\GalleryItem"
         table="media__gallery_media"
         >
 

--- a/Resources/config/doctrine/GalleryItem.phpcr.xml.skeleton
+++ b/Resources/config/doctrine/GalleryItem.phpcr.xml.skeleton
@@ -14,8 +14,8 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
 
-    <document name="Application\Sonata\MediaBundle\PHPCR\GalleryHasMedia"
-              repository-class="Application\Sonata\MediaBundle\PHPCR\GalleryHasMediaRepository">
+    <document name="Application\Sonata\MediaBundle\PHPCR\GalleryItem"
+              repository-class="Application\Sonata\MediaBundle\PHPCR\GalleryItemRepository">
 
         <id name="id">
             <generator strategy="REPOSITORY" />

--- a/Resources/config/doctrine_mongodb_admin.xml
+++ b/Resources/config/doctrine_mongodb_admin.xml
@@ -10,9 +10,9 @@
         <parameter key="sonata.media.admin.gallery.controller">SonataMediaBundle:GalleryAdmin</parameter>
         <parameter key="sonata.media.admin.gallery.translation_domain">%sonata.media.admin.media.translation_domain%</parameter>
         <!-- GALLERY HAS MEDIA -->
-        <parameter key="sonata.media.admin.gallery_has_media.class">Sonata\MediaBundle\Admin\GalleryHasMediaAdmin</parameter>
-        <parameter key="sonata.media.admin.gallery_has_media.controller">SonataAdminBundle:CRUD</parameter>
-        <parameter key="sonata.media.admin.gallery_has_media.translation_domain">%sonata.media.admin.media.translation_domain%</parameter>
+        <parameter key="sonata.media.admin.gallery_item.class">Sonata\MediaBundle\Admin\GalleryItemAdmin</parameter>
+        <parameter key="sonata.media.admin.gallery_item.controller">SonataAdminBundle:CRUD</parameter>
+        <parameter key="sonata.media.admin.gallery_item.translation_domain">%sonata.media.admin.media.translation_domain%</parameter>
     </parameters>
     <services>
         <service id="sonata.media.admin.media" class="%sonata.media.admin.media.class%">
@@ -54,13 +54,13 @@
                 </argument>
             </call>
         </service>
-        <service id="sonata.media.admin.gallery_has_media" class="%sonata.media.admin.gallery_has_media.class%">
-            <tag name="sonata.admin" manager_type="doctrine_mongodb" group="sonata_media" label_catalogue="%sonata.media.admin.gallery_has_media.translation_domain%" label="gallery_has_media" show_in_dashboard="false" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
+        <service id="sonata.media.admin.gallery_item" class="%sonata.media.admin.gallery_item.class%">
+            <tag name="sonata.admin" manager_type="doctrine_mongodb" group="sonata_media" label_catalogue="%sonata.media.admin.gallery_item.translation_domain%" label="gallery_item" show_in_dashboard="false" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
             <argument/>
-            <argument>%sonata.media.admin.gallery_has_media.entity%</argument>
-            <argument>%sonata.media.admin.gallery_has_media.controller%</argument>
+            <argument>%sonata.media.admin.gallery_item.entity%</argument>
+            <argument>%sonata.media.admin.gallery_item.controller%</argument>
             <call method="setTranslationDomain">
-                <argument>%sonata.media.admin.gallery_has_media.translation_domain%</argument>
+                <argument>%sonata.media.admin.gallery_item.translation_domain%</argument>
             </call>
         </service>
     </services>

--- a/Resources/config/doctrine_orm_admin.xml
+++ b/Resources/config/doctrine_orm_admin.xml
@@ -10,9 +10,9 @@
         <parameter key="sonata.media.admin.gallery.controller">SonataMediaBundle:GalleryAdmin</parameter>
         <parameter key="sonata.media.admin.gallery.translation_domain">%sonata.media.admin.media.translation_domain%</parameter>
         <!-- GALLERY HAS MEDIA -->
-        <parameter key="sonata.media.admin.gallery_has_media.class">Sonata\MediaBundle\Admin\GalleryHasMediaAdmin</parameter>
-        <parameter key="sonata.media.admin.gallery_has_media.controller">SonataAdminBundle:CRUD</parameter>
-        <parameter key="sonata.media.admin.gallery_has_media.translation_domain">%sonata.media.admin.media.translation_domain%</parameter>
+        <parameter key="sonata.media.admin.gallery_item.class">Sonata\MediaBundle\Admin\GalleryItemAdmin</parameter>
+        <parameter key="sonata.media.admin.gallery_item.controller">SonataAdminBundle:CRUD</parameter>
+        <parameter key="sonata.media.admin.gallery_item.translation_domain">%sonata.media.admin.media.translation_domain%</parameter>
     </parameters>
     <services>
         <service id="sonata.media.admin.media" class="%sonata.media.admin.media.class%">
@@ -56,13 +56,13 @@
                 </argument>
             </call>
         </service>
-        <service id="sonata.media.admin.gallery_has_media" class="%sonata.media.admin.gallery_has_media.class%">
-            <tag name="sonata.admin" manager_type="orm" show_in_dashboard="false" group="sonata_media" label_catalogue="%sonata.media.admin.gallery_has_media.translation_domain%" label="gallery_has_media" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
+        <service id="sonata.media.admin.gallery_item" class="%sonata.media.admin.gallery_item.class%">
+            <tag name="sonata.admin" manager_type="orm" show_in_dashboard="false" group="sonata_media" label_catalogue="%sonata.media.admin.gallery_item.translation_domain%" label="gallery_item" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
             <argument/>
-            <argument>%sonata.media.admin.gallery_has_media.entity%</argument>
-            <argument>%sonata.media.admin.gallery_has_media.controller%</argument>
+            <argument>%sonata.media.admin.gallery_item.entity%</argument>
+            <argument>%sonata.media.admin.gallery_item.controller%</argument>
             <call method="setTranslationDomain">
-                <argument>%sonata.media.admin.gallery_has_media.translation_domain%</argument>
+                <argument>%sonata.media.admin.gallery_item.translation_domain%</argument>
             </call>
         </service>
     </services>

--- a/Resources/config/doctrine_phpcr_admin.xml
+++ b/Resources/config/doctrine_phpcr_admin.xml
@@ -10,9 +10,9 @@
         <parameter key="sonata.media.admin.gallery.controller">SonataMediaBundle:GalleryAdmin</parameter>
         <parameter key="sonata.media.admin.gallery.translation_domain">%sonata.media.admin.media.translation_domain%</parameter>
         <!-- GALLERY HAS MEDIA -->
-        <parameter key="sonata.media.admin.gallery_has_media.class">Sonata\MediaBundle\Admin\GalleryHasMediaAdmin</parameter>
-        <parameter key="sonata.media.admin.gallery_has_media.controller">SonataAdminBundle:CRUD</parameter>
-        <parameter key="sonata.media.admin.gallery_has_media.translation_domain">%sonata.media.admin.media.translation_domain%</parameter>
+        <parameter key="sonata.media.admin.gallery_item.class">Sonata\MediaBundle\Admin\GalleryItemAdmin</parameter>
+        <parameter key="sonata.media.admin.gallery_item.controller">SonataAdminBundle:CRUD</parameter>
+        <parameter key="sonata.media.admin.gallery_item.translation_domain">%sonata.media.admin.media.translation_domain%</parameter>
     </parameters>
     <services>
         <service id="sonata.media.admin.media.manager" alias="sonata.admin.manager.doctrine_phpcr"/>
@@ -55,13 +55,13 @@
                 <argument type="service" id="sonata.admin.route.path_info_slashes"/>
             </call>
         </service>
-        <service id="sonata.media.admin.gallery_has_media" class="%sonata.media.admin.gallery_has_media.class%">
-            <tag name="sonata.admin" manager_type="doctrine_phpcr" show_in_dashboard="false" group="sonata_media" label_catalogue="%sonata.media.admin.gallery_has_media.translation_domain%" label="gallery_has_media" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
+        <service id="sonata.media.admin.gallery_item" class="%sonata.media.admin.gallery_item.class%">
+            <tag name="sonata.admin" manager_type="doctrine_phpcr" show_in_dashboard="false" group="sonata_media" label_catalogue="%sonata.media.admin.gallery_item.translation_domain%" label="gallery_item" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
             <argument/>
-            <argument>%sonata.media.admin.gallery_has_media.entity%</argument>
-            <argument>%sonata.media.admin.gallery_has_media.controller%</argument>
+            <argument>%sonata.media.admin.gallery_item.entity%</argument>
+            <argument>%sonata.media.admin.gallery_item.controller%</argument>
             <call method="setTranslationDomain">
-                <argument>%sonata.media.admin.gallery_has_media.translation_domain%</argument>
+                <argument>%sonata.media.admin.gallery_item.translation_domain%</argument>
             </call>
             <call method="setRouteBuilder">
                 <argument type="service" id="sonata.admin.route.path_info_slashes"/>

--- a/Resources/config/serializer/Model.GalleryItem.xml
+++ b/Resources/config/serializer/Model.GalleryItem.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer>
+    <class name="Sonata\MediaBundle\Model\GalleryItem" exclusion-policy="all" xml-root-name="gallery_item">
+        <property name="position" type="integer" expose="true" groups="sonata_api_read,sonata_api_write,sonata_search" since-version="1.0" xml-attribute="true"/>
+        <property name="enabled" type="boolean" expose="true" since-version="1.0" groups="sonata_api_read,sonata_api_write"/>
+        <property name="createdAt" type="DateTime" expose="true" since-version="1.0" groups="sonata_api_read,sonata_search"/>
+        <property name="updatedAt" type="DateTime" expose="true" since-version="1.0" groups="sonata_api_read,sonata_search"/>
+        <property name="gallery" serialized-name="gallery_id" type="sonata_media_gallery_id" expose="true" since-version="1.0" groups="sonata_api_read,sonata_search"/>
+        <property name="media" serialized-name="media_id" type="sonata_media_media_id" expose="true" since-version="1.0" groups="sonata_api_read,sonata_search"/>
+    </class>
+</serializer>

--- a/Resources/config/validation.xml
+++ b/Resources/config/validation.xml
@@ -25,7 +25,7 @@
     </class>
     <class name="Sonata\MediaBundle\Model\Gallery">
         <constraint name="Sonata\MediaBundle\Validator\Constraints\ValidMediaFormat"/>
-        <property name="galleryHasMedias">
+        <property name="galleryItems">
             <constraint name="Valid"/>
         </property>
         <property name="context">

--- a/Resources/doc/reference/advanced_configuration.rst
+++ b/Resources/doc/reference/advanced_configuration.rst
@@ -10,7 +10,7 @@ Full configuration options:
         class:
             media:              Application\Sonata\MediaBundle\Entity\Media
             gallery:            Application\Sonata\MediaBundle\Entity\Gallery
-            gallery_has_media:  Application\Sonata\MediaBundle\Entity\GalleryHasMedia
+            gallery_item:       Application\Sonata\MediaBundle\Entity\GalleryItem
             category:           Application\Sonata\ClassificationBundle\Entity\Category
 
         default_context: default

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -108,9 +108,9 @@ Doctrine PHPCR:
         sonata_media:
             # if you don't use default namespace configuration
             #class:
-            #    media: MyVendor\MediaBundle\Entity\Media
-            #    gallery: MyVendor\MediaBundle\Entity\Gallery
-            #    gallery_has_media: MyVendor\MediaBundle\Entity\GalleryHasMedia
+            #    media:        MyVendor\MediaBundle\Entity\Media
+            #    gallery:      MyVendor\MediaBundle\Entity\Gallery
+            #    gallery_item: MyVendor\MediaBundle\Entity\GalleryItem
             db_driver: doctrine_orm # or doctrine_mongodb, doctrine_phpcr it is mandatory to choose one here
             default_context: default # you need to set a context
             contexts:

--- a/Resources/doc/reference/troubleshooting.rst
+++ b/Resources/doc/reference/troubleshooting.rst
@@ -80,9 +80,9 @@ Finally your settings in your ``sonata_media`` parameters will look like this:
     sonata_media:
         # if you don't use default namespace configuration
         #class:
-        #    media: MyVendor\MediaBundle\Entity\Media
-        #    gallery: MyVendor\MediaBundle\Entity\Gallery
-        #    gallery_has_media: MyVendor\MediaBundle\Entity\GalleryHasMedia
+        #    media:        MyVendor\MediaBundle\Entity\Media
+        #    gallery:      MyVendor\MediaBundle\Entity\Gallery
+        #    gallery_item: MyVendor\MediaBundle\Entity\GalleryItem
         default_context: default
         db_driver: doctrine_orm # or doctrine_mongodb, doctrine_phpcr
         contexts:

--- a/Resources/translations/SonataMediaBundle.bg.xliff
+++ b/Resources/translations/SonataMediaBundle.bg.xliff
@@ -150,8 +150,8 @@
                 <source>form.label_default_format</source>
                 <target>Формат</target>
             </trans-unit>
-            <trans-unit id="form.label_gallery_has_medias">
-                <source>form.label_gallery_has_medias</source>
+            <trans-unit id="form.label_gallery_items">
+                <source>form.label_gallery_items</source>
                 <target>Медиа</target>
             </trans-unit>
             <trans-unit id="form.label_author_name">

--- a/Resources/translations/SonataMediaBundle.de.xliff
+++ b/Resources/translations/SonataMediaBundle.de.xliff
@@ -146,8 +146,8 @@
                 <source>form.label_default_format</source>
                 <target>Format</target>
             </trans-unit>
-            <trans-unit id="form.label_gallery_has_medias">
-                <source>form.label_gallery_has_medias</source>
+            <trans-unit id="form.label_gallery_items">
+                <source>form.label_gallery_items</source>
                 <target>Medium</target>
             </trans-unit>
             <trans-unit id="form.label_author_name">

--- a/Resources/translations/SonataMediaBundle.en.xliff
+++ b/Resources/translations/SonataMediaBundle.en.xliff
@@ -146,8 +146,8 @@
                 <source>form.label_default_format</source>
                 <target>Format</target>
             </trans-unit>
-            <trans-unit id="form.label_gallery_has_medias">
-                <source>form.label_gallery_has_medias</source>
+            <trans-unit id="form.label_gallery_items">
+                <source>form.label_gallery_items</source>
                 <target>Media</target>
             </trans-unit>
             <trans-unit id="form.label_author_name">

--- a/Resources/translations/SonataMediaBundle.es.xliff
+++ b/Resources/translations/SonataMediaBundle.es.xliff
@@ -150,8 +150,8 @@
                 <source>form.label_default_format</source>
                 <target>Formato</target>
             </trans-unit>
-            <trans-unit id="form.label_gallery_has_medias">
-                <source>form.label_gallery_has_medias</source>
+            <trans-unit id="form.label_gallery_items">
+                <source>form.label_gallery_items</source>
                 <target>Multimedias</target>
             </trans-unit>
             <trans-unit id="form.label_author_name">

--- a/Resources/translations/SonataMediaBundle.fa.xliff
+++ b/Resources/translations/SonataMediaBundle.fa.xliff
@@ -146,8 +146,8 @@
                 <source>form.label_default_format</source>
                 <target>فورمت</target>
             </trans-unit>
-            <trans-unit id="form.label_gallery_has_medias">
-                <source>form.label_gallery_has_medias</source>
+            <trans-unit id="form.label_gallery_items">
+                <source>form.label_gallery_items</source>
                 <target>رسانه</target>
             </trans-unit>
             <trans-unit id="form.label_author_name">

--- a/Resources/translations/SonataMediaBundle.fi.xliff
+++ b/Resources/translations/SonataMediaBundle.fi.xliff
@@ -146,8 +146,8 @@
                 <source>form.label_default_format</source>
                 <target>Muoto</target>
             </trans-unit>
-            <trans-unit id="form.label_gallery_has_medias">
-                <source>form.label_gallery_has_medias</source>
+            <trans-unit id="form.label_gallery_items">
+                <source>form.label_gallery_items</source>
                 <target>Media</target>
             </trans-unit>
             <trans-unit id="form.label_author_name">

--- a/Resources/translations/SonataMediaBundle.fr.xliff
+++ b/Resources/translations/SonataMediaBundle.fr.xliff
@@ -146,8 +146,8 @@
                 <source>form.label_default_format</source>
                 <target>Format</target>
             </trans-unit>
-            <trans-unit id="form.label_gallery_has_medias">
-                <source>form.label_gallery_has_medias</source>
+            <trans-unit id="form.label_gallery_items">
+                <source>form.label_gallery_items</source>
                 <target>Médias</target>
             </trans-unit>
             <trans-unit id="form.label_author_name">

--- a/Resources/translations/SonataMediaBundle.hu.xliff
+++ b/Resources/translations/SonataMediaBundle.hu.xliff
@@ -150,8 +150,8 @@
                 <source>form.label_default_format</source>
                 <target>Formátum</target>
             </trans-unit>
-            <trans-unit id="form.label_gallery_has_medias">
-                <source>form.label_gallery_has_medias</source>
+            <trans-unit id="form.label_gallery_items">
+                <source>form.label_gallery_items</source>
                 <target>Média</target>
             </trans-unit>
             <trans-unit id="form.label_author_name">

--- a/Resources/translations/SonataMediaBundle.it.xliff
+++ b/Resources/translations/SonataMediaBundle.it.xliff
@@ -146,8 +146,8 @@
                 <source>form.label_default_format</source>
                 <target>Formato</target>
             </trans-unit>
-            <trans-unit id="form.label_gallery_has_medias">
-                <source>form.label_gallery_has_medias</source>
+            <trans-unit id="form.label_gallery_items">
+                <source>form.label_gallery_items</source>
                 <target>Media</target>
             </trans-unit>
             <trans-unit id="form.label_author_name">

--- a/Resources/translations/SonataMediaBundle.ja.xliff
+++ b/Resources/translations/SonataMediaBundle.ja.xliff
@@ -126,8 +126,8 @@
                 <source>form.label_default_format</source>
                 <target>フォーマット</target>
             </trans-unit>
-            <trans-unit id="form.label_gallery_has_medias">
-                <source>form.label_gallery_has_medias</source>
+            <trans-unit id="form.label_gallery_items">
+                <source>form.label_gallery_items</source>
                 <target>メディア</target>
             </trans-unit>
             <trans-unit id="form.label_author_name">

--- a/Resources/translations/SonataMediaBundle.lt.xliff
+++ b/Resources/translations/SonataMediaBundle.lt.xliff
@@ -150,8 +150,8 @@
                 <source>form.label_default_format</source>
                 <target>Formatas</target>
             </trans-unit>
-            <trans-unit id="form.label_gallery_has_medias">
-                <source>form.label_gallery_has_medias</source>
+            <trans-unit id="form.label_gallery_items">
+                <source>form.label_gallery_items</source>
                 <target>Media</target>
             </trans-unit>
             <trans-unit id="form.label_author_name">

--- a/Resources/translations/SonataMediaBundle.nl.xliff
+++ b/Resources/translations/SonataMediaBundle.nl.xliff
@@ -146,8 +146,8 @@
                 <source>form.label_default_format</source>
                 <target>Formaat</target>
             </trans-unit>
-            <trans-unit id="form.label_gallery_has_medias">
-                <source>form.label_gallery_has_medias</source>
+            <trans-unit id="form.label_gallery_items">
+                <source>form.label_gallery_items</source>
                 <target>Media items</target>
             </trans-unit>
             <trans-unit id="form.label_author_name">

--- a/Resources/translations/SonataMediaBundle.pl.xliff
+++ b/Resources/translations/SonataMediaBundle.pl.xliff
@@ -150,8 +150,8 @@
                 <source>form.label_default_format</source>
                 <target>Format</target>
             </trans-unit>
-            <trans-unit id="form.label_gallery_has_medias">
-                <source>form.label_gallery_has_medias</source>
+            <trans-unit id="form.label_gallery_items">
+                <source>form.label_gallery_items</source>
                 <target>Media</target>
             </trans-unit>
             <trans-unit id="form.label_author_name">

--- a/Resources/translations/SonataMediaBundle.pt_BR.xliff
+++ b/Resources/translations/SonataMediaBundle.pt_BR.xliff
@@ -130,8 +130,8 @@
                 <source>form.label_default_format</source>
                 <target>Formato</target>
             </trans-unit>
-            <trans-unit id="form.label_gallery_has_medias">
-                <source>form.label_gallery_has_medias</source>
+            <trans-unit id="form.label_gallery_items">
+                <source>form.label_gallery_items</source>
                 <target>Mídias</target>
             </trans-unit>
             <trans-unit id="form.label_author_name">

--- a/Resources/translations/SonataMediaBundle.ro.xliff
+++ b/Resources/translations/SonataMediaBundle.ro.xliff
@@ -146,8 +146,8 @@
                 <source>form.label_default_format</source>
                 <target>Format</target>
             </trans-unit>
-            <trans-unit id="form.label_gallery_has_medias">
-                <source>form.label_gallery_has_medias</source>
+            <trans-unit id="form.label_gallery_items">
+                <source>form.label_gallery_items</source>
                 <target>Media</target>
             </trans-unit>
             <trans-unit id="form.label_author_name">

--- a/Resources/translations/SonataMediaBundle.ru.xliff
+++ b/Resources/translations/SonataMediaBundle.ru.xliff
@@ -150,8 +150,8 @@
                 <source>form.label_default_format</source>
                 <target>Формат</target>
             </trans-unit>
-            <trans-unit id="form.label_gallery_has_medias">
-                <source>form.label_gallery_has_medias</source>
+            <trans-unit id="form.label_gallery_items">
+                <source>form.label_gallery_items</source>
                 <target>Список медиа</target>
             </trans-unit>
             <trans-unit id="form.label_author_name">

--- a/Resources/translations/SonataMediaBundle.sl.xliff
+++ b/Resources/translations/SonataMediaBundle.sl.xliff
@@ -150,8 +150,8 @@
                 <source>form.label_default_format</source>
                 <target>Oblika</target>
             </trans-unit>
-            <trans-unit id="form.label_gallery_has_medias">
-                <source>form.label_gallery_has_medias</source>
+            <trans-unit id="form.label_gallery_items">
+                <source>form.label_gallery_items</source>
                 <target>Mediji</target>
             </trans-unit>
             <trans-unit id="form.label_author_name">

--- a/Resources/translations/SonataMediaBundle.uk.xliff
+++ b/Resources/translations/SonataMediaBundle.uk.xliff
@@ -126,8 +126,8 @@
                 <source>form.label_default_format</source>
                 <target>Формат</target>
             </trans-unit>
-            <trans-unit id="form.label_gallery_has_medias">
-                <source>form.label_gallery_has_medias</source>
+            <trans-unit id="form.label_gallery_items">
+                <source>form.label_gallery_items</source>
                 <target>Список медіа</target>
             </trans-unit>
             <trans-unit id="form.label_author_name">

--- a/Resources/views/Gallery/view.html.twig
+++ b/Resources/views/Gallery/view.html.twig
@@ -20,14 +20,14 @@ file that was distributed with this source code.
 <h1>{{ gallery.name }}</h1>
 
 <div class="sonata-media-gallery-media-list">
-    {% for galleryHasMedia in gallery.GalleryHasMedias %}
+    {% for galleryItem in gallery.GalleryItems %}
         <div class="media sonata-media-gallery-media-item">
-            <a class="pull-left sonata-media-gallery-media-item-link" href="{{ url('sonata_media_view', {'id': galleryHasMedia.media|sonata_urlsafeid }) }}">
-                {% thumbnail galleryHasMedia.media, gallery.defaultFormat with {'class': 'media-object'} %}
+            <a class="pull-left sonata-media-gallery-media-item-link" href="{{ url('sonata_media_view', {'id': galleryItem.media|sonata_urlsafeid }) }}">
+                {% thumbnail galleryItem.media, gallery.defaultFormat with {'class': 'media-object'} %}
             </a>
             <div class="media-body">
-                <h4 class="media-heading">{{ galleryHasMedia.media.name }}</h4>
-                <p>{{ galleryHasMedia.media.description|raw }}</p>
+                <h4 class="media-heading">{{ galleryItem.media.name }}</h4>
+                <p>{{ galleryItem.media.description|raw }}</p>
             </div>
         </div>
     {% endfor %}

--- a/SonataMediaBundle.php
+++ b/SonataMediaBundle.php
@@ -55,7 +55,7 @@ class SonataMediaBundle extends Bundle
             'sonata_media_api_form_media' => 'Sonata\MediaBundle\Form\Type\ApiMediaType',
             'sonata_media_api_form_doctrine_media' => 'Sonata\MediaBundle\Form\Type\ApiDoctrineMediaType',
             'sonata_media_api_form_gallery' => 'Sonata\MediaBundle\Form\Type\ApiGalleryType',
-            'sonata_media_api_form_gallery_has_media' => 'Sonata\MediaBundle\Form\Type\ApiGalleryHasMediaType',
+            'sonata_media_api_form_gallery_item' => 'Sonata\MediaBundle\Form\Type\ApiGalleryItemType',
         ));
     }
 }

--- a/Tests/Controller/Api/GalleryControllerTest.php
+++ b/Tests/Controller/Api/GalleryControllerTest.php
@@ -13,10 +13,10 @@ namespace Sonata\MediaBundle\Tests\Controller\Api;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Sonata\MediaBundle\Controller\Api\GalleryController;
-use Sonata\MediaBundle\Model\GalleryHasMedia;
+use Sonata\MediaBundle\Model\GalleryItem;
 use Symfony\Component\HttpFoundation\Request;
 
-class GalleryTest extends GalleryHasMedia
+class GalleryTest extends GalleryItem
 {
     private $id;
 
@@ -42,16 +42,23 @@ class GalleryControllerTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetGalleriesAction()
     {
-        $gManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $galleryManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
         $mediaManager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
         $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
 
-        $gManager->expects($this->once())->method('getPager')->will($this->returnValue(array()));
+        $galleryManager->expects($this->once())->method('getPager')->will($this->returnValue(array()));
 
-        $gController = new GalleryController($gManager, $mediaManager, $formFactory, 'test');
+        $gController = new GalleryController($galleryManager, $mediaManager, $formFactory, 'test');
 
         $params = $this->getMock('FOS\RestBundle\Request\ParamFetcherInterface');
-        $params->expects($this->once())->method('all')->will($this->returnValue(array('page' => 1, 'count' => 10, 'orderBy' => array('id' => 'ASC'))));
+        $params
+            ->expects($this->once())
+            ->method('all')
+            ->will($this->returnValue(array(
+                'page' => 1,
+                'count' => 10,
+                'orderBy' => array('id' => 'ASC'),
+        )));
         $params->expects($this->exactly(3))->method('get');
 
         $this->assertSame(array(), $gController->getGalleriesAction($params));
@@ -59,14 +66,14 @@ class GalleryControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetGalleryAction()
     {
-        $gManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $galleryManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
         $mediaManager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
         $gallery = $this->getMock('Sonata\MediaBundle\Model\GalleryInterface');
         $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
 
-        $gManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
+        $galleryManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
 
-        $gController = new GalleryController($gManager, $mediaManager, $formFactory, 'test');
+        $gController = new GalleryController($galleryManager, $mediaManager, $formFactory, 'test');
 
         $this->assertSame($gallery, $gController->getGalleryAction(1));
     }
@@ -77,34 +84,34 @@ class GalleryControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetGalleryNotFoundAction()
     {
-        $gManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $galleryManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
         $mediaManager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
 
         $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
 
-        $gManager->expects($this->once())->method('findOneBy');
+        $galleryManager->expects($this->once())->method('findOneBy');
 
-        $gController = new GalleryController($gManager, $mediaManager, $formFactory, 'test');
+        $gController = new GalleryController($galleryManager, $mediaManager, $formFactory, 'test');
 
         $gController->getGalleryAction(42);
     }
 
-    public function testGetGalleryGalleryhasmediasAction()
+    public function testGetGalleryGalleryItemsAction()
     {
-        $gManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
-        $galleryHasMedia = $this->getMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
+        $galleryManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $galleryItem = $this->getMock('Sonata\MediaBundle\Model\GalleryItemInterface');
         $gallery = $this->getMock('Sonata\MediaBundle\Model\GalleryInterface');
         $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
 
-        $gallery->expects($this->once())->method('getGalleryHasMedias')->will($this->returnValue(array($galleryHasMedia)));
+        $gallery->expects($this->once())->method('getGalleryItems')->will($this->returnValue(array($galleryItem)));
 
-        $gManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
+        $galleryManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
 
         $mediaManager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
 
-        $gController = new GalleryController($gManager, $mediaManager, $formFactory, 'test');
+        $gController = new GalleryController($galleryManager, $mediaManager, $formFactory, 'test');
 
-        $this->assertSame(array($galleryHasMedia), $gController->getGalleryGalleryhasmediasAction(1));
+        $this->assertSame(array($galleryItem), $gController->getGalleryGalleryItemAction(1));
     }
 
     public function testGetGalleryMediaAction()
@@ -112,34 +119,34 @@ class GalleryControllerTest extends \PHPUnit_Framework_TestCase
         $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
         $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
 
-        $galleryHasMedia = $this->getMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
-        $galleryHasMedia->expects($this->once())->method('getMedia')->will($this->returnValue($media));
+        $galleryItem = $this->getMock('Sonata\MediaBundle\Model\GalleryItemInterface');
+        $galleryItem->expects($this->once())->method('getMedia')->will($this->returnValue($media));
 
         $gallery = $this->getMock('Sonata\MediaBundle\Model\GalleryInterface');
-        $gallery->expects($this->once())->method('getGalleryHasMedias')->will($this->returnValue(array($galleryHasMedia)));
+        $gallery->expects($this->once())->method('getGalleryItems')->will($this->returnValue(array($galleryItem)));
 
-        $gManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
-        $gManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
+        $galleryManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $galleryManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
 
         $mediaManager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
 
-        $gController = new GalleryController($gManager, $mediaManager, $formFactory, 'test');
+        $gController = new GalleryController($galleryManager, $mediaManager, $formFactory, 'test');
 
         $this->assertSame(array($media), $gController->getGalleryMediasAction(1));
     }
 
-    public function testPostGalleryMediaGalleryhasmediaAction()
+    public function testPostGalleryMediaGalleryItemAction()
     {
         $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
 
         $media2 = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
         $media2->expects($this->any())->method('getId')->will($this->returnValue(1));
 
-        $galleryHasMedia = $this->getMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
-        $galleryHasMedia->expects($this->once())->method('getMedia')->will($this->returnValue($media2));
+        $galleryItem = $this->getMock('Sonata\MediaBundle\Model\GalleryItemInterface');
+        $galleryItem->expects($this->once())->method('getMedia')->will($this->returnValue($media2));
 
         $gallery = $this->getMock('Sonata\MediaBundle\Model\GalleryInterface');
-        $gallery->expects($this->once())->method('getGalleryHasMedias')->will($this->returnValue(array($galleryHasMedia)));
+        $gallery->expects($this->once())->method('getGalleryItems')->will($this->returnValue(array($galleryItem)));
 
         $galleryManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
         $galleryManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
@@ -150,28 +157,33 @@ class GalleryControllerTest extends \PHPUnit_Framework_TestCase
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
-        $form->expects($this->once())->method('getData')->will($this->returnValue($galleryHasMedia));
+        $form->expects($this->once())->method('getData')->will($this->returnValue($galleryItem));
 
         $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
-        $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, 'Sonata\MediaBundle\Tests\Controller\Api\GalleryTest');
-        $view = $galleryController->postGalleryMediaGalleryhasmediaAction(1, 2, new Request());
+        $galleryController = new GalleryController(
+            $galleryManager,
+            $mediaManager,
+            $formFactory,
+            'Sonata\MediaBundle\Tests\Controller\Api\GalleryTest'
+        );
+        $view = $galleryController->postGalleryMediaGalleryItemAction(1, 2, new Request());
 
         $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
         $this->assertSame(200, $view->getStatusCode(), 'Should return 200');
     }
 
-    public function testPostGalleryMediaGalleryhasmediaInvalidAction()
+    public function testPostGalleryMediaGalleryItemInvalidAction()
     {
         $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
         $media->expects($this->any())->method('getId')->will($this->returnValue(1));
 
-        $galleryHasMedia = $this->getMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
-        $galleryHasMedia->expects($this->once())->method('getMedia')->will($this->returnValue($media));
+        $galleryItem = $this->getMock('Sonata\MediaBundle\Model\GalleryItemInterface');
+        $galleryItem->expects($this->once())->method('getMedia')->will($this->returnValue($media));
 
         $gallery = $this->getMock('Sonata\MediaBundle\Model\GalleryInterface');
-        $gallery->expects($this->once())->method('getGalleryHasMedias')->will($this->returnValue(array($galleryHasMedia)));
+        $gallery->expects($this->once())->method('getGalleryItems')->will($this->returnValue(array($galleryItem)));
 
         $galleryManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
         $galleryManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
@@ -181,23 +193,28 @@ class GalleryControllerTest extends \PHPUnit_Framework_TestCase
 
         $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
 
-        $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, 'Sonata\MediaBundle\Tests\Controller\Api\GalleryTest');
-        $view = $galleryController->postGalleryMediaGalleryhasmediaAction(1, 1, new Request());
+        $galleryController = new GalleryController(
+            $galleryManager,
+            $mediaManager,
+            $formFactory,
+            'Sonata\MediaBundle\Tests\Controller\Api\GalleryTest'
+        );
+        $view = $galleryController->postGalleryMediaGalleryItemAction(1, 1, new Request());
 
         $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
         $this->assertSame(400, $view->getStatusCode(), 'Should return 400');
     }
 
-    public function testPutGalleryMediaGalleryhasmediaAction()
+    public function testPutGalleryMediaGalleryItemAction()
     {
         $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
         $media->expects($this->any())->method('getId')->will($this->returnValue(1));
 
-        $galleryHasMedia = $this->getMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
-        $galleryHasMedia->expects($this->once())->method('getMedia')->will($this->returnValue($media));
+        $galleryItem = $this->getMock('Sonata\MediaBundle\Model\GalleryItemInterface');
+        $galleryItem->expects($this->once())->method('getMedia')->will($this->returnValue($media));
 
         $gallery = $this->getMock('Sonata\MediaBundle\Model\GalleryInterface');
-        $gallery->expects($this->once())->method('getGalleryHasMedias')->will($this->returnValue(array($galleryHasMedia)));
+        $gallery->expects($this->once())->method('getGalleryItems')->will($this->returnValue(array($galleryItem)));
 
         $galleryManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
         $galleryManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
@@ -208,28 +225,33 @@ class GalleryControllerTest extends \PHPUnit_Framework_TestCase
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
-        $form->expects($this->once())->method('getData')->will($this->returnValue($galleryHasMedia));
+        $form->expects($this->once())->method('getData')->will($this->returnValue($galleryItem));
 
         $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
-        $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, 'Sonata\MediaBundle\Tests\Controller\Api\GalleryTest');
-        $view = $galleryController->putGalleryMediaGalleryhasmediaAction(1, 1, new Request());
+        $galleryController = new GalleryController(
+            $galleryManager,
+            $mediaManager,
+            $formFactory,
+            'Sonata\MediaBundle\Tests\Controller\Api\GalleryTest'
+        );
+        $view = $galleryController->putGalleryMediaGalleryItemAction(1, 1, new Request());
 
         $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
         $this->assertSame(200, $view->getStatusCode(), 'Should return 200');
     }
 
-    public function testPutGalleryMediaGalleryhasmediaInvalidAction()
+    public function testPutGalleryMediaGalleryItemInvalidAction()
     {
         $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
         $media->expects($this->any())->method('getId')->will($this->returnValue(1));
 
-        $galleryHasMedia = $this->getMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
-        $galleryHasMedia->expects($this->once())->method('getMedia')->will($this->returnValue($media));
+        $galleryItem = $this->getMock('Sonata\MediaBundle\Model\GalleryItemInterface');
+        $galleryItem->expects($this->once())->method('getMedia')->will($this->returnValue($media));
 
         $gallery = $this->getMock('Sonata\MediaBundle\Model\GalleryInterface');
-        $gallery->expects($this->once())->method('getGalleryHasMedias')->will($this->returnValue(array($galleryHasMedia)));
+        $gallery->expects($this->once())->method('getGalleryItems')->will($this->returnValue(array($galleryItem)));
 
         $galleryManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
         $galleryManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
@@ -244,22 +266,30 @@ class GalleryControllerTest extends \PHPUnit_Framework_TestCase
         $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
-        $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, 'Sonata\MediaBundle\Tests\Controller\Api\GalleryTest');
-        $view = $galleryController->putGalleryMediaGalleryhasmediaAction(1, 1, new Request());
+        $galleryController = new GalleryController(
+            $galleryManager,
+            $mediaManager,
+            $formFactory,
+            'Sonata\MediaBundle\Tests\Controller\Api\GalleryTest'
+        );
+        $view = $galleryController->putGalleryMediaGalleryItemAction(1, 1, new Request());
 
         $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
     }
 
-    public function testDeleteGalleryMediaGalleryhasmediaAction()
+    public function testDeleteGalleryMediaGalleryItemAction()
     {
         $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
         $media->expects($this->any())->method('getId')->will($this->returnValue(1));
 
-        $galleryHasMedia = $this->getMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
-        $galleryHasMedia->expects($this->once())->method('getMedia')->will($this->returnValue($media));
+        $galleryItem = $this->getMock('Sonata\MediaBundle\Model\GalleryItemInterface');
+        $galleryItem->expects($this->once())->method('getMedia')->will($this->returnValue($media));
 
         $gallery = $this->getMock('Sonata\MediaBundle\Model\GalleryInterface');
-        $gallery->expects($this->any())->method('getGalleryHasMedias')->will($this->returnValue(new ArrayCollection(array($galleryHasMedia))));
+        $gallery
+            ->expects($this->any())
+            ->method('getGalleryItems')
+            ->will($this->returnValue(new ArrayCollection(array($galleryItem))));
 
         $galleryManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
         $galleryManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
@@ -269,24 +299,32 @@ class GalleryControllerTest extends \PHPUnit_Framework_TestCase
 
         $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
 
-        $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, 'Sonata\MediaBundle\Tests\Controller\Api\GalleryTest');
-        $view = $galleryController->deleteGalleryMediaGalleryhasmediaAction(1, 1);
+        $galleryController = new GalleryController(
+            $galleryManager,
+            $mediaManager,
+            $formFactory,
+            'Sonata\MediaBundle\Tests\Controller\Api\GalleryTest'
+        );
+        $view = $galleryController->deleteGalleryMediaGalleryItemAction(1, 1);
 
         $this->assertSame(array('deleted' => true), $view);
     }
 
-    public function testDeleteGalleryMediaGalleryhasmediaInvalidAction()
+    public function testDeleteGalleryMediaGalleryItemInvalidAction()
     {
         $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
 
         $media2 = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
         $media2->expects($this->any())->method('getId')->will($this->returnValue(2));
 
-        $galleryHasMedia = $this->getMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
-        $galleryHasMedia->expects($this->once())->method('getMedia')->will($this->returnValue($media2));
+        $galleryItem = $this->getMock('Sonata\MediaBundle\Model\GalleryItemInterface');
+        $galleryItem->expects($this->once())->method('getMedia')->will($this->returnValue($media2));
 
         $gallery = $this->getMock('Sonata\MediaBundle\Model\GalleryInterface');
-        $gallery->expects($this->any())->method('getGalleryHasMedias')->will($this->returnValue(new ArrayCollection(array($galleryHasMedia))));
+        $gallery
+            ->expects($this->any())
+            ->method('getGalleryItems')
+            ->will($this->returnValue(new ArrayCollection(array($galleryItem))));
 
         $galleryManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
         $galleryManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
@@ -296,8 +334,13 @@ class GalleryControllerTest extends \PHPUnit_Framework_TestCase
 
         $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
 
-        $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, 'Sonata\MediaBundle\Tests\Controller\Api\GalleryTest');
-        $view = $galleryController->deleteGalleryMediaGalleryhasmediaAction(1, 1);
+        $galleryController = new GalleryController(
+            $galleryManager,
+            $mediaManager,
+            $formFactory,
+            'Sonata\MediaBundle\Tests\Controller\Api\GalleryTest'
+        );
+        $view = $galleryController->deleteGalleryMediaGalleryItemAction(1, 1);
 
         $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
         $this->assertSame(400, $view->getStatusCode(), 'Should return 400');

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -1,0 +1,6 @@
+UPGRADE FROM 2.x to 3.0
+=======================
+
+### Dependencies
+
+You will need to follow the dependencies upgrade instructions.

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -18,3 +18,6 @@ If you have implemented a custom model, you must adapt the signature of the foll
  * `GalleryHasMediaInterface::getId`
  * `GalleryInterface::getId`
  
+## Renamed GalleryHasMedia to GalleryItem
+
+All Actions, Controllers, Interfaces and anything related to this is renamed accordingly.


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #828 

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Changed
- Renamed `GalleryHasMedia` to `GalleryItem` and all controllers, interfaces and actions accordingly
- Renamed `setGalleryHasMedias` to `setGalleryItems` in `Gallery`
- Renamed `getGalleryHasMedias` to `getGalleryItems` in `Gallery`
- Renamed `addGalleryHasMedias` to `addGalleryItem` in `Gallery`
- Renamed `$galleryHasMedias` to `$galleryItems` in `Gallery`
- Renamed `GalleryHasMediaAdmin` to `GalleryItemAdmin`
- Renamed `$galleryHasMediaClass` to `$galleryItemClass` in `GalleryController`
- Renamed `getGalleryGaleryhasmediasAction` to `getGalleryGalleryItemAction` in `GalleryController`
- Renamed `postGalleryMediaGalleryhasmediaAction` to `postGalleryMediaGalleryItemAction` in `GalleryController`
- Renamed `handleWriteGalleryhasmedia` to `handleWriteGalleryItem` in `GalleryController`
- Renamed `putGalleryMediaGalleryhasmediaAction` to `putGalleryMediaGalleryItemAction` in `GalleryController`
- Renamed `deleteGalleryMediaGalleryhasmediaAction` to `deleteGalleryMediaGalleryItemAction` in `GalleryController`
- Changed route name from `sonata_media_api_form_gallery_has_media ` to `sonata_media_api_form_gallery_item`
- Renamed `GalleryHasMediaInterface` to `GalleryItemInterface`
- Renamed config key from `gallery_has_media` to `gallery_item` under `sonata_media.class`
- Renamed `BaseGalleryHasMedia` to `BaseGalleryItem`
- Renamed `ApiGalleryHasMediaType` to `ApiGalleryItemType`
- Changed `GalleryInterface` and renamed `setGalleryHasMedias`, `getGalleryHasMedias` and `addGalleryHasMedias` to `setGalleryItems`, `getGalleryItems` and `addGalleryItem`
- Renamed `reorderGalleryHasMedia` to `reorderGalleryItems` in `BaseGallery`
- Renamed `BaseGalleryHasMediaRepository` to `BaseGalleryItemRepository`
- Renamed `GalleryHasMediaRepository` to `GalleryItemRepository`
- Renamed `form.type` alias from `sonata_media_api_form_gallery_has_media` to `sonata_media_api_form_gallery_item`
- Renamed PHP files, skeletons and schema XML's accordingly to their class/entity names
- Renamed `serializer/Model.GalleryHasMedia.xml` to `serializer/Model.GalleryItem.xml`
- Renamed `translation keys from `form.label_gallery_has_medias` to `form.label.gallery_items`
- Changed `Resources/views/Gallery/view.html.twig`
```

### Subject

This change is to huge to keep it BC, so i will schedule this for the next major release.

@sonata-project/contributors please review this change, thank you!