### PR TITLE
Add BaseVideoProvider::getReferenceUrl() method

### DIFF
--- a/Provider/BaseVideoProvider.php
+++ b/Provider/BaseVideoProvider.php
@@ -50,6 +50,11 @@ abstract class BaseVideoProvider extends BaseProvider
     {
         parent::__construct($name, $filesystem, $cdn, $pathGenerator, $thumbnail);
 
+        // NEXT_MAJOR: remove this check!
+        if (!method_exists($this, 'getReferenceUrl')) {
+            @trigger_error('The method "getReferenceUrl" is required with the next major release.', E_USER_DEPRECATED);
+        }
+
         $this->browser = $browser;
         $this->metadata = $metadata;
     }
@@ -201,6 +206,16 @@ abstract class BaseVideoProvider extends BaseProvider
     public function postRemove(MediaInterface $media)
     {
     }
+
+    // NEXT_MAJOR: Uncomment this method
+    /*
+     * Get provider reference url.
+     *
+     * @param MediaInterface $media
+     *
+     * @return string
+     */
+    // abstract public function getReferenceUrl(MediaInterface $media);
 
     /**
      * @throws \RuntimeException

--- a/Provider/DailyMotionProvider.php
+++ b/Provider/DailyMotionProvider.php
@@ -98,7 +98,7 @@ class DailyMotionProvider extends BaseVideoProvider
      */
     public function updateMetadata(MediaInterface $media, $force = false)
     {
-        $url = sprintf('http://www.dailymotion.com/services/oembed?url=http://www.dailymotion.com/video/%s&format=json', $media->getProviderReference());
+        $url = sprintf('http://www.dailymotion.com/services/oembed?url=%s&format=json', $this->getReferenceUrl($media));
 
         try {
             $metadata = $this->getMetadata($media, $url);
@@ -125,7 +125,19 @@ class DailyMotionProvider extends BaseVideoProvider
      */
     public function getDownloadResponse(MediaInterface $media, $format, $mode, array $headers = array())
     {
-        return new RedirectResponse(sprintf('http://www.dailymotion.com/video/%s', $media->getProviderReference()), 302, $headers);
+        return new RedirectResponse($this->getReferenceUrl($media), 302, $headers);
+    }
+
+    /**
+     * Get provider reference url.
+     *
+     * @param MediaInterface $media
+     *
+     * @return string
+     */
+    public function getReferenceUrl(MediaInterface $media)
+    {
+        return sprintf('http://www.dailymotion.com/video/%s', $media->getProviderReference());
     }
 
     /**

--- a/Provider/VimeoProvider.php
+++ b/Provider/VimeoProvider.php
@@ -86,7 +86,7 @@ class VimeoProvider extends BaseVideoProvider
      */
     public function updateMetadata(MediaInterface $media, $force = false)
     {
-        $url = sprintf('http://vimeo.com/api/oembed.json?url=http://vimeo.com/%s', $media->getProviderReference());
+        $url = sprintf('http://vimeo.com/api/oembed.json?url=%s', $this->getReferenceUrl($media));
 
         try {
             $metadata = $this->getMetadata($media, $url);
@@ -118,7 +118,19 @@ class VimeoProvider extends BaseVideoProvider
      */
     public function getDownloadResponse(MediaInterface $media, $format, $mode, array $headers = array())
     {
-        return new RedirectResponse(sprintf('http://vimeo.com/%s', $media->getProviderReference()), 302, $headers);
+        return new RedirectResponse($this->getReferenceUrl($media), 302, $headers);
+    }
+
+    /**
+     * Get provider reference url.
+     *
+     * @param MediaInterface $media
+     *
+     * @return string
+     */
+    public function getReferenceUrl(MediaInterface $media)
+    {
+        return sprintf('http://vimeo.com/%s', $media->getProviderReference());
     }
 
     /**

--- a/Provider/YouTubeProvider.php
+++ b/Provider/YouTubeProvider.php
@@ -207,7 +207,7 @@ class YouTubeProvider extends BaseVideoProvider
      */
     public function updateMetadata(MediaInterface $media, $force = false)
     {
-        $url = sprintf('http://www.youtube.com/oembed?url=http://www.youtube.com/watch?v=%s&format=json', $media->getProviderReference());
+        $url = sprintf('http://www.youtube.com/oembed?url=%s&format=json', $this->getReferenceUrl($media));
 
         try {
             $metadata = $this->getMetadata($media, $url);
@@ -235,7 +235,19 @@ class YouTubeProvider extends BaseVideoProvider
      */
     public function getDownloadResponse(MediaInterface $media, $format, $mode, array $headers = array())
     {
-        return new RedirectResponse(sprintf('http://www.youtube.com/watch?v=%s', $media->getProviderReference()), 302, $headers);
+        return new RedirectResponse($this->getReferenceUrl($media), 302, $headers);
+    }
+
+    /**
+     * Get provider reference url.
+     *
+     * @param MediaInterface $media
+     *
+     * @return string
+     */
+    public function getReferenceUrl(MediaInterface $media)
+    {
+        return sprintf('http://www.youtube.com/watch?v=%s', $media->getProviderReference());
     }
 
     /**

--- a/Resources/doc/reference/creating_a_provider_class.rst
+++ b/Resources/doc/reference/creating_a_provider_class.rst
@@ -262,6 +262,20 @@ At this point, the provider class is almost finish: we can add and remove
 a vimeo video : thanks to the ``AdminBundle`` integration and the ``VimeoProvider``
 service.
 
+Video Provider
+^^^^^^^^^^^^^^
+
+When creating a video provider by extending the  ``BaseVideoProvider`` class, you have to implement the
+``getReferenceUrl`` method. This method contains the external url to the video media.
+
+.. code-block:: php
+
+    <?php
+    public function getReferenceUrl(MediaInterface $media)
+    {
+        return sprintf('http://foobar.com/%s', $media->getProviderReference());
+    }
+
 Register the Class with the Service Container
 ---------------------------------------------
 

--- a/Tests/Provider/DailyMotionProviderTest.php
+++ b/Tests/Provider/DailyMotionProviderTest.php
@@ -187,4 +187,11 @@ class DailyMotionProviderTest extends AbstractProviderTest
         $this->assertSame(100, $properties['height']);
         $this->assertSame(100, $properties['width']);
     }
+
+    public function testGetReferenceUrl()
+    {
+        $media = new Media();
+        $media->setProviderReference('123456');
+        $this->assertEquals('http://www.dailymotion.com/video/123456', $this->getProvider()->getReferenceUrl($media));
+    }
 }

--- a/Tests/Provider/VimeoProviderTest.php
+++ b/Tests/Provider/VimeoProviderTest.php
@@ -203,4 +203,11 @@ class VimeoProviderTest extends AbstractProviderTest
         $this->assertSame(100, $properties['height']);
         $this->assertSame(100, $properties['width']);
     }
+
+    public function testGetReferenceUrl()
+    {
+        $media = new Media();
+        $media->setProviderReference('123456');
+        $this->assertEquals('http://vimeo.com/123456', $this->getProvider()->getReferenceUrl($media));
+    }
 }

--- a/Tests/Provider/YouTubeProviderTest.php
+++ b/Tests/Provider/YouTubeProviderTest.php
@@ -206,4 +206,11 @@ class YouTubeProviderTest extends AbstractProviderTest
         $this->assertSame(100, $properties['player_parameters']['height']);
         $this->assertSame(100, $properties['player_parameters']['width']);
     }
+
+    public function testGetReferenceUrl()
+    {
+        $media = new Media();
+        $media->setProviderReference('123456');
+        $this->assertEquals('http://www.youtube.com/watch?v=123456', $this->getProvider()->getReferenceUrl($media));
+    }
 }

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,11 @@
 UPGRADE 3.x
 ===========
 
+### Custom video provider
+
+When creating a custom video provider, you have to implement the ``getReferenceUrl`` method to establish
+the media url.
+
 UPGRADE FROM 3.0 to 3.1
 =======================
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Rebase of https://github.com/sonata-project/SonataMediaBundle/pull/622

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Added
- Created `getReferenceUrl` method for all video providers
```

### Subject

Created a new method which returns the reference url of a video.

### To do

<!--
    Complete the tasks.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

- [X] Update the tests

