### PR TITLE
Use configured default context for ApiMediaType

### DIFF
--- a/Form/Type/ApiMediaType.php
+++ b/Form/Type/ApiMediaType.php
@@ -53,6 +53,7 @@ class ApiMediaType extends AbstractType
     {
         $builder->addModelTransformer(new ProviderDataTransformer($this->mediaPool, $this->class, array(
             'empty_on_new' => false,
+            'context'      => $options['context'],
         )), true);
 
         $provider = $this->mediaPool->getProvider($options['provider_name']);
@@ -76,7 +77,7 @@ class ApiMediaType extends AbstractType
     {
         $resolver->setDefaults(array(
             'provider_name' => 'sonata.media.provider.image',
-            'context'       => 'api',
+            'context'       => $this->mediaPool->getDefaultContext(),
         ));
     }
 

--- a/Tests/Form/Type/ApiMediaTypeTest.php
+++ b/Tests/Form/Type/ApiMediaTypeTest.php
@@ -33,6 +33,6 @@ class ApiMediaTypeTest extends \PHPUnit_Framework_TestCase
         $builder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
         $builder->expects($this->once())->method('addModelTransformer');
 
-        $type->buildForm($builder, array('provider_name' => 'sonata.media.provider.image'));
+        $type->buildForm($builder, array('provider_name' => 'sonata.media.provider.image', 'context' => 'default'));
     }
 }


### PR DESCRIPTION
`ApiMediaType` should really use the default media context, rather than a hardcoded value. Passing the context into the `ProviderDataTransformer` also ensures the context is set in the Media object.