### PR TITLE
Define group zoning and form fields together

### DIFF
--- a/Admin/GalleryAdmin.php
+++ b/Admin/GalleryAdmin.php
@@ -94,12 +94,6 @@ class GalleryAdmin extends Admin
      */
     protected function configureFormFields(FormMapper $formMapper)
     {
-        // define group zoning
-        $formMapper
-            ->with('Gallery', array('class' => 'col-md-9'))->end()
-            ->with('Options', array('class' => 'col-md-3'))->end()
-        ;
-
         $context = $this->getPersistentParameter('context');
 
         if (!$context) {
@@ -117,16 +111,7 @@ class GalleryAdmin extends Admin
         }
 
         $formMapper
-            ->with('Options')
-                ->add('context', 'choice', array(
-                    'choices' => $contexts,
-                    'translation_domain' => 'SonataMediaBundle',
-                ))
-                ->add('enabled', null, array('required' => false))
-                ->add('name')
-                ->add('defaultFormat', 'choice', array('choices' => $formats))
-            ->end()
-            ->with('Gallery')
+            ->with('Gallery', array('class' => 'col-md-9'))
                 ->add('galleryHasMedias', 'sonata_type_collection', array(
                         'cascade_validation' => true,
                     ), array(
@@ -137,6 +122,15 @@ class GalleryAdmin extends Admin
                         'admin_code' => 'sonata.media.admin.gallery_has_media',
                     )
                 )
+            ->end()
+            ->with('Options', array('class' => 'col-md-3'))
+                ->add('context', 'choice', array(
+                    'choices' => $contexts,
+                    'translation_domain' => 'SonataMediaBundle',
+                ))
+                ->add('enabled', null, array('required' => false))
+                ->add('name')
+                ->add('defaultFormat', 'choice', array('choices' => $formats))
             ->end()
         ;
     }


### PR DESCRIPTION
### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

``` markdown
### Changed
- Define group zoning on `GalleryAdmin` and form fields together

### Fixed
- Duplicating groups with `uk`-translation
```
### Subject

Groups on Gallery add/edit form has been duplicated with `uk`-translation. It has not been tested on another translations

Before changing:
![screenshot from 2016-06-03 15 50 42](https://cloud.githubusercontent.com/assets/1562244/15779199/8f679244-29a3-11e6-8788-18347f807f89.png)

And after (with this PR's code)
![screenshot from 2016-06-03 16 00 21](https://cloud.githubusercontent.com/assets/1562244/15779317/4aa2bfa2-29a4-11e6-9703-6f6d5e23cd2d.png)

Fix for my project is extent `GalleryAdmin`, change `configureFormFields` and use own `GalleryAdmin`:

``` yaml
parameters:
    sonata.media.admin.gallery.class:  Application\Sonata\MediaBundle\Admin\GalleryAdmin
```

I define translation on `app/Resources/SonataMediaBundle/translations/SonataMediaBundle.uk.yml` file

```
$ php -v
PHP 5.5.9-1ubuntu4.17 (cli) (built: May 19 2016 19:05:57) 
Copyright (c) 1997-2014 The PHP Group
Zend Engine v2.5.0, Copyright (c) 1998-2014 Zend Technologies
    with Zend OPcache v7.0.3, Copyright (c) 1999-2014, by Zend Technologies
    with Xdebug v2.2.3, Copyright (c) 2002-2013, by Derick Rethans
```
- [x] My PR stuff
- [ ] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note
