### PR TITLE
added missing use statement

### DIFF
--- a/Security/SessionDownloadStrategy.php
+++ b/Security/SessionDownloadStrategy.php
@@ -14,6 +14,7 @@ namespace Sonata\MediaBundle\Security;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class SessionDownloadStrategy implements DownloadStrategyInterface


### PR DESCRIPTION
<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

Refs #999

```markdown
### Fixed
- Added missing use statement to `Security/SessionDownloadStrategy.php`
```

### Subject

```php
use Symfony\Component\HttpFoundation\Session\Session;
```
was missing.