### PR TITLE
Remove Buzz dependency and replace it with guzzle

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -54,7 +54,7 @@ class Configuration implements ConfigurationInterface
         $this->addProvidersSection($node);
         $this->addExtraSection($node);
         $this->addModelSection($node);
-        $this->addBuzzSection($node);
+        $this->addGuzzleSection($node);
         $this->addResizerSection($node);
 
         return $treeBuilder;
@@ -428,22 +428,31 @@ class Configuration implements ConfigurationInterface
     /**
      * @param ArrayNodeDefinition $node
      */
-    private function addBuzzSection(ArrayNodeDefinition $node)
+    private function addGuzzleSection(ArrayNodeDefinition $node)
     {
         $node
             ->children()
-                ->arrayNode('buzz')
+                ->arrayNode('guzzle')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->scalarNode('connector')->defaultValue('sonata.media.buzz.connector.curl')->end()
                         ->arrayNode('client')
                         ->addDefaultsIfNotSet()
                         ->children()
-                            ->booleanNode('ignore_errors')->defaultValue(true)->end()
-                            ->scalarNode('max_redirects')->defaultValue(5)->end()
+                            ->booleanNode('http_errors')->defaultValue(false)->end()
+                            ->arrayNode('allow_redirects')
+                                ->addDefaultsIfNotSet()
+                                ->children()
+                                    ->integerNode('max')->defaultValue(5)->end()
+                                    ->booleanNode('strict')->defaultValue(false)->end()
+                                    ->booleanNode('referer')->defaultValue(true)->end()
+                                ->end()
+                            ->end()
                             ->scalarNode('timeout')->defaultValue(5)->end()
-                            ->booleanNode('verify_peer')->defaultValue(true)->end()
-                            ->scalarNode('proxy')->defaultNull()->end()
+                            ->booleanNode('verify')->defaultValue(true)->end()
+                            ->arrayNode('proxy')
+                                ->useAttributeAsKey('id')
+                                ->prototype('scalar')->end()
+                            ->end()
                         ->end()
                     ->end()
                 ->end()

--- a/DependencyInjection/SonataMediaExtension.php
+++ b/DependencyInjection/SonataMediaExtension.php
@@ -127,7 +127,7 @@ class SonataMediaExtension extends Extension
 
         $this->configureParameterClass($container, $config);
         $this->configureExtra($container, $config);
-        $this->configureBuzz($container, $config);
+        $this->configureGuzzle($container, $config);
         $this->configureProviders($container, $config);
         $this->configureClassesToCompile();
     }
@@ -156,22 +156,9 @@ class SonataMediaExtension extends Extension
      * @param ContainerBuilder $container
      * @param array            $config
      */
-    public function configureBuzz(ContainerBuilder $container, array $config)
+    public function configureGuzzle(ContainerBuilder $container, array $config)
     {
-        $container->getDefinition('sonata.media.buzz.browser')
-            ->replaceArgument(0, new Reference($config['buzz']['connector']));
-
-        foreach (array(
-            'sonata.media.buzz.connector.curl',
-            'sonata.media.buzz.connector.file_get_contents',
-        ) as $connector) {
-            $container->getDefinition($connector)
-                ->addMethodCall('setIgnoreErrors', array($config['buzz']['client']['ignore_errors']))
-                ->addMethodCall('setMaxRedirects', array($config['buzz']['client']['max_redirects']))
-                ->addMethodCall('setTimeout', array($config['buzz']['client']['timeout']))
-                ->addMethodCall('setVerifyPeer', array($config['buzz']['client']['verify_peer']))
-                ->addMethodCall('setProxy', array($config['buzz']['client']['proxy']));
-        }
+        $container->setParameter('sonata.media.guzzle.client.options', $config['guzzle']['client']);
     }
 
     /**

--- a/Provider/YouTubeProvider.php
+++ b/Provider/YouTubeProvider.php
@@ -11,8 +11,8 @@
 
 namespace Sonata\MediaBundle\Provider;
 
-use Buzz\Browser;
 use Gaufrette\Filesystem;
+use GuzzleHttp\ClientInterface;
 use Sonata\CoreBundle\Model\Metadata;
 use Sonata\MediaBundle\CDN\CDNInterface;
 use Sonata\MediaBundle\Generator\GeneratorInterface;
@@ -34,13 +34,13 @@ class YouTubeProvider extends BaseVideoProvider
      * @param CDNInterface             $cdn
      * @param GeneratorInterface       $pathGenerator
      * @param ThumbnailInterface       $thumbnail
-     * @param Browser                  $browser
+     * @param ClientInterface          $client
      * @param MetadataBuilderInterface $metadata
      * @param bool                     $html5
      */
-    public function __construct($name, Filesystem $filesystem, CDNInterface $cdn, GeneratorInterface $pathGenerator, ThumbnailInterface $thumbnail, Browser $browser, MetadataBuilderInterface $metadata = null, $html5 = false)
+    public function __construct($name, Filesystem $filesystem, CDNInterface $cdn, GeneratorInterface $pathGenerator, ThumbnailInterface $thumbnail, ClientInterface $client, MetadataBuilderInterface $metadata = null, $html5 = false)
     {
-        parent::__construct($name, $filesystem, $cdn, $pathGenerator, $thumbnail, $browser, $metadata);
+        parent::__construct($name, $filesystem, $cdn, $pathGenerator, $thumbnail, $client, $metadata);
         $this->html5 = $html5;
     }
 

--- a/Resources/config/provider.xml
+++ b/Resources/config/provider.xml
@@ -63,7 +63,7 @@
             <argument/>
             <argument/>
             <argument type="service" id="sonata.media.thumbnail.format"/>
-            <argument type="service" id="sonata.media.buzz.browser"/>
+            <argument type="service" id="sonata.media.guzzle.client"/>
             <argument type="service" id="sonata.media.metadata.proxy"/>
             <argument/>
             <call method="setTemplates">
@@ -80,7 +80,7 @@
             <argument/>
             <argument/>
             <argument type="service" id="sonata.media.thumbnail.format"/>
-            <argument type="service" id="sonata.media.buzz.browser"/>
+            <argument type="service" id="sonata.media.guzzle.client"/>
             <argument type="service" id="sonata.media.metadata.proxy"/>
             <call method="setTemplates">
                 <argument type="collection">
@@ -96,7 +96,7 @@
             <argument/>
             <argument/>
             <argument type="service" id="sonata.media.thumbnail.format"/>
-            <argument type="service" id="sonata.media.buzz.browser"/>
+            <argument type="service" id="sonata.media.guzzle.client"/>
             <argument type="service" id="sonata.media.metadata.proxy"/>
             <call method="setTemplates">
                 <argument type="collection">
@@ -105,10 +105,8 @@
                 </argument>
             </call>
         </service>
-        <service id="sonata.media.buzz.connector.file_get_contents" class="Buzz\Client\FileGetContents"/>
-        <service id="sonata.media.buzz.connector.curl" class="Buzz\Client\Curl"/>
-        <service id="sonata.media.buzz.browser" class="Buzz\Browser">
-            <argument/>
+        <service id="sonata.media.guzzle.client" class="GuzzleHttp\Client">
+            <argument>%sonata.media.guzzle.client.options%</argument>
         </service>
     </services>
 </container>

--- a/Resources/doc/reference/advanced_configuration.rst
+++ b/Resources/doc/reference/advanced_configuration.rst
@@ -168,7 +168,3 @@ Full configuration options:
                 cdn:        sonata.media.cdn.server
                 generator:  sonata.media.generator.default
                 thumbnail:  sonata.media.thumbnail.format
-
-        buzz:
-            connector:  sonata.media.buzz.connector.file_get_contents # sonata.media.buzz.connector.curl
-

--- a/Resources/doc/reference/creating_a_provider_class.rst
+++ b/Resources/doc/reference/creating_a_provider_class.rst
@@ -277,7 +277,7 @@ added to the provider pool.
         <argument type="service" id="sonata.media.cdn.server" />
         <argument type="service" id="sonata.media.generator.default" />
         <argument type="service" id="sonata.media.thumbnail.format" />
-        <argument type="service" id="sonata.media.buzz.browser" />
+        <argument type="service" id="sonata.media.guzzle.client" />
         <argument type="service" id="sonata.media.metadata.proxy" />
         <call method="setTemplates">
             <argument type="collection">

--- a/Tests/Provider/DailyMotionProviderTest.php
+++ b/Tests/Provider/DailyMotionProviderTest.php
@@ -11,8 +11,7 @@
 
 namespace Sonata\MediaBundle\Tests\Provider;
 
-use Buzz\Browser;
-use Buzz\Message\Response;
+use GuzzleHttp\ClientInterface;
 use Imagine\Image\Box;
 use Sonata\MediaBundle\Provider\DailyMotionProvider;
 use Sonata\MediaBundle\Tests\Entity\Media;
@@ -20,10 +19,10 @@ use Sonata\MediaBundle\Thumbnail\FormatThumbnail;
 
 class DailyMotionProviderTest extends \PHPUnit_Framework_TestCase
 {
-    public function getProvider(Browser $browser = null)
+    public function getProvider(ClientInterface $client = null)
     {
-        if (!$browser) {
-            $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
+        if (!$client) {
+            $client = $this->getMock('GuzzleHttp\ClientInterface');
         }
 
         $resizer = $this->getMock('Sonata\MediaBundle\Resizer\ResizerInterface');
@@ -44,7 +43,7 @@ class DailyMotionProviderTest extends \PHPUnit_Framework_TestCase
 
         $metadata = $this->getMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
 
-        $provider = new DailyMotionProvider('file', $filesystem, $cdn, $generator, $thumbnail, $browser, $metadata);
+        $provider = new DailyMotionProvider('file', $filesystem, $cdn, $generator, $thumbnail, $client, $metadata);
         $provider->setResizer($resizer);
 
         return $provider;
@@ -71,14 +70,14 @@ class DailyMotionProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testThumbnail()
     {
-        $response = $this->getMock('Buzz\Message\AbstractMessage');
-        $response->expects($this->once())->method('getContent')->will($this->returnValue('content'));
+        $response = $this->getMock('Psr\Http\Message\ResponseInterface');
+        $response->expects($this->once())->method('getBody')->will($this->returnValue('content'));
 
-        $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
+        $client = $this->getMock('GuzzleHttp\ClientInterface');
 
-        $browser->expects($this->once())->method('get')->will($this->returnValue($response));
+        $client->expects($this->once())->method('request')->will($this->returnValue($response));
 
-        $provider = $this->getProvider($browser);
+        $provider = $this->getProvider($client);
 
         $media = new Media();
         $media->setName('les tests fonctionnels - Symfony Live 2009');
@@ -102,13 +101,15 @@ class DailyMotionProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testTransformWithSig()
     {
-        $response = new Response();
-        $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_dailymotion.txt'));
+        $response = $this->getMock('Psr\Http\Message\ResponseInterface');
+        $response->expects($this->once())->method('getBody')->will($this->returnValue(
+            file_get_contents(__DIR__.'/../fixtures/valid_dailymotion.txt')
+        ));
 
-        $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
-        $browser->expects($this->once())->method('get')->will($this->returnValue($response));
+        $client = $this->getMock('GuzzleHttp\ClientInterface');
+        $client->expects($this->once())->method('request')->will($this->returnValue($response));
 
-        $provider = $this->getProvider($browser);
+        $provider = $this->getProvider($client);
 
         $provider->addFormat('big', array('width' => 200, 'height' => null, 'constraint' => true));
 
@@ -125,13 +126,15 @@ class DailyMotionProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testTransformWithUrl()
     {
-        $response = new Response();
-        $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_dailymotion.txt'));
+        $response = $this->getMock('Psr\Http\Message\ResponseInterface');
+        $response->expects($this->once())->method('getBody')->will($this->returnValue(
+            file_get_contents(__DIR__.'/../fixtures/valid_dailymotion.txt')
+        ));
 
-        $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
-        $browser->expects($this->once())->method('get')->will($this->returnValue($response));
+        $client = $this->getMock('GuzzleHttp\ClientInterface');
+        $client->expects($this->once())->method('request')->will($this->returnValue($response));
 
-        $provider = $this->getProvider($browser);
+        $provider = $this->getProvider($client);
 
         $provider->addFormat('big', array('width' => 200, 'height' => null, 'constraint' => true));
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -12,3 +12,7 @@ See also the [diff code](https://github.com/sonata-project/SonataMediaBundle/com
 ## Blocks
 
 The property `wrap` in `GalleryBlockService` was removed. You must create a custom block, if you still want to use ist.
+
+## BaseVideoProvider
+
+The `Buzz` dependency was removed and replaced with `GuzzleHttp`. You must adapt the new `BaseVideoProvider::__construct` signature.

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     ],
     "require": {
         "php": "^5.3 || ^7.0",
+        "guzzlehttp/guzzle": "^6.2",
         "symfony/config": "^2.3.9 || ^3.0",
         "symfony/console": "^2.3 || ^3.0",
         "symfony/dependency-injection": "^2.3.3 || ^3.0",
@@ -40,7 +41,6 @@
         "sonata-project/classification-bundle": "^3.0",
         "knplabs/gaufrette": "^0.1.6",
         "imagine/imagine": "^0.6",
-        "kriswallsmith/buzz": "^0.15",
         "jms/serializer-bundle": "^0.13 || ^1.0",
         "sonata-project/intl-bundle": "^2.2"
     },


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #951

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Changed
- Removed `buzz` dependency and replaced it with `GuzzleHttp`
```

### Subject

Today we use both dependencies for http connection. This change removed the buzz dependency completly. This shouldn't be done with a BC, because we had to load both to stay BC.

### To do

<!--
    Complete the tasks.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

- [X] Update the tests
- [X] Add an upgrade note

