### PR TITLE
Fix imports in GalleryController

### DIFF
--- a/Controller/Api/GalleryController.php
+++ b/Controller/Api/GalleryController.php
@@ -12,10 +12,12 @@
 namespace Sonata\MediaBundle\Controller\Api;
 
 use FOS\RestBundle\Context\Context;
+use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\View;
 use FOS\RestBundle\Request\ParamFetcherInterface;
 use FOS\RestBundle\View\View as FOSRestView;
 use JMS\Serializer\SerializationContext;
+use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\MediaBundle\Model\GalleryHasMediaInterface;
 use Sonata\MediaBundle\Model\GalleryInterface;


### PR DESCRIPTION
I am targeting 3.x, because 3.x was never working, to get it work.

Fixes #1080

## Changelog

```markdown
### Fixed
- Restored `ApiDoc` and `QueryParam` use statements in `Api/GalleryController`

```

## Subject

Restores use statements to fix import exceptions in example in composer install. More details in the issue.