### PR TITLE
composer require should not have the flag --no-update 

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -25,7 +25,7 @@ Retrieve the bundle with composer:
 
 .. code-block:: bash
 
-    $ php composer.phar require sonata-project/media-bundle --no-update
+    $ php composer.phar require sonata-project/media-bundle
 
 Register these bundles in your AppKernel:
 


### PR DESCRIPTION
composer require should not have the flag --no-update  when only one package is required.

Would introduce some confusion