### PR TITLE
Use FQCNs when building mocks

### DIFF
--- a/Tests/CDN/CloudFrontTest.php
+++ b/Tests/CDN/CloudFrontTest.php
@@ -21,7 +21,13 @@ class CloudFrontTest extends \PHPUnit_Framework_TestCase
      */
     public function testLegacyCloudFront()
     {
-        $client = $this->getMock('CloudFrontClientSpy', array('createInvalidation'), array(), '', false);
+        $client = $this->getMock(
+            'Sonata\MediaBundle\Tests\CDN\CloudFrontClientSpy',
+            array('createInvalidation'),
+            array(),
+            '',
+            false
+        );
         $client->expects($this->exactly(3))->method('createInvalidation')->will($this->returnValue(new CloudFrontResultSpy()));
 
         $cloudFront = $this->getMockBuilder('Sonata\MediaBundle\CDN\CloudFront')
@@ -45,7 +51,13 @@ class CloudFrontTest extends \PHPUnit_Framework_TestCase
     public function testLegacyException()
     {
         $this->setExpectedException('\RuntimeException', 'Unable to flush : ');
-        $client = $this->getMock('CloudFrontClientSpy', array('createInvalidation'), array(), '', false);
+        $client = $this->getMock(
+            'Sonata\MediaBundle\Tests\CDN\CloudFrontClientSpy',
+            array('createInvalidation'),
+            array(),
+            '',
+            false
+        );
         $client->expects($this->exactly(1))->method('createInvalidation')->will($this->returnValue(new CloudFrontResultSpy(true)));
         $cloudFront = $this->getMockBuilder('Sonata\MediaBundle\CDN\CloudFront')
                     ->setConstructorArgs(array('/foo', 'secret', 'key', 'xxxxxxxxxxxxxx'))

--- a/Tests/CDN/PantherPortalTest.php
+++ b/Tests/CDN/PantherPortalTest.php
@@ -17,7 +17,13 @@ class PantherPortalTest extends \PHPUnit_Framework_TestCase
 {
     public function testPortal()
     {
-        $client = $this->getMock('ClientSpy', array('flush'), array(), '', false);
+        $client = $this->getMock(
+            'Sonata\MediaBundle\Tests\CDN\ClientSpy',
+            array('flush'),
+            array(),
+            '',
+            false
+        );
         $client->expects($this->exactly(3))->method('flush')->will($this->returnValue('Flush successfully submitted.'));
 
         $panther = new PantherPortal('/foo', 'login', 'pass', 42);
@@ -36,7 +42,13 @@ class PantherPortalTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('\RuntimeException', 'Unable to flush : Failed!!');
 
-        $client = $this->getMock('ClientSpy', array('flush'), array(), '', false);
+        $client = $this->getMock(
+            'Sonata\MediaBundle\Tests\CDN\ClientSpy',
+            array('flush'),
+            array(),
+            '',
+            false
+        );
         $client->expects($this->exactly(1))->method('flush')->will($this->returnValue('Failed!!'));
 
         $panther = new PantherPortal('/foo', 'login', 'pass', 42);


### PR DESCRIPTION
I am targetting this branch, because it is a critical patch.

## Changelog

No changelog, users do not care about our tests (right?)

## To do

Merge ASAP :rotating_light: 

## Subject

phpunit has no idea what the current namespace is.

This is why builds on most PRs are failing right now.