### PR TITLE
Support binary content which have in memory path

### DIFF
--- a/Provider/FileProvider.php
+++ b/Provider/FileProvider.php
@@ -318,8 +318,10 @@ class FileProvider extends BaseProvider
             return;
         }
 
-        if ($media->getBinaryContent() instanceof File) {
-            $file->setContent(file_get_contents($media->getBinaryContent()->getRealPath()), $metadata);
+        $binaryContent = $media->getBinaryContent();
+        if ($binaryContent instanceof File) {
+            $path = $binaryContent->getRealPath() ?: $binaryContent->getPathname();
+            $file->setContent(file_get_contents($path), $metadata);
 
             return;
         }

--- a/Tests/Provider/FileProviderTest.php
+++ b/Tests/Provider/FileProviderTest.php
@@ -224,4 +224,85 @@ class FileProviderTest extends \PHPUnit_Framework_TestCase
             array(null, $media3),
         );
     }
+
+    public function testBinaryContentWithRealPath()
+    {
+        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+
+        $media->expects($this->any())
+            ->method('getProviderReference')
+            ->willReturn('provider');
+
+        $media->expects($this->any())
+            ->method('getId')
+            ->willReturn(10000);
+
+        $media->expects($this->any())
+            ->method('getContext')
+            ->willReturn('context');
+
+        $binaryContent = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')
+            ->setMethods(array('getRealPath', 'getPathname'))
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $binaryContent->expects($this->atLeastOnce())
+            ->method('getRealPath')
+            ->willReturn(__DIR__.'/../fixtures/file.txt');
+
+        $binaryContent->expects($this->never())
+            ->method('getPathname');
+
+        $media->expects($this->any())
+            ->method('getBinaryContent')
+            ->willReturn($binaryContent);
+
+        $provider = $this->getProvider();
+
+        $setFileContents = new \ReflectionMethod('Sonata\MediaBundle\Provider\FileProvider', 'setFileContents');
+        $setFileContents->setAccessible(true);
+
+        $setFileContents->invoke($provider, $media);
+    }
+
+    public function testBinaryContentStreamWrapped()
+    {
+        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+
+        $media->expects($this->any())
+            ->method('getProviderReference')
+            ->willReturn('provider');
+
+        $media->expects($this->any())
+            ->method('getId')
+            ->willReturn(10000);
+
+        $media->expects($this->any())
+            ->method('getContext')
+            ->willReturn('context');
+
+        $binaryContent = $this->getMockBuilder('Symfony\Component\HttpFoundation\File\File')
+            ->setMethods(array('getRealPath', 'getPathname'))
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $binaryContent->expects($this->atLeastOnce())
+            ->method('getRealPath')
+            ->willReturn(false);
+
+        $binaryContent->expects($this->atLeastOnce())
+            ->method('getPathname')
+            ->willReturn(__DIR__.'/../fixtures/file.txt');
+
+        $media->expects($this->any())
+            ->method('getBinaryContent')
+            ->willReturn($binaryContent);
+
+        $provider = $this->getProvider();
+
+        $setFileContents = new \ReflectionMethod('Sonata\MediaBundle\Provider\FileProvider', 'setFileContents');
+        $setFileContents->setAccessible(true);
+
+        $setFileContents->invoke($provider, $media);
+    }
 }


### PR DESCRIPTION
Hi,

This PR provide support for stream wrapped paths (including Gaufrette) as pre-processed binaryContent.

In `FileProvider#setFileContents()` (**L 310**), the "realpath" to the pre-processed file is determined using `$media->getBinaryContent()->getRealPath()`. However, this returns `false` for stream wrapped paths (at least Gaufrette does). This causes a `ContextErrorException: Warning: file_get_contents(): Filename cannot be empty` error in Symfony.

With this PR, we now rely on  `$media->getBinaryContent()->getPathName()` if (and only if) `getRealPath()` fails, allowing the use of stream wrapped files.

This allow us, for example, to use Gaufrette's InMemoryAdapter to store pre-processed files and stop dealing with temporary files.

Since there were no tests for `setFileContents()`, I didn't know what kind of tests to add. The new behavior is relevant only in cases where the previous was failing anyway.