### PR TITLE
Added missing block dependency

### DIFF
--- a/DependencyInjection/SonataMediaExtension.php
+++ b/DependencyInjection/SonataMediaExtension.php
@@ -39,7 +39,6 @@ class SonataMediaExtension extends Extension
         $loader->load('provider.xml');
         $loader->load('media.xml');
         $loader->load('twig.xml');
-        $loader->load('block.xml');
         $loader->load('security.xml');
         $loader->load('extra.xml');
         $loader->load('form.xml');
@@ -86,6 +85,10 @@ class SonataMediaExtension extends Extension
 
         if (isset($bundles['SonataFormatterBundle'])) {
             $loader->load('formatter.xml');
+        }
+
+        if (isset($bundles['SonataBlockBundle'])) {
+            $loader->load('block.xml');
         }
 
         if (isset($bundles['SonataSeoBundle'])) {

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
         "sonata-project/admin-bundle": "^3.1",
         "sonata-project/formatter-bundle": "^3.0",
         "sonata-project/datagrid-bundle": "^2.2",
+        "sonata-project/block-bundle": "^3.1.1",
         "sonata-project/seo-bundle": "^2.0",
         "aws/aws-sdk-php": "^2.7",
         "jackalope/jackalope-doctrine-dbal": "^1.1",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Added `sonata-project/block-bundle` dependency
```

## Subject

Made the block bundle dependency surly optional.
