### PR TITLE
Fix media access times increment in session variable

### DIFF
--- a/Resources/doc/reference/security.rst
+++ b/Resources/doc/reference/security.rst
@@ -112,7 +112,7 @@ Let's create the following strategy : a media can be downloaded only once per se
                 return false;
             }
 
-            $this->getSession()->set($this->sessionKey, $times++);
+            $this->getSession()->set($this->sessionKey, $times + 1);
 
             return true;
         }


### PR DESCRIPTION
Pre-increment should be used otherwise the $times session variable never increases.