### PR TITLE
migrate ErrorElement Validator

### DIFF
--- a/Block/GalleryBlockService.php
+++ b/Block/GalleryBlockService.php
@@ -12,11 +12,11 @@
 namespace Sonata\MediaBundle\Block;
 
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\AdminBundle\Validator\ErrorElement;
 use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\CoreBundle\Model\ManagerInterface;
+use Sonata\CoreBundle\Validator\ErrorElement;
 use Sonata\MediaBundle\Model\GalleryInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/Provider/BaseProvider.php
+++ b/Provider/BaseProvider.php
@@ -12,8 +12,8 @@
 namespace Sonata\MediaBundle\Provider;
 
 use Gaufrette\Filesystem;
-use Sonata\AdminBundle\Validator\ErrorElement;
 use Sonata\CoreBundle\Model\Metadata;
+use Sonata\CoreBundle\Validator\ErrorElement;
 use Sonata\MediaBundle\CDN\CDNInterface;
 use Sonata\MediaBundle\Generator\GeneratorInterface;
 use Sonata\MediaBundle\Model\MediaInterface;

--- a/Provider/FileProvider.php
+++ b/Provider/FileProvider.php
@@ -13,8 +13,8 @@ namespace Sonata\MediaBundle\Provider;
 
 use Gaufrette\Filesystem;
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\AdminBundle\Validator\ErrorElement;
 use Sonata\CoreBundle\Model\Metadata;
+use Sonata\CoreBundle\Validator\ErrorElement;
 use Sonata\MediaBundle\CDN\CDNInterface;
 use Sonata\MediaBundle\Generator\GeneratorInterface;
 use Sonata\MediaBundle\Metadata\MetadataBuilderInterface;

--- a/Provider/MediaProviderInterface.php
+++ b/Provider/MediaProviderInterface.php
@@ -13,8 +13,8 @@ namespace Sonata\MediaBundle\Provider;
 
 use Gaufrette\Filesystem;
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\AdminBundle\Validator\ErrorElement;
 use Sonata\CoreBundle\Model\MetadataInterface;
+use Sonata\CoreBundle\Validator\ErrorElement;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Resizer\ResizerInterface;
 use Symfony\Component\Form\FormBuilder;

--- a/Provider/Pool.php
+++ b/Provider/Pool.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\MediaBundle\Provider;
 
-use Sonata\AdminBundle\Validator\ErrorElement;
+use Sonata\CoreBundle\Validator\ErrorElement;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Security\DownloadStrategyInterface;
 
@@ -247,8 +247,8 @@ class Pool
     }
 
     /**
-     * @param \Sonata\AdminBundle\Validator\ErrorElement $errorElement
-     * @param \Sonata\MediaBundle\Model\MediaInterface   $media
+     * @param \Sonata\CoreBundle\Validator\ErrorElement $errorElement
+     * @param \Sonata\MediaBundle\Model\MediaInterface  $media
      */
     public function validate(ErrorElement $errorElement, MediaInterface $media)
     {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "symfony/symfony": "~2.3",
-        "sonata-project/core-bundle": "~2.3",
+        "sonata-project/core-bundle": "^2.3.10",
         "sonata-project/notification-bundle": "~2.2",
         "sonata-project/easy-extends-bundle": "~2.1",
         "sonata-project/doctrine-extensions": "~1.0",


### PR DESCRIPTION
Fix issue with wrong validator in the Pool

````
Catchable Fatal Error: Argument 1 passed to Sonata\MediaBundle\Provider\Pool::validate() must be an instance of Sonata\AdminBundle\Validator\ErrorElement, instance of Sonata\CoreBundle\Validator\ErrorElement given
````

See: https://github.com/sonata-project/SonataMediaBundle/pull/916#issuecomment-190985720