### PR TITLE
Fix media widget spanish translations

### DIFF
--- a/Resources/translations/SonataMediaBundle.es.xliff
+++ b/Resources/translations/SonataMediaBundle.es.xliff
@@ -385,23 +385,23 @@
             </trans-unit>
             <trans-unit id="widget_label_type">
                 <source>widget_label_type</source>
-                <target>widget_label_type</target>
+                <target>Tipo</target>
             </trans-unit>
             <trans-unit id="widget_label_context">
                 <source>widget_label_context</source>
-                <target>widget_label_context</target>
+                <target>Contexto</target>
             </trans-unit>
             <trans-unit id="widget_headline_information">
                 <source>widget_headline_information</source>
-                <target>widget_headline_information</target>
+                <target>Información</target>
             </trans-unit>
             <trans-unit id="widget_label_unlink">
                 <source>widget_label_unlink</source>
-                <target>widget_label_unlink</target>
+                <target>Eliminar</target>
             </trans-unit>
             <trans-unit id="widget_label_binary_content">
                 <source>widget_label_binary_content</source>
-                <target>widget_label_binary_content</target>
+                <target>Fichero</target>
             </trans-unit>
             <trans-unit id="sonata_media_gallery_index">
                 <source>sonata_media_gallery_index</source>
@@ -409,7 +409,7 @@
             </trans-unit>
             <trans-unit id="sonata_template_box_media_gallery_block">
                 <source>sonata_template_box_media_gallery_block</source>
-                <target>Este es el bloque media para la gelería. Puedes sobreescribirlo cuando gustes.</target>
+                <target>Este es el bloque media para la galería. Puedes sobreescribirlo cuando gustes.</target>
             </trans-unit>
             <trans-unit id="list.label_description">
                 <source>list.label_description</source>


### PR DESCRIPTION
I am targetting this branch, because this is a translation improvement.

## Changelog

```markdown
### Fixed
- Fixed media widget spanish translations
```

## Subject

This fixes media widget spanish translations.

