### PR TITLE
Fixed wrong edit form extension

### DIFF
--- a/Resources/views/MediaAdmin/edit.html.twig
+++ b/Resources/views/MediaAdmin/edit.html.twig
@@ -20,8 +20,7 @@ file that was distributed with this source code.
     </style>
 {% endblock %}
 
-{% block sonata_admin_content %}
-
+{% block form %}
     <div class="row">
         {% if object.id %}
             <div class="col-md-6">
@@ -137,6 +136,4 @@ file that was distributed with this source code.
             Admin.setup_list_modal(jQuery('#pixlr-modal'));
         </script>
     {% endif %}
-
-
-{% endblock sonata_admin_content %}
+{% endblock form %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Fixed wrong block inheritance in edit template
```

## Subject

Before

![bildschirmfoto 2016-08-07 um 10 48 33](https://cloud.githubusercontent.com/assets/3440437/17461448/fa72ad5a-5c8c-11e6-8ea3-f0b4821acce6.PNG)

After
![bildschirmfoto 2016-08-07 um 10 47 12](https://cloud.githubusercontent.com/assets/3440437/17461447/fa6ecc08-5c8c-11e6-9ec6-d48e290e6d66.PNG)


