### PR TITLE
Fixed wrong imports in tests

### DIFF
--- a/Tests/Block/GalleryListBlockServiceTest.php
+++ b/Tests/Block/GalleryListBlockServiceTest.php
@@ -13,13 +13,12 @@ namespace Sonata\MediaBundle\Tests\Block\Service;
 
 use Sonata\BlockBundle\Block\BlockContext;
 use Sonata\BlockBundle\Model\Block;
-use Sonata\BlockBundle\Tests\Block\AbstractBlockServiceTest;
-use Sonata\BlockBundle\Tests\Block\Service\FakeTemplating;
+use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
 use Sonata\MediaBundle\Block\GalleryListBlockService;
 use Sonata\MediaBundle\Model\GalleryManagerInterface;
 use Sonata\MediaBundle\Provider\Pool;
 
-class GalleryListBlockServiceTest extends AbstractBlockServiceTest
+class GalleryListBlockServiceTest extends AbstractBlockServiceTestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|GalleryManagerInterface
@@ -31,18 +30,12 @@ class GalleryListBlockServiceTest extends AbstractBlockServiceTest
      */
     protected $pool;
 
-    /**
-     * @var FakeTemplating
-     */
-    protected $templating;
-
     protected function setUp()
     {
         parent::setUp();
 
         $this->galleryManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
         $this->pool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
-        $this->templating = new FakeTemplating();
     }
 
     public function testExecute()

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         "friendsofsymfony/rest-bundle": "<1.7.4 || >=3.0",
         "jms/serializer": "<0.13",
         "sonata-project/seo-bundle": "<2.0 || >=3.0",
-        "sonata-project/block-bundle": "<3.0 || >=4.0"
+        "sonata-project/block-bundle": "<3.1.1 || >=4.0"
     },
     "autoload": {
         "psr-4": { "Sonata\\MediaBundle\\": "" }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a fix for the unit tests in the stable branch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- unit tests use the correct namespace in imports.
```

## Subject

This fixes the imports in the test cases. The sub namespace `Tests` isn't public anymore.

