### PR TITLE
use AbstractAdmin instead of deprecated Admin class

### DIFF
--- a/Admin/BaseMediaAdmin.php
+++ b/Admin/BaseMediaAdmin.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\MediaBundle\Admin;
 
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
@@ -19,7 +19,7 @@ use Sonata\CoreBundle\Model\Metadata;
 use Sonata\MediaBundle\Form\DataTransformer\ProviderDataTransformer;
 use Sonata\MediaBundle\Provider\Pool;
 
-abstract class BaseMediaAdmin extends Admin
+abstract class BaseMediaAdmin extends AbstractAdmin
 {
     /**
      * @var Pool

--- a/Admin/GalleryAdmin.php
+++ b/Admin/GalleryAdmin.php
@@ -11,13 +11,13 @@
 
 namespace Sonata\MediaBundle\Admin;
 
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\MediaBundle\Provider\Pool;
 
-class GalleryAdmin extends Admin
+class GalleryAdmin extends AbstractAdmin
 {
     /**
      * @var Pool

--- a/Admin/GalleryHasMediaAdmin.php
+++ b/Admin/GalleryHasMediaAdmin.php
@@ -11,11 +11,11 @@
 
 namespace Sonata\MediaBundle\Admin;
 
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 
-class GalleryHasMediaAdmin extends Admin
+class GalleryHasMediaAdmin extends AbstractAdmin
 {
     /**
      * {@inheritdoc}

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     },
     "require-dev": {
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
-        "sonata-project/admin-bundle": "^3.0",
+        "sonata-project/admin-bundle": "^3.1",
         "sonata-project/formatter-bundle": "^3.0",
         "sonata-project/datagrid-bundle": "^2.2",
         "sonata-project/seo-bundle": "^2.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Fixed
- Fix deprecated usage of `Admin` class
```

### Subject

The `Admin` class is deprecated since SonataAdminBundle `3.0`