### PR TITLE
make gaufrette config compatible with sf3

### DIFF
--- a/DependencyInjection/SonataMediaExtension.php
+++ b/DependencyInjection/SonataMediaExtension.php
@@ -44,6 +44,25 @@ class SonataMediaExtension extends Extension
         $loader->load('extra.xml');
         $loader->load('form.xml');
         $loader->load('gaufrette.xml');
+
+        // NEXT_MAJOR: Remove Following lines
+        $amazonS3Definition = $container->getDefinition('sonata.media.adapter.service.s3');
+        if (method_exists($amazonS3Definition, 'setFactory')) {
+            $amazonS3Definition->setFactory(array('Aws\S3\S3Client', 'factory'));
+        } else {
+            $amazonS3Definition->setFactoryClass('Aws\S3\S3Client');
+            $amazonS3Definition->setFactoryMethod('factory');
+        }
+
+        // NEXT_MAJOR: Remove Following lines
+        $openCloudDefinition = $container->getDefinition('sonata.media.adapter.filesystem.opencloud.objectstore');
+        if (method_exists($openCloudDefinition, 'setFactory')) {
+            $openCloudDefinition->setFactory(array(new Reference('sonata.media.adapter.filesystem.opencloud.connection'), 'ObjectStore'));
+        } else {
+            $openCloudDefinition->setFactoryService('sonata.media.adapter.filesystem.opencloud.connection');
+            $openCloudDefinition->setFactoryMethod('ObjectStore');
+        }
+
         $loader->load('validators.xml');
         $loader->load('serializer.xml');
 

--- a/Resources/config/gaufrette.xml
+++ b/Resources/config/gaufrette.xml
@@ -9,7 +9,10 @@
     <services>
         <service id="sonata.media.adapter.filesystem.local" class="Sonata\MediaBundle\Filesystem\Local"/>
         <service id="sonata.media.adapter.filesystem.ftp" class="Gaufrette\Adapter\Ftp"/>
-        <service id="sonata.media.adapter.service.s3" class="Aws\S3\S3Client" factory-class="Aws\S3\S3Client" factory-method="factory">
+        <service id="sonata.media.adapter.service.s3" class="Aws\S3\S3Client">
+            <!-- NEXT_MAJOR: Uncomment Following line
+            <factory class="Aws\S3\S3Client" method="factory"/>
+            -->
             <argument type="collection"/>
         </service>
         <service id="sonata.media.adapter.filesystem.s3" class="Gaufrette\Adapter\AwsS3">
@@ -35,7 +38,10 @@
             <argument/>
             <argument/>
         </service>
-        <service id="sonata.media.adapter.filesystem.opencloud.objectstore" class="OpenCloud\ObjectSource\Service" factory-service="sonata.media.adapter.filesystem.opencloud.connection" factory-method="ObjectStore">
+        <service id="sonata.media.adapter.filesystem.opencloud.objectstore" class="OpenCloud\ObjectSource\Service">
+            <!-- NEXT_MAJOR: Uncomment Following line
+            <factory service="sonata.media.adapter.filesystem.opencloud.connection" method="ObjectStore"/>
+            -->
             <argument/>
             <argument/>
         </service>


### PR DESCRIPTION
Closes #987

### Changelog

```markdown
### Fixed
- `gaufrette.xml` is now compatible with Symfony 3
```

### Subject

The Gaufrette configuration was using the deprecated functions setFactoryClass, setFactoryService and setFactoryMethod.

Fix source https://github.com/doctrine/DoctrineBundle/pull/381


