### PR TITLE
Use AssetsHelper so we can generate relative urls when it's in sub-di…

### DIFF
--- a/CDN/Server.php
+++ b/CDN/Server.php
@@ -8,7 +8,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
- 
+
 namespace Sonata\MediaBundle\CDN;
 
 use Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper;

--- a/CDN/Server.php
+++ b/CDN/Server.php
@@ -8,6 +8,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+ 
 namespace Sonata\MediaBundle\CDN;
 
 use Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper;

--- a/CDN/Server.php
+++ b/CDN/Server.php
@@ -1,22 +1,27 @@
 <?php
 
 /*
- * This file is part of the Sonata Project package.
+ * This file is part of the Sonata project.
  *
  * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace Sonata\MediaBundle\CDN;
+
+use Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper;
 
 class Server implements CDNInterface
 {
-    /**
-     * @var string
-     */
+
     protected $path;
+
+    /**
+     *
+     * @var AssetsHelper
+     */
+    private $assetsHelper;
 
     /**
      * @param string $path
@@ -27,15 +32,24 @@ class Server implements CDNInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param AssetsHelper $assetsHelper
      */
-    public function getPath($relativePath, $isFlushable)
+    public function setAssetsHelper(AssetsHelper $assetsHelper)
     {
-        return sprintf('%s/%s', rtrim($this->path, '/'), ltrim($relativePath, '/'));
+        $this->assetsHelper = $assetsHelper;
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
+     */
+    public function getPath($relativePath, $isFlushable)
+    {
+        $path = sprintf('%s/%s', rtrim($this->path, '/'), ltrim($relativePath, '/'));
+        return $this->assetsHelper->getUrl($path);
+    }
+
+    /**
+     * {@inheritDoc}
      */
     public function flushByString($string)
     {
@@ -43,7 +57,7 @@ class Server implements CDNInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function flush($string)
     {
@@ -51,17 +65,9 @@ class Server implements CDNInterface
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     public function flushPaths(array $paths)
-    {
-        // nothing to do
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getFlushStatus($identifier)
     {
         // nothing to do
     }

--- a/CDN/Server.php
+++ b/CDN/Server.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Sonata project package.
+ * This file is part of the Sonata Project package.
  *
  * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
@@ -14,7 +14,6 @@ use Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper;
 
 class Server implements CDNInterface
 {
-
     protected $path;
 
     /**
@@ -44,7 +43,7 @@ class Server implements CDNInterface
     public function getPath($relativePath, $isFlushable)
     {
         $path = sprintf('%s/%s', rtrim($this->path, '/'), ltrim($relativePath, '/'));
-        
+
         return $this->assetsHelper->getUrl($path);
     }
 

--- a/CDN/Server.php
+++ b/CDN/Server.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of the Sonata project.
+ * This file is part of the Sonata project package.
  *
  * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
@@ -18,7 +18,6 @@ class Server implements CDNInterface
     protected $path;
 
     /**
-     *
      * @var AssetsHelper
      */
     private $assetsHelper;
@@ -40,16 +39,17 @@ class Server implements CDNInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getPath($relativePath, $isFlushable)
     {
         $path = sprintf('%s/%s', rtrim($this->path, '/'), ltrim($relativePath, '/'));
+        
         return $this->assetsHelper->getUrl($path);
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function flushByString($string)
     {
@@ -57,7 +57,7 @@ class Server implements CDNInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function flush($string)
     {
@@ -65,7 +65,7 @@ class Server implements CDNInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function flushPaths(array $paths)
     {

--- a/Resources/config/media.xml
+++ b/Resources/config/media.xml
@@ -29,6 +29,9 @@
         <!-- CDN abstraction service -->
         <service id="sonata.media.cdn.server" class="Sonata\MediaBundle\CDN\Server">
             <argument />
+			<call method="setAssetsHelper">
+                <argument type="service" id="templating.helper.assets" />
+            </call>
         </service>
 
         <service id="sonata.media.cdn.panther" class="Sonata\MediaBundle\CDN\PantherPortal">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->
### Changelog

``` markdown
### Added
- Now using AssetsHelper to generate urls

### Added
- Added `Sonata\MediaBundle\CDN::setAssetsHelper` so we can set AssetsHelper to be used when generating urls.

### Changed
- Changed `Sonata\MediaBundle\CDN::getPath` so it will use AssetsHelper to generate correctly urls.
```
### Subject

Server CDN is not generating correct url when project is inside directory of domain. (You had to describe the whole url instead).
