### PR TITLE
Remove Guzzle and Buzz dependency and replace it with HTTPlug

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -54,7 +54,7 @@ class Configuration implements ConfigurationInterface
         $this->addProvidersSection($node);
         $this->addExtraSection($node);
         $this->addModelSection($node);
-        $this->addBuzzSection($node);
+        $this->addHttpClientSection($node);
         $this->addResizerSection($node);
 
         return $treeBuilder;
@@ -428,23 +428,15 @@ class Configuration implements ConfigurationInterface
     /**
      * @param ArrayNodeDefinition $node
      */
-    private function addBuzzSection(ArrayNodeDefinition $node)
+    private function addHttpClientSection(ArrayNodeDefinition $node)
     {
         $node
             ->children()
-                ->arrayNode('buzz')
+                ->arrayNode('http')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->scalarNode('connector')->defaultValue('sonata.media.buzz.connector.curl')->end()
-                        ->arrayNode('client')
-                        ->addDefaultsIfNotSet()
-                        ->children()
-                            ->booleanNode('ignore_errors')->defaultValue(true)->end()
-                            ->scalarNode('max_redirects')->defaultValue(5)->end()
-                            ->scalarNode('timeout')->defaultValue(5)->end()
-                            ->booleanNode('verify_peer')->defaultValue(true)->end()
-                            ->scalarNode('proxy')->defaultNull()->end()
-                        ->end()
+                        ->scalarNode('client')->defaultValue('httplug.client.default')->end()
+                        ->scalarNode('message_factory')->defaultValue('httplug.message_factory.default')->end()
                     ->end()
                 ->end()
             ->end()

--- a/DependencyInjection/SonataMediaExtension.php
+++ b/DependencyInjection/SonataMediaExtension.php
@@ -146,7 +146,7 @@ class SonataMediaExtension extends Extension
 
         $this->configureParameterClass($container, $config);
         $this->configureExtra($container, $config);
-        $this->configureBuzz($container, $config);
+        $this->configureHttpClient($container, $config);
         $this->configureProviders($container, $config);
         $this->configureClassesToCompile();
     }
@@ -169,28 +169,6 @@ class SonataMediaExtension extends Extension
         ;
 
         $container->getDefinition('sonata.media.provider.youtube')->replaceArgument(7, $config['providers']['youtube']['html5']);
-    }
-
-    /**
-     * @param ContainerBuilder $container
-     * @param array            $config
-     */
-    public function configureBuzz(ContainerBuilder $container, array $config)
-    {
-        $container->getDefinition('sonata.media.buzz.browser')
-            ->replaceArgument(0, new Reference($config['buzz']['connector']));
-
-        foreach (array(
-            'sonata.media.buzz.connector.curl',
-            'sonata.media.buzz.connector.file_get_contents',
-        ) as $connector) {
-            $container->getDefinition($connector)
-                ->addMethodCall('setIgnoreErrors', array($config['buzz']['client']['ignore_errors']))
-                ->addMethodCall('setMaxRedirects', array($config['buzz']['client']['max_redirects']))
-                ->addMethodCall('setTimeout', array($config['buzz']['client']['timeout']))
-                ->addMethodCall('setVerifyPeer', array($config['buzz']['client']['verify_peer']))
-                ->addMethodCall('setProxy', array($config['buzz']['client']['proxy']));
-        }
     }
 
     /**
@@ -529,5 +507,15 @@ class SonataMediaExtension extends Extension
             'Sonata\\MediaBundle\\Twig\\Node\\PathNode',
             'Sonata\\MediaBundle\\Twig\\Node\\ThumbnailNode',
         ));
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param array            $config
+     */
+    private function configureHttpClient(ContainerBuilder $container, array $config)
+    {
+        $container->setAlias('sonata.media.http.client', $config['http']['client']);
+        $container->setAlias('sonata.media.http.message_factory', $config['http']['message_factory']);
     }
 }

--- a/Metadata/AmazonMetadataBuilder.php
+++ b/Metadata/AmazonMetadataBuilder.php
@@ -13,7 +13,7 @@ namespace Sonata\MediaBundle\Metadata;
 
 use Aws\S3\Enum\CannedAcl;
 use Aws\S3\Enum\Storage;
-use Guzzle\Http\Mimetypes;
+use Core23\MimeUtil\MimeUtil;
 use Sonata\MediaBundle\Model\MediaInterface;
 
 class AmazonMetadataBuilder implements MetadataBuilderInterface
@@ -105,9 +105,8 @@ class AmazonMetadataBuilder implements MetadataBuilderInterface
      */
     protected function getContentType($filename)
     {
-        $extension = pathinfo($filename, PATHINFO_EXTENSION);
-        $contentType = Mimetypes::getInstance()->fromExtension($extension);
-
-        return array('contentType' => $contentType);
+        return array(
+            'contentType' => MimeUtil::getInstance()->getTypeFromFilename($filename),
+        );
     }
 }

--- a/Provider/BaseVideoProvider.php
+++ b/Provider/BaseVideoProvider.php
@@ -11,9 +11,11 @@
 
 namespace Sonata\MediaBundle\Provider;
 
-use Buzz\Browser;
 use Gaufrette\Filesystem;
+use Http\Client\HttpClient;
+use Http\Message\MessageFactory;
 use Imagine\Image\Box;
+use Psr\Http\Message\ResponseInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\CoreBundle\Model\Metadata;
 use Sonata\MediaBundle\CDN\CDNInterface;
@@ -28,9 +30,14 @@ use Symfony\Component\Validator\Constraints\NotNull;
 abstract class BaseVideoProvider extends BaseProvider
 {
     /**
-     * @var Browser
+     * @var HttpClient
      */
-    protected $browser;
+    protected $client;
+
+    /**
+     * @var MessageFactory
+     */
+    protected $messageFactory;
 
     /**
      * @var MetadataBuilderInterface
@@ -43,14 +50,16 @@ abstract class BaseVideoProvider extends BaseProvider
      * @param CDNInterface                  $cdn
      * @param GeneratorInterface            $pathGenerator
      * @param ThumbnailInterface            $thumbnail
-     * @param Browser                       $browser
+     * @param HttpClient                    $client
+     * @param MessageFactory                $messageFactory
      * @param MetadataBuilderInterface|null $metadata
      */
-    public function __construct($name, Filesystem $filesystem, CDNInterface $cdn, GeneratorInterface $pathGenerator, ThumbnailInterface $thumbnail, Browser $browser, MetadataBuilderInterface $metadata = null)
+    public function __construct($name, Filesystem $filesystem, CDNInterface $cdn, GeneratorInterface $pathGenerator, ThumbnailInterface $thumbnail, HttpClient $client, MessageFactory $messageFactory, MetadataBuilderInterface $metadata = null)
     {
         parent::__construct($name, $filesystem, $cdn, $pathGenerator, $thumbnail);
 
-        $this->browser = $browser;
+        $this->client = $client;
+        $this->messageFactory = $messageFactory;
         $this->metadata = $metadata;
     }
 
@@ -83,7 +92,10 @@ abstract class BaseVideoProvider extends BaseProvider
         } else {
             $referenceFile = $this->getFilesystem()->get($key, true);
             $metadata = $this->metadata ? $this->metadata->get($media, $referenceFile->getName()) : array();
-            $referenceFile->setContent($this->browser->get($this->getReferenceImage($media))->getContent(), $metadata);
+
+            $response = $this->sendRequest('GET', $this->getReferenceImage($media));
+
+            $referenceFile->setContent($response->getBody(), $metadata);
         }
 
         return $referenceFile;
@@ -190,12 +202,12 @@ abstract class BaseVideoProvider extends BaseProvider
     protected function getMetadata(MediaInterface $media, $url)
     {
         try {
-            $response = $this->browser->get($url);
+            $response = $this->sendRequest('GET', $url);
         } catch (\RuntimeException $e) {
             throw new \RuntimeException('Unable to retrieve the video information for :'.$url, null, $e);
         }
 
-        $metadata = json_decode($response->getContent(), true);
+        $metadata = json_decode($response->getBody(), true);
 
         if (!$metadata) {
             throw new \RuntimeException('Unable to decode the video information for :'.$url);
@@ -227,5 +239,20 @@ abstract class BaseVideoProvider extends BaseProvider
         }
 
         return $this->resizer->getBox($media, $settings);
+    }
+
+    /**
+     * Create a http request and sends it to the server.
+     *
+     * @param string $method
+     * @param string $url
+     *
+     * @return ResponseInterface
+     */
+    final protected function sendRequest($method, $url)
+    {
+        return $this->client->sendRequest(
+            $this->messageFactory->createRequest($method, $url)
+        );
     }
 }

--- a/Provider/YouTubeProvider.php
+++ b/Provider/YouTubeProvider.php
@@ -11,8 +11,9 @@
 
 namespace Sonata\MediaBundle\Provider;
 
-use Buzz\Browser;
 use Gaufrette\Filesystem;
+use Http\Client\HttpClient;
+use Http\Message\MessageFactory;
 use Sonata\CoreBundle\Model\Metadata;
 use Sonata\MediaBundle\CDN\CDNInterface;
 use Sonata\MediaBundle\Generator\GeneratorInterface;
@@ -34,13 +35,13 @@ class YouTubeProvider extends BaseVideoProvider
      * @param CDNInterface             $cdn
      * @param GeneratorInterface       $pathGenerator
      * @param ThumbnailInterface       $thumbnail
-     * @param Browser                  $browser
+     * @param HttpClient               $client
      * @param MetadataBuilderInterface $metadata
      * @param bool                     $html5
      */
-    public function __construct($name, Filesystem $filesystem, CDNInterface $cdn, GeneratorInterface $pathGenerator, ThumbnailInterface $thumbnail, Browser $browser, MetadataBuilderInterface $metadata = null, $html5 = false)
+    public function __construct($name, Filesystem $filesystem, CDNInterface $cdn, GeneratorInterface $pathGenerator, ThumbnailInterface $thumbnail, HttpClient $client, MessageFactory $messageFactory, MetadataBuilderInterface $metadata = null, $html5 = false)
     {
-        parent::__construct($name, $filesystem, $cdn, $pathGenerator, $thumbnail, $browser, $metadata);
+        parent::__construct($name, $filesystem, $cdn, $pathGenerator, $thumbnail, $client, $messageFactory, $metadata);
         $this->html5 = $html5;
     }
 

--- a/Resources/config/provider.xml
+++ b/Resources/config/provider.xml
@@ -63,7 +63,8 @@
             <argument/>
             <argument/>
             <argument type="service" id="sonata.media.thumbnail.format"/>
-            <argument type="service" id="sonata.media.buzz.browser"/>
+            <argument type="service" id="sonata.media.http.client"/>
+            <argument type="service" id="sonata.media.http.message_factory"/>
             <argument type="service" id="sonata.media.metadata.proxy"/>
             <argument/>
             <call method="setTemplates">
@@ -80,7 +81,8 @@
             <argument/>
             <argument/>
             <argument type="service" id="sonata.media.thumbnail.format"/>
-            <argument type="service" id="sonata.media.buzz.browser"/>
+            <argument type="service" id="sonata.media.http.client"/>
+            <argument type="service" id="sonata.media.http.message_factory"/>
             <argument type="service" id="sonata.media.metadata.proxy"/>
             <call method="setTemplates">
                 <argument type="collection">
@@ -96,7 +98,8 @@
             <argument/>
             <argument/>
             <argument type="service" id="sonata.media.thumbnail.format"/>
-            <argument type="service" id="sonata.media.buzz.browser"/>
+            <argument type="service" id="sonata.media.http.client"/>
+            <argument type="service" id="sonata.media.http.message_factory"/>
             <argument type="service" id="sonata.media.metadata.proxy"/>
             <call method="setTemplates">
                 <argument type="collection">
@@ -104,11 +107,6 @@
                     <argument key="helper_view">SonataMediaBundle:Provider:view_vimeo.html.twig</argument>
                 </argument>
             </call>
-        </service>
-        <service id="sonata.media.buzz.connector.file_get_contents" class="Buzz\Client\FileGetContents"/>
-        <service id="sonata.media.buzz.connector.curl" class="Buzz\Client\Curl"/>
-        <service id="sonata.media.buzz.browser" class="Buzz\Browser">
-            <argument/>
         </service>
     </services>
 </container>

--- a/Resources/doc/reference/advanced_configuration.rst
+++ b/Resources/doc/reference/advanced_configuration.rst
@@ -169,6 +169,7 @@ Full configuration options:
                 generator:  sonata.media.generator.default
                 thumbnail:  sonata.media.thumbnail.format
 
-        buzz:
-            connector:  sonata.media.buzz.connector.file_get_contents # sonata.media.buzz.connector.curl
-
+        http:
+            # If you want to use a custom client, have a look at http://docs.php-http.org
+            client:             httplug.client.default
+            message_factory:    httplug.message_factory.default

--- a/Resources/doc/reference/creating_a_provider_class.rst
+++ b/Resources/doc/reference/creating_a_provider_class.rst
@@ -277,7 +277,8 @@ added to the provider pool.
         <argument type="service" id="sonata.media.cdn.server" />
         <argument type="service" id="sonata.media.generator.default" />
         <argument type="service" id="sonata.media.thumbnail.format" />
-        <argument type="service" id="sonata.media.buzz.browser" />
+        <argument type="service" id="sonata.media.http.client" />
+        <argument type="service" id="sonata.media.http.message_factory"/>
         <argument type="service" id="sonata.media.metadata.proxy" />
         <call method="setTemplates">
             <argument type="collection">

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -26,6 +26,7 @@ Retrieve the bundle with composer:
 .. code-block:: bash
 
     $ composer require sonata-project/media-bundle
+    $ composer require php-http/guzzle6-adapter # recommended HTTP client
 
 Register these bundles in your AppKernel:
 
@@ -42,7 +43,8 @@ Register these bundles in your AppKernel:
           new Sonata\EasyExtendsBundle\SonataEasyExtendsBundle(),
           new Sonata\IntlBundle\SonataIntlBundle(),
 
-          // You need to add this dependency to make media functional
+          // You need to add these dependencies to make media functional
+          new Http\HttplugBundle\HttplugBundle(),
           new JMS\SerializerBundle\JMSSerializerBundle(),
           // ...
       );

--- a/Tests/Provider/VimeoProviderTest.php
+++ b/Tests/Provider/VimeoProviderTest.php
@@ -11,8 +11,8 @@
 
 namespace Sonata\MediaBundle\Tests\Provider;
 
-use Buzz\Browser;
-use Buzz\Message\Response;
+use Http\Client\HttpClient;
+use Http\Message\MessageFactory;
 use Imagine\Image\Box;
 use Sonata\MediaBundle\Provider\VimeoProvider;
 use Sonata\MediaBundle\Tests\Entity\Media;
@@ -20,10 +20,14 @@ use Sonata\MediaBundle\Thumbnail\FormatThumbnail;
 
 class VimeoProviderTest extends \PHPUnit_Framework_TestCase
 {
-    public function getProvider(Browser $browser = null)
+    public function getProvider(HttpClient $client = null, MessageFactory $messageFactory = null)
     {
-        if (!$browser) {
-            $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
+        if ($client === null) {
+            $client = $this->getMock('Http\Client\HttpClient');
+        }
+
+        if ($messageFactory === null) {
+            $messageFactory = $this->getMock('Http\Message\MessageFactory');
         }
 
         $resizer = $this->getMock('Sonata\MediaBundle\Resizer\ResizerInterface');
@@ -44,7 +48,7 @@ class VimeoProviderTest extends \PHPUnit_Framework_TestCase
 
         $metadata = $this->getMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
 
-        $provider = new VimeoProvider('file', $filesystem, $cdn, $generator, $thumbnail, $browser, $metadata);
+        $provider = new VimeoProvider('file', $filesystem, $cdn, $generator, $thumbnail, $client, $messageFactory, $metadata);
         $provider->setResizer($resizer);
 
         return $provider;
@@ -70,14 +74,18 @@ class VimeoProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testThumbnail()
     {
-        $response = $this->getMock('Buzz\Message\AbstractMessage');
-        $response->expects($this->once())->method('getContent')->will($this->returnValue('content'));
+        $request = $this->getMock('Psr\Http\Message\RequestInterface');
 
-        $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
+        $messageFactory = $this->getMock('Http\Message\MessageFactory');
+        $messageFactory->expects($this->once())->method('createRequest')->will($this->returnValue($request));
 
-        $browser->expects($this->once())->method('get')->will($this->returnValue($response));
+        $response = $this->getMock('Psr\Http\Message\ResponseInterface');
+        $response->expects($this->once())->method('getBody')->will($this->returnValue('content'));
 
-        $provider = $this->getProvider($browser);
+        $client = $this->getMock('Http\Client\HttpClient');
+        $client->expects($this->once())->method('sendRequest')->with($this->equalTo($request))->will($this->returnValue($response));
+
+        $provider = $this->getProvider($client, $messageFactory);
 
         $media = new Media();
         $media->setName('Blinky™');
@@ -101,13 +109,20 @@ class VimeoProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testTransformWithSig()
     {
-        $response = new Response();
-        $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_vimeo.txt'));
+        $request = $this->getMock('Psr\Http\Message\RequestInterface');
 
-        $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
-        $browser->expects($this->once())->method('get')->will($this->returnValue($response));
+        $messageFactory = $this->getMock('Http\Message\MessageFactory');
+        $messageFactory->expects($this->once())->method('createRequest')->will($this->returnValue($request));
 
-        $provider = $this->getProvider($browser);
+        $response = $this->getMock('Psr\Http\Message\ResponseInterface');
+        $response->expects($this->once())->method('getBody')->will($this->returnValue(
+            file_get_contents(__DIR__.'/../fixtures/valid_vimeo.txt')
+        ));
+
+        $client = $this->getMock('Http\Client\HttpClient');
+        $client->expects($this->once())->method('sendRequest')->with($this->equalTo($request))->will($this->returnValue($response));
+
+        $provider = $this->getProvider($client, $messageFactory);
 
         $provider->addFormat('big', array('width' => 200, 'height' => 100, 'constraint' => true));
 
@@ -128,13 +143,20 @@ class VimeoProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function testTransformWithUrl($media)
     {
-        $response = new Response();
-        $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_vimeo.txt'));
+        $request = $this->getMock('Psr\Http\Message\RequestInterface');
 
-        $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
-        $browser->expects($this->once())->method('get')->will($this->returnValue($response));
+        $messageFactory = $this->getMock('Http\Message\MessageFactory');
+        $messageFactory->expects($this->once())->method('createRequest')->will($this->returnValue($request));
 
-        $provider = $this->getProvider($browser);
+        $response = $this->getMock('Psr\Http\Message\ResponseInterface');
+        $response->expects($this->once())->method('getBody')->will($this->returnValue(
+            file_get_contents(__DIR__.'/../fixtures/valid_vimeo.txt')
+        ));
+
+        $client = $this->getMock('Http\Client\HttpClient');
+        $client->expects($this->once())->method('sendRequest')->with($this->equalTo($request))->will($this->returnValue($response));
+
+        $provider = $this->getProvider($client, $messageFactory);
 
         $provider->addFormat('big', array('width' => 200, 'height' => 100, 'constraint' => true));
 

--- a/Tests/Provider/YouTubeProviderTest.php
+++ b/Tests/Provider/YouTubeProviderTest.php
@@ -11,8 +11,8 @@
 
 namespace Sonata\MediaBundle\Tests\Provider;
 
-use Buzz\Browser;
-use Buzz\Message\Response;
+use Http\Client\HttpClient;
+use Http\Message\MessageFactory;
 use Imagine\Image\Box;
 use Sonata\MediaBundle\Provider\YouTubeProvider;
 use Sonata\MediaBundle\Tests\Entity\Media;
@@ -20,10 +20,14 @@ use Sonata\MediaBundle\Thumbnail\FormatThumbnail;
 
 class YouTubeProviderTest extends \PHPUnit_Framework_TestCase
 {
-    public function getProvider(Browser $browser = null)
+    public function getProvider(HttpClient $client = null, MessageFactory $messageFactory = null)
     {
-        if (!$browser) {
-            $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
+        if ($client === null) {
+            $client = $this->getMock('Http\Client\HttpClient');
+        }
+
+        if ($messageFactory === null) {
+            $messageFactory = $this->getMock('Http\Message\MessageFactory');
         }
 
         $resizer = $this->getMock('Sonata\MediaBundle\Resizer\ResizerInterface');
@@ -44,7 +48,7 @@ class YouTubeProviderTest extends \PHPUnit_Framework_TestCase
 
         $metadata = $this->getMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
 
-        $provider = new YouTubeProvider('file', $filesystem, $cdn, $generator, $thumbnail, $browser, $metadata);
+        $provider = new YouTubeProvider('file', $filesystem, $cdn, $generator, $thumbnail, $client, $messageFactory, $metadata);
         $provider->setResizer($resizer);
 
         return $provider;
@@ -71,14 +75,18 @@ class YouTubeProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testThumbnail()
     {
-        $response = $this->getMock('Buzz\Message\AbstractMessage');
-        $response->expects($this->once())->method('getContent')->will($this->returnValue('content'));
+        $request = $this->getMock('Psr\Http\Message\RequestInterface');
 
-        $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
+        $messageFactory = $this->getMock('Http\Message\MessageFactory');
+        $messageFactory->expects($this->once())->method('createRequest')->will($this->returnValue($request));
 
-        $browser->expects($this->once())->method('get')->will($this->returnValue($response));
+        $response = $this->getMock('Psr\Http\Message\ResponseInterface');
+        $response->expects($this->once())->method('getBody')->will($this->returnValue('content'));
 
-        $provider = $this->getProvider($browser);
+        $client = $this->getMock('Http\Client\HttpClient');
+        $client->expects($this->once())->method('sendRequest')->with($this->equalTo($request))->will($this->returnValue($response));
+
+        $provider = $this->getProvider($client, $messageFactory);
 
         $media = new Media();
         $media->setProviderName('youtube');
@@ -101,13 +109,20 @@ class YouTubeProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testTransformWithSig()
     {
-        $response = new Response();
-        $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_youtube.txt'));
+        $request = $this->getMock('Psr\Http\Message\RequestInterface');
 
-        $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
-        $browser->expects($this->once())->method('get')->will($this->returnValue($response));
+        $messageFactory = $this->getMock('Http\Message\MessageFactory');
+        $messageFactory->expects($this->once())->method('createRequest')->will($this->returnValue($request));
 
-        $provider = $this->getProvider($browser);
+        $response = $this->getMock('Psr\Http\Message\ResponseInterface');
+        $response->expects($this->once())->method('getBody')->will($this->returnValue(
+            file_get_contents(__DIR__.'/../fixtures/valid_youtube.txt')
+        ));
+
+        $client = $this->getMock('Http\Client\HttpClient');
+        $client->expects($this->once())->method('sendRequest')->with($this->equalTo($request))->will($this->returnValue($response));
+
+        $provider = $this->getProvider($client, $messageFactory);
 
         $provider->addFormat('big', array('width' => 200, 'height' => 100, 'constraint' => true));
 
@@ -127,13 +142,20 @@ class YouTubeProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function testTransformWithUrl($url)
     {
-        $response = new Response();
-        $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_youtube.txt'));
+        $request = $this->getMock('Psr\Http\Message\RequestInterface');
 
-        $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
-        $browser->expects($this->once())->method('get')->will($this->returnValue($response));
+        $messageFactory = $this->getMock('Http\Message\MessageFactory');
+        $messageFactory->expects($this->once())->method('createRequest')->will($this->returnValue($request));
 
-        $provider = $this->getProvider($browser);
+        $response = $this->getMock('Psr\Http\Message\ResponseInterface');
+        $response->expects($this->once())->method('getBody')->will($this->returnValue(
+            file_get_contents(__DIR__.'/../fixtures/valid_youtube.txt')
+        ));
+
+        $client = $this->getMock('Http\Client\HttpClient');
+        $client->expects($this->once())->method('sendRequest')->with($this->equalTo($request))->will($this->returnValue($response));
+
+        $provider = $this->getProvider($client, $messageFactory);
 
         $provider->addFormat('big', array('width' => 200, 'height' => 100, 'constraint' => true));
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -21,3 +21,7 @@ If you have implemented a custom model, you must adapt the signature of the foll
 ## Renamed GalleryHasMedia to GalleryItem
 
 All Actions, Controllers, Interfaces and anything related to this is renamed accordingly.
+
+## BaseVideoProvider uses HTTPlug
+
+The `Guzzle` and `Buzz` dependency were removed and replaced the abstract `HTTPlug` client, so you can choose your prefered client implementation. You must adapt the new `BaseVideoProvider::__construct` signature.

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,9 @@
         }
     ],
     "require": {
+        "core23/mime-util": "^0.1",
         "php": "^5.3 || ^7.0",
+        "php-http/httplug-bundle": "^1.1",
         "symfony/config": "^2.3.9 || ^3.0",
         "symfony/console": "^2.3 || ^3.0",
         "symfony/dependency-injection": "^2.3.3 || ^3.0",
@@ -40,7 +42,6 @@
         "sonata-project/classification-bundle": "^3.0 || ^4.0@dev",
         "knplabs/gaufrette": "^0.1.6",
         "imagine/imagine": "^0.6",
-        "kriswallsmith/buzz": "^0.15",
         "jms/serializer-bundle": "^0.13 || ^1.0",
         "sonata-project/intl-bundle": "^2.2"
     },
@@ -50,6 +51,7 @@
         "sonata-project/formatter-bundle": "^3.0",
         "sonata-project/datagrid-bundle": "^2.2",
         "sonata-project/seo-bundle": "^2.0",
+        "php-http/mock-client": "^0.3",
         "aws/aws-sdk-php": "^2.7",
         "jackalope/jackalope-doctrine-dbal": "^1.1",
         "symfony/phpunit-bridge": "^2.7 || ^3.0",
@@ -60,6 +62,8 @@
     "suggest": {
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
         "liip/imagine-bundle": "^0.9",
+        "php-http/buzz-adapter": "Buzz HTTP client implementation",
+        "php-http/guzzle6-adapter": "Guzzle HTTP client implementation",
         "rackspace/php-opencloud": "^1.6",
         "sonata-project/seo-bundle": "^2.0",
         "tilleuls/ckeditor-sonata-media-bundle": "^1.0"


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #951
### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

``` markdown
### Changed
- Removed `Guzzle` and `Buzz` dependency and replaced it with `HTTPlug`
```
### Subject

Today we use both dependencies for http connection. This change removed both dependencies completly and replaces them with some abstract library. 

We can't handle this with BC, because HTTPlug requires at least PHP 5.4.
### To do

<!--
    Complete the tasks.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
- [x] Update the tests
- [x] Update the documentation
- [X] Add an upgrade note
