### PR TITLE
Removed double translation in gallery edit form

### DIFF
--- a/Admin/GalleryAdmin.php
+++ b/Admin/GalleryAdmin.php
@@ -96,8 +96,8 @@ class GalleryAdmin extends Admin
     {
         // define group zoning
         $formMapper
-            ->with($this->trans('Gallery'), array('class' => 'col-md-9'))->end()
-            ->with($this->trans('Options'), array('class' => 'col-md-3'))->end()
+            ->with('Gallery', array('class' => 'col-md-9'))->end()
+            ->with('Options', array('class' => 'col-md-3'))->end()
         ;
 
         $context = $this->getPersistentParameter('context');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Rebase of #616

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Fixed
- Removed double translation in gallery edit form
```

### Subject
The form groups are translated in the twig template.
