### PR TITLE
Fix request service call

### DIFF
--- a/Controller/MediaController.php
+++ b/Controller/MediaController.php
@@ -148,7 +148,7 @@ class MediaController extends Controller
      * 
      * @return Request
      * 
-     * NEXT_MAJOR : Return $this->get('request_stack') only
+     * NEXT_MAJOR : Return $this->get('request_stack')->getCurrentRequest() only
      * 
      */
     public function getRequest()

--- a/Controller/MediaController.php
+++ b/Controller/MediaController.php
@@ -142,10 +142,10 @@ class MediaController extends Controller
 
         return $response;
     }
-    
+
     /**
      * NEXT_MAJOR : Remove this method when bumping Symfony requirement to 2.8+.
-     * 
+     *
      * @return Request
      */
     private function getRequest()

--- a/Controller/MediaController.php
+++ b/Controller/MediaController.php
@@ -144,7 +144,7 @@ class MediaController extends Controller
     }
 
     /**
-     * NEXT_MAJOR : Remove this method when bumping Symfony requirement to 2.8+.
+     * NEXT_MAJOR: Remove this method when bumping Symfony requirement to 2.8+.
      *
      * @return Request
      */

--- a/Controller/MediaController.php
+++ b/Controller/MediaController.php
@@ -145,13 +145,11 @@ class MediaController extends Controller
     
     
     /**
+     * NEXT_MAJOR : Remove this method when bumping Symfony requirement to 2.8+
      * 
      * @return Request
-     * 
-     * NEXT_MAJOR : Return $this->get('request_stack')->getCurrentRequest() only
-     * 
      */
-    public function getRequest()
+    private function getRequest()
     {
         if ($this->has('request_stack')) {
             return $this->get('request_stack')->getCurrentRequest();

--- a/Controller/MediaController.php
+++ b/Controller/MediaController.php
@@ -144,15 +144,19 @@ class MediaController extends Controller
     }
     
     
-        /**
+    /**
+     * 
      * @return Request
+     * 
+     * NEXT_MAJOR : Return $this->get('request_stack') only
+     * 
      */
     public function getRequest()
     {
-        if ($this->container->has('request_stack')) {
-            return $this->container->get('request_stack')->getCurrentRequest();
+        if ($this->has('request_stack')) {
+            return $this->get('request_stack')->getCurrentRequest();
         }
 
-        return $this->container->get('request');
+        return $this->get('request');
     }
 }

--- a/Controller/MediaController.php
+++ b/Controller/MediaController.php
@@ -143,9 +143,8 @@ class MediaController extends Controller
         return $response;
     }
     
-    
     /**
-     * NEXT_MAJOR : Remove this method when bumping Symfony requirement to 2.8+
+     * NEXT_MAJOR : Remove this method when bumping Symfony requirement to 2.8+.
      * 
      * @return Request
      */

--- a/Controller/MediaController.php
+++ b/Controller/MediaController.php
@@ -64,7 +64,7 @@ class MediaController extends Controller
         $response = $this->getProvider($media)->getDownloadResponse($media, $format, $this->get('sonata.media.pool')->getDownloadMode($media));
 
         if ($response instanceof BinaryFileResponse) {
-            $response->prepare($this->get('request'));
+            $response->prepare($this->getRequest());
         }
 
         return $response;
@@ -113,7 +113,7 @@ class MediaController extends Controller
             throw new NotFoundHttpException();
         }
 
-        $targetPath = $this->get('liip_imagine.cache.manager')->resolve($this->get('request'), $path, $filter);
+        $targetPath = $this->get('liip_imagine.cache.manager')->resolve($this->getRequest(), $path, $filter);
 
         if ($targetPath instanceof Response) {
             return $targetPath;
@@ -134,12 +134,25 @@ class MediaController extends Controller
 
         $image = $this->get('liip_imagine')->open($tmpFile);
 
-        $response = $this->get('liip_imagine.filter.manager')->get($this->get('request'), $filter, $image, $path);
+        $response = $this->get('liip_imagine.filter.manager')->get($this->getRequest(), $filter, $image, $path);
 
         if ($targetPath) {
             $response = $this->get('liip_imagine.cache.manager')->store($response, $targetPath, $filter);
         }
 
         return $response;
+    }
+    
+    
+        /**
+     * @return Request
+     */
+    public function getRequest()
+    {
+        if ($this->container->has('request_stack')) {
+            return $this->container->get('request_stack')->getCurrentRequest();
+        }
+
+        return $this->container->get('request');
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I've explained [here](https://github.com/sonata-project/SonataMediaBundle/issues/1068) method `getRequest()` has been removed in SF3
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Added
- Added `getRequest` method on controller for BC with Symfony 2.3+
```
