### PR TITLE
Sync fix cli

### DIFF
--- a/Thumbnail/ConsumerThumbnail.php
+++ b/Thumbnail/ConsumerThumbnail.php
@@ -73,26 +73,30 @@ class ConsumerThumbnail implements ThumbnailInterface
      */
     public function generate(MediaProviderInterface $provider, MediaInterface $media)
     {
-        $backend = $this->backend;
-        $id = $this->id;
-
-        $publish = function () use ($backend, $media, $id) {
-            $backend->createAndPublish('sonata.media.create_thumbnail', array(
-                'thumbnailId' => $id,
-                'mediaId' => $media->getId(),
-
-                // force this value as the message is sent inside a transaction,
-                // so we have a race condition
-                'providerReference' => $media->getProviderReference(),
-            ));
-        };
-
-        // BC compatibility for missing EventDispatcher
-        if (null === $this->dispatcher) {
-            trigger_error('Since version 2.3.3, passing an empty parameter in argument 4 for __construct() in '.__CLASS__.' is deprecated and the workaround for it will be removed in 3.0.', E_USER_DEPRECATED);
-            $publish();
+        if (php_sapi_name() === 'cli') {
+            $this->thumbnail->generate($provider, $media);
         } else {
-            $this->dispatcher->addListener('kernel.finish_request', $publish);
+            $backend = $this->backend;
+            $id = $this->id;
+
+            $publish = function () use ($backend, $media, $id) {
+                $backend->createAndPublish('sonata.media.create_thumbnail', array(
+                    'thumbnailId' => $id,
+                    'mediaId' => $media->getId(),
+
+                    // force this value as the message is sent inside a transaction,
+                    // so we have a race condition
+                    'providerReference' => $media->getProviderReference(),
+                ));
+            };
+
+            // BC compatibility for missing EventDispatcher
+            if (null === $this->dispatcher) {
+                trigger_error('Since version 2.3.3, passing an empty parameter in argument 4 for __construct() in '.__CLASS__.' is deprecated and the workaround for it will be removed in 3.0.', E_USER_DEPRECATED);
+                $publish();
+            } else {
+                $this->dispatcher->addListener('kernel.finish_request', $publish);
+            }
         }
     }
 


### PR DESCRIPTION
### Changelog

ConsumerThumbnail does not use backend when running on cli anymore.

```markdown
### Fixed
- syncing thumbnails with `sonata:media:sync-thumbnails` command when using `sonata.media.thumbnail.consumer.format` thumbnail consumer.
```

### Subject

When using `sonata.media.thumbnail.consumer.format` as thumbnail service I recently fixed an issue where the job was sent too early resulting in a race condition. The solution was to postpone firing of the event with the `event_dispatcher` until the event `kernel.finish_request` is thrown.
This resulted in an other issue where the sync command was not working anymore because there is no `kernel.finish_request` event being fired. First I thought that the solution might be to add another listener on the `console.terminate` command. But this would be resulting in a strange behavior of the sync command (The jobs would be published until the command was run completely).
An other issue would have been that the deletion was not made through a notification, but the generation might. This would have been a problem on production environments because of the duration between deleting and creating.

**IMPORTANT**: The diff might look complicated which is caused by indentation. The change itself is very simple:
```php
if (php_sapi_name() === 'cli') {
    $this->thumbnail->generate($provider, $media);
} else {
    /* UNCHANGED */
}
```