### PR TITLE
Update gaufrette.xml for symfony 3

### DIFF
--- a/Resources/config/gaufrette.xml
+++ b/Resources/config/gaufrette.xml
@@ -13,7 +13,8 @@
     <services>
         <service id="sonata.media.adapter.filesystem.local" class="Sonata\MediaBundle\Filesystem\Local" />
         <service id="sonata.media.adapter.filesystem.ftp"   class="Gaufrette\Adapter\Ftp" />
-        <service id="sonata.media.adapter.service.s3"       class="Aws\S3\S3Client" factory-class="Aws\S3\S3Client" factory-method="factory">
+        <service id="sonata.media.adapter.service.s3"       class="Aws\S3\S3Client">
+            <factory class="Aws\S3\S3Client" method="factory" />
             <argument type="collection" />
         </service>
 
@@ -45,9 +46,8 @@
             <argument/>
         </service>
 
-        <service id="sonata.media.adapter.filesystem.opencloud.objectstore" class="OpenCloud\ObjectSource\Service"
-                 factory-service="sonata.media.adapter.filesystem.opencloud.connection"
-                 factory-method="ObjectStore">
+        <service id="sonata.media.adapter.filesystem.opencloud.objectstore" class="OpenCloud\ObjectSource\Service">
+            <factory service="sonata.media.adapter.filesystem.opencloud.connection" method="ObjectStore" />
             <argument/>
             <argument/>
         </service>


### PR DESCRIPTION
fix for:

[Symfony\Component\DependencyInjection\Exception\InvalidArgumentException]                                                                                      
  Unable to parse file ".../vendor/sonata-project/media-bundle/DependencyInjection/../Resources/config/gaufrette.xml".                                                                                                                                                                
                                                                                                                                                                                                                                
  [InvalidArgumentException]                                                                                                                                                                                                    
  [ERROR 1866] Element '{http://symfony.com/schema/dic/services}service', attribute 'factory-class': The attribute 'factory-class' is not allowed. (in ... - line 16, column 0)      
  [ERROR 1866] Element '{http://symfony.com/schema/dic/services}service', attribute 'factory-method': The attribute 'factory-method' is not allowed. (in ... - line 16, column 0)    
  [ERROR 1866] Element '{http://symfony.com/schema/dic/services}service', attribute 'factory-service': The attribute 'factory-service' is not allowed. (in ... - line 50, column 0)  
  [ERROR 1866] Element '{http://symfony.com/schema/dic/services}service', attribute 'factory-method': The attribute 'factory-method' is not allowed. (in ... - line 50, column 0)  