### PR TITLE
Switches Pixlr endpoints to https protocol

### DIFF
--- a/Extra/Pixlr.php
+++ b/Extra/Pixlr.php
@@ -90,7 +90,7 @@ class Pixlr
         $this->container = $container;
 
         $this->validFormats = array('jpg', 'jpeg', 'png');
-        $this->allowEreg = '@http://([a-zA-Z0-9]*).pixlr.com/_temp/[0-9a-z]{24}\.[a-z]*@';
+        $this->allowEreg = '@https://([a-zA-Z0-9]*).pixlr.com/_temp/[0-9a-z]{24}\.[a-z]*@';
     }
 
     /**
@@ -124,7 +124,7 @@ class Pixlr
             'locktarget' => true,
         );
 
-        $url = sprintf('http://pixlr.com/%s/?%s', $mode, $this->buildQuery($parameters));
+        $url = sprintf('https://pixlr.com/%s/?%s', $mode, $this->buildQuery($parameters));
 
         return new RedirectResponse($url);
     }


### PR DESCRIPTION
Closes #1051

### Changelog

```markdown
### Changed
- Pixlr endpoints now use https

### Fixed
- Fixed mixed-content error when loading Pixlr editor under https
```

### Subject

In sites under https, the Pixlr editor iframe didn't load, because of the hardcoded http protocol.
This commit hardcodes all Pixlr urls to https, to avoid mixed-content errors.