### PR TITLE
make gaufrette config compatible with sf3 - master branch

### DIFF
--- a/Resources/config/gaufrette.xml
+++ b/Resources/config/gaufrette.xml
@@ -9,7 +9,8 @@
     <services>
         <service id="sonata.media.adapter.filesystem.local" class="Sonata\MediaBundle\Filesystem\Local"/>
         <service id="sonata.media.adapter.filesystem.ftp" class="Gaufrette\Adapter\Ftp"/>
-        <service id="sonata.media.adapter.service.s3" class="Aws\S3\S3Client" factory-class="Aws\S3\S3Client" factory-method="factory">
+        <service id="sonata.media.adapter.service.s3" class="Aws\S3\S3Client">
+            <factory class="Aws\S3\S3Client" method="factory"/>
             <argument type="collection"/>
         </service>
         <service id="sonata.media.adapter.filesystem.s3" class="Gaufrette\Adapter\AwsS3">
@@ -35,7 +36,8 @@
             <argument/>
             <argument/>
         </service>
-        <service id="sonata.media.adapter.filesystem.opencloud.objectstore" class="OpenCloud\ObjectSource\Service" factory-service="sonata.media.adapter.filesystem.opencloud.connection" factory-method="ObjectStore">
+        <service id="sonata.media.adapter.filesystem.opencloud.objectstore" class="OpenCloud\ObjectSource\Service">
+            <factory service="sonata.media.adapter.filesystem.opencloud.connection" method="ObjectStore"/>
             <argument/>
             <argument/>
         </service>


### PR DESCRIPTION
### Changelog

```markdown
### Fixed
- `gaufrette.xml` is now compatible with Symfony 3
```

### Subject

The Gaufrette configuration was using the deprecated functions setFactoryClass, setFactoryService and setFactoryMethod.

Fix source https://github.com/doctrine/DoctrineBundle/pull/381