### PR TITLE
Make forms compatible with Symfony3

### DIFF
--- a/Form/Type/ApiMediaType.php
+++ b/Form/Type/ApiMediaType.php
@@ -85,7 +85,11 @@ class ApiMediaType extends AbstractType
      */
     public function getParent()
     {
-        return 'sonata_media_api_form_doctrine_media';
+        // NEXT_MAJOR: Return 'Sonata\MediaBundle\Form\Type\ApiDoctrineMediaType'
+        // (when requirement of Symfony is >= 2.8)
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Sonata\MediaBundle\Form\Type\ApiDoctrineMediaType'
+            : 'sonata_media_api_form_doctrine_media';
     }
 
     /**

--- a/Form/Type/MediaType.php
+++ b/Form/Type/MediaType.php
@@ -64,12 +64,20 @@ class MediaType extends AbstractType
 
         $this->pool->getProvider($options['provider'])->buildMediaType($builder);
 
-        $builder->add('unlink', 'checkbox', array(
-            'label' => 'widget_label_unlink',
-            'mapped' => false,
-            'data' => false,
-            'required' => false,
-        ));
+        // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\CheckboxType' value.
+        // (when requirement of Symfony is >= 2.8)
+        $builder->add(
+            'unlink',
+            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\CheckboxType'
+                : 'checkbox',
+            array(
+                'label' => 'widget_label_unlink',
+                'mapped' => false,
+                'data' => false,
+                'required' => false,
+            )
+        );
     }
 
     /**
@@ -111,7 +119,11 @@ class MediaType extends AbstractType
      */
     public function getParent()
     {
-        return 'form';
+        // NEXT_MAJOR: Return 'Symfony\Component\Form\Extension\Core\Type\FormType'
+        // (when requirement of Symfony is >= 2.8)
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\FormType'
+            : 'form';
     }
 
     /**

--- a/Provider/BaseVideoProvider.php
+++ b/Provider/BaseVideoProvider.php
@@ -118,13 +118,20 @@ abstract class BaseVideoProvider extends BaseProvider
      */
     public function buildEditForm(FormMapper $formMapper)
     {
+        // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\TextType' value
+        // (when requirement of Symfony is >= 2.8)
         $formMapper->add('name');
         $formMapper->add('enabled', null, array('required' => false));
         $formMapper->add('authorName');
         $formMapper->add('cdnIsFlushable');
         $formMapper->add('description');
         $formMapper->add('copyright');
-        $formMapper->add('binaryContent', 'text', array('required' => false));
+        $formMapper->add(
+            'binaryContent',
+            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
+                : 'text',
+            array('required' => false));
     }
 
     /**
@@ -132,12 +139,20 @@ abstract class BaseVideoProvider extends BaseProvider
      */
     public function buildCreateForm(FormMapper $formMapper)
     {
-        $formMapper->add('binaryContent', 'text', array(
-            'constraints' => array(
-                new NotBlank(),
-                new NotNull(),
-            ),
-        ));
+        // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\TextType' value
+        // (when requirement of Symfony is >= 2.8)
+        $formMapper->add(
+            'binaryContent',
+            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
+                : 'text',
+            array(
+                'constraints' => array(
+                    new NotBlank(),
+                    new NotNull(),
+                ),
+            )
+        );
     }
 
     /**
@@ -145,9 +160,17 @@ abstract class BaseVideoProvider extends BaseProvider
      */
     public function buildMediaType(FormBuilder $formBuilder)
     {
-        $formBuilder->add('binaryContent', 'text', array(
-            'label' => 'widget_label_binary_content',
-        ));
+        // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\TextType'
+        // (when requirement of Symfony is >= 2.8)
+        $formBuilder->add(
+            'binaryContent',
+            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
+                : 'text',
+            array(
+                'label' => 'widget_label_binary_content',
+            )
+        );
     }
 
     /**

--- a/Provider/BaseVideoProvider.php
+++ b/Provider/BaseVideoProvider.php
@@ -118,8 +118,6 @@ abstract class BaseVideoProvider extends BaseProvider
      */
     public function buildEditForm(FormMapper $formMapper)
     {
-        // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\TextType' value
-        // (when requirement of Symfony is >= 2.8)
         $formMapper->add('name');
         $formMapper->add('enabled', null, array('required' => false));
         $formMapper->add('authorName');
@@ -128,6 +126,8 @@ abstract class BaseVideoProvider extends BaseProvider
         $formMapper->add('copyright');
         $formMapper->add(
             'binaryContent',
+            // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\TextType' value
+            // (when requirement of Symfony is >= 2.8)
             method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
                 ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
                 : 'text',
@@ -139,10 +139,10 @@ abstract class BaseVideoProvider extends BaseProvider
      */
     public function buildCreateForm(FormMapper $formMapper)
     {
-        // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\TextType' value
-        // (when requirement of Symfony is >= 2.8)
         $formMapper->add(
             'binaryContent',
+            // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\TextType' value
+            // (when requirement of Symfony is >= 2.8)
             method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
                 ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
                 : 'text',

--- a/Provider/FileProvider.php
+++ b/Provider/FileProvider.php
@@ -96,7 +96,15 @@ class FileProvider extends BaseProvider
         $formMapper->add('cdnIsFlushable');
         $formMapper->add('description');
         $formMapper->add('copyright');
-        $formMapper->add('binaryContent', 'file', array('required' => false));
+        $formMapper->add(
+            'binaryContent',
+            // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\FileType' value
+            // (when requirement of Symfony is >= 2.8)
+            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\FileType'
+                : 'file',
+            array('required' => false)
+        );
     }
 
     /**
@@ -104,12 +112,20 @@ class FileProvider extends BaseProvider
      */
     public function buildCreateForm(FormMapper $formMapper)
     {
-        $formMapper->add('binaryContent', 'file', array(
-            'constraints' => array(
-                new NotBlank(),
-                new NotNull(),
-            ),
-        ));
+        $formMapper->add(
+            'binaryContent',
+            // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\FileType' value
+            // (when requirement of Symfony is >= 2.8)
+            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+                ? 'Symfony\Component\Form\Extension\Core\Type\FileType'
+                : 'file',
+            array(
+                'constraints' => array(
+                    new NotBlank(),
+                    new NotNull(),
+                ),
+            )
+        );
     }
 
     /**
@@ -117,11 +133,17 @@ class FileProvider extends BaseProvider
      */
     public function buildMediaType(FormBuilder $formBuilder)
     {
+        // NEXT_MAJOR: Remove $fileType variable and inline 'Symfony\Component\Form\Extension\Core\Type\FileType'
+        // (when requirement of Symfony is >= 2.8)
+        $fileType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\FileType'
+            : 'file';
+
         if ($formBuilder->getOption('context') == 'api') {
-            $formBuilder->add('binaryContent', 'file');
+            $formBuilder->add('binaryContent', $fileType);
             $formBuilder->add('contentType');
         } else {
-            $formBuilder->add('binaryContent', 'file', array(
+            $formBuilder->add('binaryContent', $fileType, array(
                 'required' => false,
                 'label' => 'widget_label_binary_content',
             ));

--- a/Tests/Form/Type/AbstractTypeTest.php
+++ b/Tests/Form/Type/AbstractTypeTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\Form\Type;
+
+use Sonata\MediaBundle\Provider\Pool;
+use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\FormTypeInterface;
+
+/**
+ * @author Virgile Vivier <virgilevivier@gmail.com>
+ */
+abstract class AbstractTypeTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var FormBuilder
+     */
+    protected $formBuilder;
+
+    /**
+     * @var FormTypeInterface
+     */
+    protected $formType;
+
+    /**
+     * @var Pool
+     */
+    protected $mediaPool;
+
+    public function setUp()
+    {
+        $provider = $this->getMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+
+        $this->mediaPool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
+        $this->mediaPool->expects($this->any())->method('getProvider')->willReturn($provider);
+
+        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
+        $that = $this;
+
+        $this->formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $this->formBuilder
+            ->expects($this->any())
+            ->method('add')
+            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+                    if (null !== $type) {
+                        $isFQCN = class_exists($type);
+                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                            // 2.8
+                            @trigger_error(
+                                sprintf(
+                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                                    .' Use the fully-qualified type class name instead.',
+                                    $type
+                                ),
+                                E_USER_DEPRECATED)
+                            ;
+                        }
+
+                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                    }
+                }
+            }));
+
+        $this->formType = $this->getTestedInstance();
+    }
+
+    public function testBuildForm()
+    {
+        $this->formType->buildForm($this->formBuilder, array(
+            'provider_name' => 'sonata.media.provider.image',
+            'provider' => null,
+            'context' => null,
+            'empty_on_new' => true,
+            'new_on_update' => true,
+        ));
+    }
+
+    public function testGetParent()
+    {
+        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $parentRef = $this->formType->getParent();
+
+            $isFQCN = class_exists($parentRef);
+            if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                // 2.8
+                @trigger_error(
+                    sprintf(
+                        'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                        .' Use the fully-qualified type class name instead.',
+                        $parentRef
+                    ),
+                    E_USER_DEPRECATED)
+                ;
+            }
+
+            $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
+        }
+    }
+
+    /**
+     * Get the tested form type instance.
+     *
+     * @return FormTypeInterface
+     */
+    abstract protected function getTestedInstance();
+}

--- a/Tests/Form/Type/ApiMediaTypeTest.php
+++ b/Tests/Form/Type/ApiMediaTypeTest.php
@@ -19,10 +19,11 @@ use Sonata\MediaBundle\Form\Type\ApiMediaType;
  *
  * @author Hugo Briand <briand@ekino.com>
  */
-class ApiMediaTypeTest extends \PHPUnit_Framework_TestCase
+class ApiMediaTypeTest extends AbstractTypeTest
 {
     public function testBuildForm()
     {
+        parent::testBuildForm();
         $provider = $this->getMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
 
         $mediaPool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
@@ -34,5 +35,10 @@ class ApiMediaTypeTest extends \PHPUnit_Framework_TestCase
         $builder->expects($this->once())->method('addModelTransformer');
 
         $type->buildForm($builder, array('provider_name' => 'sonata.media.provider.image'));
+    }
+
+    protected function getTestedInstance()
+    {
+        return new ApiMediaType($this->mediaPool, 'testclass');
     }
 }

--- a/Tests/Form/Type/MediaTypeTest.php
+++ b/Tests/Form/Type/MediaTypeTest.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\Form\Type;
+
+use Sonata\MediaBundle\Form\Type\MediaType;
+
+/**
+ * @author Virgile Vivier <virgilevivier@gmail.com>
+ */
+class MediaTypeTest extends AbstractTypeTest
+{
+    protected function getTestedInstance()
+    {
+        return new MediaType($this->mediaPool, 'testclass');
+    }
+}

--- a/Tests/Provider/AbstractProviderTest.php
+++ b/Tests/Provider/AbstractProviderTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\Provider;
+
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\MediaBundle\Provider\MediaProviderInterface;
+use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\FormTypeInterface;
+
+/**
+ * @author Virgile Vivier <virgilevivier@gmail.com>
+ */
+abstract class AbstractProviderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var FormBuilder
+     */
+    protected $formBuilder;
+
+    /**
+     * @var FormMapper
+     */
+    protected $formMapper;
+
+    /**
+     * @var FormTypeInterface
+     */
+    protected $formType;
+
+    /**
+     * @var MediaProviderInterface
+     */
+    protected $provider;
+
+    public function setUp()
+    {
+        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
+        $that = $this;
+
+        $this->formMapper = $this->getMockBuilder('Sonata\AdminBundle\Form\FormMapper')->disableOriginalConstructor()->getMock();
+        $this->formMapper
+            ->expects($this->any())
+            ->method('add')
+            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+                    if (null !== $type) {
+                        $isFQCN = class_exists($type);
+                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                            // 2.8
+                            @trigger_error(
+                                sprintf(
+                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                                    .' Use the fully-qualified type class name instead.',
+                                    $type
+                                ),
+                                E_USER_DEPRECATED)
+                            ;
+                        }
+
+                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                    }
+                }
+            }));
+
+        $this->formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $this->formBuilder
+            ->expects($this->any())
+            ->method('add')
+            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
+                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
+                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+                    if (null !== $type) {
+                        $isFQCN = class_exists($type);
+                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
+                            // 2.8
+                            @trigger_error(
+                                sprintf(
+                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
+                                    .' Use the fully-qualified type class name instead.',
+                                    $type
+                                ),
+                                E_USER_DEPRECATED)
+                            ;
+                        }
+
+                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                    }
+                }
+            }));
+
+
+        $this->formBuilder->expects($this->any())->method('getOption')->willReturn('api');
+
+        $this->provider = $this->getProvider();
+    }
+
+    /**
+     * Get the provider which have to be tested.
+     */
+    abstract public function getProvider();
+
+    public function testBuildEditForm()
+    {
+        $this->provider->buildEditForm($this->formMapper);
+    }
+
+    public function testBuildCreateForm()
+    {
+        $this->provider->buildCreateForm($this->formMapper);
+    }
+
+    public function testBuildMediaType()
+    {
+        $this->provider->buildMediaType($this->formBuilder);
+    }
+}

--- a/Tests/Provider/BaseProviderTest.php
+++ b/Tests/Provider/BaseProviderTest.php
@@ -17,7 +17,7 @@ use Sonata\MediaBundle\Provider\BaseProvider;
 use Sonata\MediaBundle\Tests\Entity\Media;
 use Symfony\Component\Form\FormBuilder;
 
-class BaseProviderTest extends \PHPUnit_Framework_TestCase
+class BaseProviderTest extends AbstractProviderTest
 {
     public function getProvider()
     {

--- a/Tests/Provider/DailyMotionProviderTest.php
+++ b/Tests/Provider/DailyMotionProviderTest.php
@@ -18,7 +18,7 @@ use Sonata\MediaBundle\Provider\DailyMotionProvider;
 use Sonata\MediaBundle\Tests\Entity\Media;
 use Sonata\MediaBundle\Thumbnail\FormatThumbnail;
 
-class DailyMotionProviderTest extends \PHPUnit_Framework_TestCase
+class DailyMotionProviderTest extends AbstractProviderTest
 {
     public function getProvider(Browser $browser = null)
     {

--- a/Tests/Provider/FileProviderTest.php
+++ b/Tests/Provider/FileProviderTest.php
@@ -17,7 +17,7 @@ use Sonata\MediaBundle\Thumbnail\FormatThumbnail;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\Request;
 
-class FileProviderTest extends \PHPUnit_Framework_TestCase
+class FileProviderTest extends AbstractProviderTest
 {
     public function getProvider()
     {

--- a/Tests/Provider/ImageProviderTest.php
+++ b/Tests/Provider/ImageProviderTest.php
@@ -16,7 +16,7 @@ use Sonata\MediaBundle\Provider\ImageProvider;
 use Sonata\MediaBundle\Tests\Entity\Media;
 use Sonata\MediaBundle\Thumbnail\FormatThumbnail;
 
-class ImageProviderTest extends \PHPUnit_Framework_TestCase
+class ImageProviderTest extends AbstractProviderTest
 {
     public function getProvider($allowedExtensions = array(), $allowedMimeTypes = array())
     {

--- a/Tests/Provider/VimeoProviderTest.php
+++ b/Tests/Provider/VimeoProviderTest.php
@@ -18,7 +18,7 @@ use Sonata\MediaBundle\Provider\VimeoProvider;
 use Sonata\MediaBundle\Tests\Entity\Media;
 use Sonata\MediaBundle\Thumbnail\FormatThumbnail;
 
-class VimeoProviderTest extends \PHPUnit_Framework_TestCase
+class VimeoProviderTest extends AbstractProviderTest
 {
     public function getProvider(Browser $browser = null)
     {

--- a/Tests/Provider/YouTubeProviderTest.php
+++ b/Tests/Provider/YouTubeProviderTest.php
@@ -18,7 +18,7 @@ use Sonata\MediaBundle\Provider\YouTubeProvider;
 use Sonata\MediaBundle\Tests\Entity\Media;
 use Sonata\MediaBundle\Thumbnail\FormatThumbnail;
 
-class YouTubeProviderTest extends \PHPUnit_Framework_TestCase
+class YouTubeProviderTest extends AbstractProviderTest
 {
     public function getProvider(Browser $browser = null)
     {


### PR DESCRIPTION
I am targeting `3.x`, because it's the branch that should be compatible with Symfony 3+ but isn't.

## Changelog

```markdown
### Fixed
- Fixed `ApiMediaType::getParent` compatibility with Symfony3 forms
- Fixed `MediaType::buildForm` compatibility with Symfony3 forms
- Fixed `MediaType::getParent` compatibility with Symfony3 forms
- Fixed `BaseVideoProvider::buildEditForm` compatibility with Symfony3 forms
- Fixed `BaseVideoProvider::buildCreateForm` compatibility with Symfony3 forms
- Fixed `BaseVideoProvider:: buildMediaType` compatibility with Symfony3 forms
- Fixed `FileProvider::buildEditForm` compatibility with Symfony3 forms
- Fixed `FileProvider::buildCreateForm` compatibility with Symfony3 forms
- Fixed `FileProvider::buildMediaType` compatibility with Symfony3 forms

```

## Subject

Forms are not compatible with Symfony3 because it is currently using form short name instead of the FQCN. Since Symfony 3.0, you have to `'Symfony\Component\Form\Extension\Core\Type\TextType'` instead of `'text'`.

I am also preparing an equivalent PR for SonataCoreBundle (for the `Api*Type`s).