### PR TITLE
Made form options "provider" and "context" required in MediaType

### DIFF
--- a/Form/Type/MediaType.php
+++ b/Form/Type/MediaType.php
@@ -104,14 +104,37 @@ class MediaType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
-            'data_class' => $this->class,
-            'provider' => null,
-            'context' => null,
-            'empty_on_new' => true,
-            'new_on_update' => true,
-            'translation_domain' => 'SonataMediaBundle',
-        ));
+        $resolver
+            ->setDefaults(array(
+                'data_class' => $this->class,
+                'empty_on_new' => true,
+                'new_on_update' => true,
+                'translation_domain' => 'SonataMediaBundle',
+            ))
+            ->setRequired(array(
+                'provider',
+                'context',
+            ));
+
+        // NEXT_MAJOR: Remove this hack when dropping support for symfony 2.3
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $resolver
+                ->setAllowedTypes('provider', 'string')
+                ->setAllowedTypes('context', 'string')
+                ->setAllowedValues('provider', $this->pool->getProviderList())
+                ->setAllowedValues('context', array_keys($this->pool->getContexts()))
+            ;
+        } else {
+            $resolver
+                ->setAllowedTypes(array(
+                    'provider' => 'string',
+                    'context' => 'string',
+                ))
+                ->setAllowedValues(array(
+                    'provider' => $this->pool->getProviderList(),
+                    'context' => array_keys($this->pool->getContexts()),
+                ));
+        }
     }
 
     /**

--- a/Tests/Form/Type/AbstractTypeTest.php
+++ b/Tests/Form/Type/AbstractTypeTest.php
@@ -14,11 +14,12 @@ namespace Sonata\MediaBundle\Tests\Form\Type;
 use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormTypeInterface;
+use Symfony\Component\Form\Test\TypeTestCase;
 
 /**
  * @author Virgile Vivier <virgilevivier@gmail.com>
  */
-abstract class AbstractTypeTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractTypeTest extends TypeTestCase
 {
     /**
      * @var FormBuilder
@@ -35,7 +36,7 @@ abstract class AbstractTypeTest extends \PHPUnit_Framework_TestCase
      */
     protected $mediaPool;
 
-    public function setUp()
+    protected function setUp()
     {
         $provider = $this->getMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
 

--- a/Tests/Form/Type/MediaTypeTest.php
+++ b/Tests/Form/Type/MediaTypeTest.php
@@ -12,14 +12,158 @@
 namespace Sonata\MediaBundle\Tests\Form\Type;
 
 use Sonata\MediaBundle\Form\Type\MediaType;
+use Symfony\Component\Form\Forms;
 
 /**
  * @author Virgile Vivier <virgilevivier@gmail.com>
+ * @author Christian Gripp <mail@core23.de>
  */
 class MediaTypeTest extends AbstractTypeTest
 {
+    protected $mediaPool;
+
+    /**
+     * @var MediaType
+     */
+    protected $mediaType;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->mediaPool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
+        $this->mediaType = new MediaType($this->mediaPool, 'testClass');
+
+        $this->factory = Forms::createFormFactoryBuilder()
+            ->addType($this->mediaType)
+            ->addExtensions($this->getExtensions())
+            ->getFormFactory();
+    }
+
+    public function testMissingFormOptions()
+    {
+        $this->mediaPool->expects($this->any())->method('getProviderList')->will($this->returnValue(array(
+            'provider_a' => 'provider_a',
+            'provider_b' => 'provider_b',
+        )));
+        $this->mediaPool->expects($this->any())->method('getContexts')->will($this->returnValue(array(
+            'video' => array(),
+            'pic' => array(),
+        )));
+
+        $this->setExpectedException(
+            'Symfony\Component\OptionsResolver\Exception\MissingOptionsException',
+            'The required options "context", "provider" are missing.'
+        );
+
+        $this->factory->create($this->getFormType(), null);
+    }
+
+    public function testMissingFormContextOption()
+    {
+        $this->mediaPool->expects($this->any())->method('getProviderList')->will($this->returnValue(array(
+            'provider_a' => 'provider_a',
+            'provider_b' => 'provider_b',
+        )));
+        $this->mediaPool->expects($this->any())->method('getContexts')->will($this->returnValue(array(
+            'video' => array(),
+            'pic' => array(),
+        )));
+
+        $this->setExpectedException('Symfony\Component\OptionsResolver\Exception\MissingOptionsException');
+
+        $this->factory->create($this->getFormType(), null, array(
+            'provider' => 'provider_a',
+        ));
+    }
+
+    public function testMissingFormProviderOption()
+    {
+        $this->mediaPool->expects($this->any())->method('getProviderList')->will($this->returnValue(array(
+            'provider_a' => 'provider_a',
+            'provider_b' => 'provider_b',
+        )));
+        $this->mediaPool->expects($this->any())->method('getContexts')->will($this->returnValue(array(
+            'video' => array(),
+            'pic' => array(),
+        )));
+
+        $this->setExpectedException('Symfony\Component\OptionsResolver\Exception\MissingOptionsException');
+
+        $this->factory->create($this->getFormType(), null, array(
+            'context' => 'pic',
+        ));
+    }
+
+    public function testInvalidFormProviderOption()
+    {
+        $this->mediaPool->expects($this->any())->method('getProviderList')->will($this->returnValue(array(
+            'provider_a' => 'provider_a',
+            'provider_b' => 'provider_b',
+        )));
+        $this->mediaPool->expects($this->any())->method('getContexts')->will($this->returnValue(array(
+            'video' => array(),
+            'pic' => array(),
+        )));
+
+        // NEXT_MAJOR: Remove this hack when dropping support for symfony 2.3
+        if (class_exists('Symfony\Component\Validator\Validator\RecursiveValidator')) {
+            $this->setExpectedException(
+                'Symfony\Component\OptionsResolver\Exception\InvalidOptionsException',
+                'The option "provider" with value "provider_c" is invalid. Accepted values are: "provider_a", "provider_b".'
+            );
+        } else {
+            $this->setExpectedException(
+                'Symfony\Component\OptionsResolver\Exception\InvalidOptionsException',
+                'The option "provider" has the value "provider_c", but is expected to be one of "provider_a", "provider_b"'
+            );
+        }
+
+        $this->factory->create($this->getFormType(), null, array(
+            'provider' => 'provider_c',
+            'context' => 'pic',
+        ));
+    }
+
+    public function testInvalidFormContextOption()
+    {
+        $this->mediaPool->expects($this->any())->method('getProviderList')->will($this->returnValue(array(
+            'provider_a' => 'provider_a',
+            'provider_b' => 'provider_b',
+        )));
+        $this->mediaPool->expects($this->any())->method('getContexts')->will($this->returnValue(array(
+            'video' => array(),
+            'pic' => array(),
+        )));
+
+        // NEXT_MAJOR: Remove this hack when dropping support for symfony 2.3
+        if (class_exists('Symfony\Component\Validator\Validator\RecursiveValidator')) {
+            $this->setExpectedException(
+                'Symfony\Component\OptionsResolver\Exception\InvalidOptionsException',
+                'The option "context" with value "photo" is invalid. Accepted values are: "video", "pic".'
+            );
+        } else {
+            $this->setExpectedException(
+                'Symfony\Component\OptionsResolver\Exception\InvalidOptionsException',
+                'The option "context" has the value "photo", but is expected to be one of "video", "pic"'
+            );
+        }
+
+        $this->factory->create($this->getFormType(), null, array(
+            'provider' => 'provider_b',
+            'context' => 'photo',
+        ));
+    }
+
     protected function getTestedInstance()
     {
         return new MediaType($this->mediaPool, 'testclass');
+    }
+
+    private function getFormType()
+    {
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
+            'Sonata\MediaBundle\Form\Type\MediaType' :
+            'sonata_media_type';
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Rebase of #806

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Fixed
- The options `provider` and `context` are now required
```

### Subject

The options must be set in order to show the media_type widget.

### To do

- [x] Update the tests

