### PR TITLE
Changed factoring-definition in DI to Symfony > 2.6 compatible syntax

### DIFF
--- a/Resources/config/gaufrette.xml
+++ b/Resources/config/gaufrette.xml
@@ -13,7 +13,8 @@
     <services>
         <service id="sonata.media.adapter.filesystem.local" class="Sonata\MediaBundle\Filesystem\Local" />
         <service id="sonata.media.adapter.filesystem.ftp"   class="Gaufrette\Adapter\Ftp" />
-        <service id="sonata.media.adapter.service.s3"       class="Aws\S3\S3Client" factory-class="Aws\S3\S3Client" factory-method="factory">
+        <service id="sonata.media.adapter.service.s3"       class="Aws\S3\S3Client">
+            <factory class="Aws\S3\S3Client" method="factory" />
             <argument type="collection" />
         </service>
 
@@ -45,9 +46,9 @@
             <argument/>
         </service>
 
-        <service id="sonata.media.adapter.filesystem.opencloud.objectstore" class="OpenCloud\ObjectSource\Service"
-                 factory-service="sonata.media.adapter.filesystem.opencloud.connection"
-                 factory-method="ObjectStore">
+        <service id="sonata.media.adapter.filesystem.opencloud.objectstore" class="OpenCloud\ObjectSource\Service">
+            <factory service="sonata.media.adapter.filesystem.opencloud.connection" method="ObjectStore" />
+
             <argument/>
             <argument/>
         </service>

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "~2.3|~3.0",
+        "symfony/framework-bundle": "~2.6|~3.0",
         "sonata-project/core-bundle": "^2.3.10",
         "sonata-project/notification-bundle": "~2.2",
         "sonata-project/easy-extends-bundle": "~2.1",


### PR DESCRIPTION
factory-* syntax has been deprecated since Symfony 2.6, and removed in 3.0. 
This PR fixes #987, and enables usage of SonataMediaBundle in Symfony >3. 
Symfony <2.6 is not compatible anymore.

Credit goes to @LeoPelan, who posted this patch.