### PR TITLE
add region to S3Client config

### DIFF
--- a/DependencyInjection/SonataMediaExtension.php
+++ b/DependencyInjection/SonataMediaExtension.php
@@ -352,6 +352,7 @@ class SonataMediaExtension extends Extension
                 ->replaceArgument(0, array(
                     'secret' => $config['filesystem']['s3']['secretKey'],
                     'key'    => $config['filesystem']['s3']['accessKey'],
+                    'region' => $config['filesystem']['s3']['region'],
                 ))
             ;
         } else {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, juste because I need to have this feature in 2.x too [#1013](https://github.com/sonata-project/SonataMediaBundle/pull/1013)
This refers to my previous [#923](https://github.com/sonata-project/SonataMediaBundle/pull/923) before the new Sonata version management.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes [#923](https://github.com/sonata-project/SonataMediaBundle/pull/923)

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `region` key to S3Client config
```

## Subject

pass the region for aws sdk to generate signature

https://github.com/aws/aws-sdk-php/blob/2.7.27/src/Aws/S3/S3Client.php#L272



