### PR TITLE
Added missing BaseProvider::$name property

### DIFF
--- a/Provider/BaseProvider.php
+++ b/Provider/BaseProvider.php
@@ -58,6 +58,11 @@ abstract class BaseProvider implements MediaProviderInterface
     protected $thumbnail;
 
     /**
+     * @var string
+     */
+    protected $name;
+
+    /**
      * @param string             $name
      * @param Filesystem         $filesystem
      * @param CDNInterface       $cdn


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Fixed
- Added missing `BaseProvider::$name` property
```

### Subject

The property is used at several positions (e.g. `BaseProvider::setName` or `BaseProvider::getName`).
