### PR TITLE
added upgrade note for deprecated container property

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -9,3 +9,19 @@ UPGRADE FROM 3.0 to 3.1
 All files under the ``Tests`` directory are now correctly handled as internal test classes. 
 You can't extend them anymore, because they are only loaded when running internal tests. 
 More information can be found in the [composer docs](https://getcomposer.org/doc/04-schema.md#autoload-dev).
+
+### Deprecated
+
+`$container` property in `Security/SessionDownloadStrategy` is deprecated. Use `SessionInterface` `$session` instead.
+
+Before:
+
+```php
+    $downloadStrategy = new SessionDownloadStrategy($translator, $container, $times);
+```
+
+After:
+
+```php
+    $downloadStrategy = new SessionDownloadStrategy($translator, $session, $times);
+```


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is upgrade not of this branch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

refs #1035 

