### PR TITLE
[Doc] Fixed syntax typo in CKEditor configuration

### DIFF
--- a/Resources/doc/reference/extra.rst
+++ b/Resources/doc/reference/extra.rst
@@ -137,18 +137,19 @@ Now, just create a field with ckeditor as type and your done:
                 'mytext',
                 'ckeditor',
                 array(
-                'config' => array(
-                    'toolbar' => array(
-                        array(
-                            'name' => 'links',
-                            'items' => array('Link','Unlink'),
-                        ),
-                        array(
-                            'name' => 'insert',
-                            'items' => array('Image'),
-                        ),
+                    'config' => array(
+                        'toolbar' => array(
+                            array(
+                                'name' => 'links',
+                                'items' => array('Link', 'Unlink'),
+                            ),
+                            array(
+                                'name' => 'insert',
+                                'items' => array('Image'),
+                            ),
+                        )
                     )
-                );
+                )
             );
     }
 


### PR DESCRIPTION
Syntax fix for ckeditor formMapper example.