### PR TITLE
datagrid category value must be object, it was being set to integer

### DIFF
--- a/Controller/MediaAdminController.php
+++ b/Controller/MediaAdminController.php
@@ -80,19 +80,18 @@ class MediaAdminController extends Controller
         $category = $this->container->get('sonata.classification.manager.category')->getRootCategory($context);
 
         if (!$filters) {
-            $datagrid->setValue('category', null, $category->getId());
+            $datagrid->setValue('category', null, $category);
         }
-
         if ($request->get('category')) {
-            $contextInCategory = $this->container->get('sonata.classification.manager.category')->findBy(array(
+            $contextInCategory = $this->container->get('sonata.classification.manager.category')->findOneBy(array(
                 'id'      => (int) $request->get('category'),
                 'context' => $context,
             ));
 
             if (!empty($contextInCategory)) {
-                $datagrid->setValue('category', null, $request->get('category'));
+                $datagrid->setValue('category', null, $contextInCategory);
             } else {
-                $datagrid->setValue('category', null, $category->getId());
+                $datagrid->setValue('category', null, $category);
             }
         }
 

--- a/Resources/views/MediaAdmin/list.html.twig
+++ b/Resources/views/MediaAdmin/list.html.twig
@@ -21,7 +21,7 @@ file that was distributed with this source code.
     <ul{% if root %} class="sonata-tree sonata-tree--small js-treeview sonata-tree--toggleable"{% endif %}>
         {% for element in collection %}
             <li>
-                <div class="sonata-tree__item{% if element.id == current_category %} is-active{% endif %}"{% if depth < 2 %} data-treeview-toggled{% endif %}>
+                <div class="sonata-tree__item{% if element.id == current_category.id %} is-active{% endif %}"{% if depth < 2 %} data-treeview-toggled{% endif %}>
                     {% if element.parent or root %}<i class="fa fa-caret-right" data-treeview-toggler></i>{% endif %}
                     <a class="sonata-tree__item__edit" href="{{ url(app.request.attributes.get('_route'), app.request.query.all|merge({category: element.id})) }}">{{ element.name }}</a>
                 </div>


### PR DESCRIPTION
| Question       | Answer
|----------------|-------------------------------------------------------------
| Bundle version | sonata-project/media-bundle              dev-master b676113 
| Symfony version| symfony/symfony                          v2.8.4
| php version    | PHP 7.0.4-7ubuntu2

# Error
Deleting media object from list view was not being successful although getting the success message. 

# Steps to reproduce
On Media list view press filter once and then try to delete and object. Object is not being deleted. If you press the filter again and again, then you can delete the object.

# Change
Changed the value of category in datagrid to category object. It was being set only category id. If the category id is set by request from tree list, then we find one object by id and context and set the datagrid category to this object.