### PR TITLE
Make the documentation parseable by sphinx 1.3.5

### DIFF
--- a/Resources/doc/reference/advanced_configuration.rst
+++ b/Resources/doc/reference/advanced_configuration.rst
@@ -71,7 +71,7 @@ Full configuration options:
 
         filesystem:
             local:
-                directory:  %kernel.root_dir%/../web/uploads/media
+                directory:  "%kernel.root_dir%/../web/uploads/media"
                 create:     false
 
             ftp:

--- a/Resources/doc/reference/amazon_s3.rst
+++ b/Resources/doc/reference/amazon_s3.rst
@@ -17,7 +17,7 @@ This is a sample config file to enable amazon S3 as a filesystem & provider:
     sonata_media:
         cdn:
             server:
-                path: http://%s3_bucket_name%.s3-website-%s3_region%.amazonaws.com
+                path: "http://%s3_bucket_name%.s3-website-%s3_region%.amazonaws.com"
 
         providers:
             image:
@@ -25,7 +25,7 @@ This is a sample config file to enable amazon S3 as a filesystem & provider:
 
         filesystem:
             s3:
-                bucket:    %s3_bucket_name%
-                accessKey: %s3_access_key%
-                secretKey: %s3_secret_key%
-                region:    %s3_region%
+                bucket:    "%s3_bucket_name%"
+                accessKey: "%s3_access_key%"
+                secretKey: "%s3_secret_key%"
+                region:    "%s3_region%"

--- a/Resources/doc/reference/api.rst
+++ b/Resources/doc/reference/api.rst
@@ -70,7 +70,7 @@ This would look like this for the cURL call:
 
 And like this for the request body:
 
-.. code-block:: http
+::
 
     ------WebKitFormBoundaryFhX9k2FPT3sQos00
     Content-Disposition: form-data; name="name"

--- a/Resources/doc/reference/creating_a_provider_class.rst
+++ b/Resources/doc/reference/creating_a_provider_class.rst
@@ -310,7 +310,7 @@ The thumbnail template is common to all media and it is quite simple:
 
 .. code-block:: html+jinja
 
-    <img {% for name, value in options %}{{name}}="{{value}}" {% endfor %} />
+    <img {% for name, value in options %}{{ name ~ '="' ~ value ~ '"' }} {% endfor %} />
 
 The media template and media helper are a bit more tricky. Each provider might
 provide a rich set of options to embed the media. The

--- a/Resources/doc/reference/form.rst
+++ b/Resources/doc/reference/form.rst
@@ -46,8 +46,8 @@ You also need to add a new template for the form component:
 .. code-block:: yaml
 
     twig:
-        debug:            %kernel.debug%
-        strict_variables: %kernel.debug%
+        debug:            "%kernel.debug%"
+        strict_variables: "%kernel.debug%"
 
         form:
             resources:

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -113,7 +113,7 @@ Doctrine PHPCR:
 
         filesystem:
             local:
-                directory:  %kernel.root_dir%/../web/uploads/media
+                directory:  "%kernel.root_dir%/../web/uploads/media"
                 create:     false
 
 .. note::

--- a/Resources/doc/reference/troubleshooting.rst
+++ b/Resources/doc/reference/troubleshooting.rst
@@ -104,5 +104,5 @@ Finally your settings in your sonataMedia parameters will look like this:
 
         filesystem:
             local:
-                directory:  %kernel.root_dir%/../web/uploads/media
+                directory:  "%kernel.root_dir%/../web/uploads/media"
                 create:     false

--- a/Tests/Metadata/AmazonMetadataBuilderTest.php
+++ b/Tests/Metadata/AmazonMetadataBuilderTest.php
@@ -52,7 +52,7 @@ class AmazonMetadataBuilderTest extends \PHPUnit_Framework_TestCase
             array(array('cache_control' => 'max-age=86400'), array('headers' => array('Cache-Control' => 'max-age=86400'), 'contentType' => 'image/png')),
             array(array('encryption' => 'aes256'), array('encryption' => 'AES256', 'contentType' => 'image/png')),
             array(array('meta' => array('key' => 'value')), array('meta' => array('key' => 'value'), 'contentType' => 'image/png')),
-            array(array('acl' => 'public','storage' => 'standard','cache_control' => 'max-age=86400','encryption' => 'aes256','meta' => array('key' => 'value')), array('acl' => AmazonS3::ACL_PUBLIC, 'contentType' => 'image/png','storage' => AmazonS3::STORAGE_STANDARD,'headers' => array('Cache-Control' => 'max-age=86400'),'encryption' => 'AES256','meta' => array('key' => 'value'))),
+            array(array('acl' => 'public', 'storage' => 'standard', 'cache_control' => 'max-age=86400', 'encryption' => 'aes256', 'meta' => array('key' => 'value')), array('acl' => AmazonS3::ACL_PUBLIC, 'contentType' => 'image/png', 'storage' => AmazonS3::STORAGE_STANDARD, 'headers' => array('Cache-Control' => 'max-age=86400'), 'encryption' => 'AES256', 'meta' => array('key' => 'value'))),
         );
     }
 }


### PR DESCRIPTION
- quote meta characters in YAML
- remove highlighting for http block
  Http does not seem to be recognized at all. If it is, there is no color
  in the output, so…
- use another syntax for twig snippet

Conflicts:
	Resources/doc/reference/installation.rst