### PR TITLE
Fixed missing german translation

### DIFF
--- a/Resources/translations/SonataMediaBundle.de.xliff
+++ b/Resources/translations/SonataMediaBundle.de.xliff
@@ -567,6 +567,18 @@
                 <source>form.label_class</source>
                 <target>CSS Klasse</target>
             </trans-unit>
+            <trans-unit id="media_">
+                <source>Media</source>
+                <target>Medien</target>
+            </trans-unit>
+            <trans-unit id="gallery_">
+                <source>Gallery</source>
+                <target>Galerie</target>
+            </trans-unit>
+            <trans-unit id="options">
+                <source>Options</source>
+                <target>Einstellungen</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this adds missing lables.

## Subject

Some german translation keys were missing.

