### PR TITLE
add region to S3Client config

### DIFF
--- a/DependencyInjection/SonataMediaExtension.php
+++ b/DependencyInjection/SonataMediaExtension.php
@@ -383,6 +383,7 @@ class SonataMediaExtension extends Extension
                 ->replaceArgument(0, array(
                     'secret' => $config['filesystem']['s3']['secretKey'],
                     'key' => $config['filesystem']['s3']['accessKey'],
+                    'region' => $config['filesystem']['s3']['region'],
                 ))
             ;
         } else {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Replaces #923

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Added
- Added `region` key to S3Client config
```

### Subject

pass the region for aws sdk to generate signature

https://github.com/aws/aws-sdk-php/blob/2.7.27/src/Aws/S3/S3Client.php#L272

### Comment

> +1 - this is also required for S3Client doesBucketExist to work. If region is not provided in the client constructor, amazon returns a 302 redirect requesting you to use an URL including region, causing gaufrette to conclude that the bucket does not exist and try to create the bucket in AwsS3::ensureBucketExists. Since the bucket does exist, you end up getting a BucketAlreadyOwnedByYouException with the message "Your previous request to create the named bucket succeeded and you already own it.". Simply passing region to the constructor as above resolves this error.