### PR TITLE
Rename downloadSecurity to downloadStrategy

### DIFF
--- a/Resources/views/MediaAdmin/edit.html.twig
+++ b/Resources/views/MediaAdmin/edit.html.twig
@@ -73,7 +73,7 @@ file that was distributed with this source code.
                                     <th><a href="{{ path('sonata_media_download', {'id': object|sonata_urlsafeid }) }}">{{ 'label.protected_download_url'|trans({}, 'SonataMediaBundle') }}</a></th>
                                     <td>
                                         <input type="text" class="form-control" onClick="this.select();" readonly="readonly" value="{{ path('sonata_media_download', {'id': object|sonata_urlsafeid }) }}" />
-                                        <span class="label label-warning">{{ 'label.protected_download_url_notice'|trans({}, 'SonataMediaBundle') }}</span> {{ sonata_media.pool.downloadSecurity(object).description|raw }}
+                                        <span class="label label-warning">{{ 'label.protected_download_url_notice'|trans({}, 'SonataMediaBundle') }}</span> {{ sonata_media.pool.downloadStrategy(object).description|raw }}
                                     </td>
                                 <tr>
                                 <tr>


### PR DESCRIPTION
I am targetting this branch, because there is no BC-break, and this deprecated call can produce a 500 error on some servers.

## Changelog

```markdown

### Fixed
- Fixed deprecated call of `downloadSecurity` in `Resources/views/MediaAdmin/edit.html.twig` template.
```

## Subject

Found and fixed a deprecated call of `downloadSecurity` in `Resources/views/MediaAdmin/edit.html.twig`.
