### PR TITLE
Fixed wrong html

### DIFF
--- a/Resources/views/MediaAdmin/edit.html.twig
+++ b/Resources/views/MediaAdmin/edit.html.twig
@@ -44,20 +44,20 @@ file that was distributed with this source code.
                         </div>
                         <div class="box-body table-responsive">
 
-                            <center> <!-- yeah, center is still awesome ;) -->
+                            <div class="text-center">
                                 {% media object, 'reference' with {'class': 'img-responsive img-rounded'} %}
-                            </center>
+                            </div>
 
                             <table class="table">
                                 <tr>
                                     <th>{{ 'label.size'|trans({}, 'SonataMediaBundle') }}</th>
                                     <td>{{ object.width|number_format_decimal }}px x {{ object.height|number_format_decimal }}px
                                         {% if object.size > 0 %}({{ object.size|number_format_decimal }}o){% endif %}</td>
-                                <tr>
+                                </tr>
                                 <tr>
                                     <th>{{ 'label.content_type'|trans({}, 'SonataMediaBundle') }}</th>
                                     <td>{{ object.contenttype }}</td>
-                                <tr>
+                                </tr>
                                 <tr>
                                     <th>{{ 'label.cdn'|trans({}, 'SonataMediaBundle') }}</th>
                                     <td>
@@ -68,14 +68,14 @@ file that was distributed with this source code.
                                             {{ object.cdnflushat|date }}
                                         {% endif %}
                                     </td>
-                                <tr>
+                                </tr>
                                 <tr>
                                     <th><a href="{{ path('sonata_media_download', {'id': object|sonata_urlsafeid }) }}">{{ 'label.protected_download_url'|trans({}, 'SonataMediaBundle') }}</a></th>
                                     <td>
                                         <input type="text" class="form-control" onClick="this.select();" readonly="readonly" value="{{ path('sonata_media_download', {'id': object|sonata_urlsafeid }) }}" />
                                         <span class="label label-warning">{{ 'label.protected_download_url_notice'|trans({}, 'SonataMediaBundle') }}</span> {{ sonata_media.pool.downloadSecurity(object).description|raw }}
                                     </td>
-                                <tr>
+                                </tr>
                                 <tr>
                                     <th>
                                         <a href="{% path object, 'reference' %}" target="_blank">reference</a>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because…

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Fixed wrong html usage in edit template
```

## Subject

The `center` tag doesn't exist anymore and the closing tags of `<tr>`s were missing.
