### PR TITLE
Add default resizer and default resizer adapter

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -56,6 +56,7 @@ class Configuration implements ConfigurationInterface
         $this->addModelSection($node);
         $this->addBuzzSection($node);
         $this->addResizerSection($node);
+        $this->addAdapterSection($node);
 
         return $treeBuilder;
     }
@@ -326,12 +327,12 @@ class Configuration implements ConfigurationInterface
                             ->addDefaultsIfNotSet()
                             ->children()
                                 ->scalarNode('service')->defaultValue('sonata.media.provider.image')->end()
-                                ->scalarNode('resizer')->defaultValue('sonata.media.resizer.simple')->end()
+                                ->scalarNode('resizer')->defaultValue('sonata.media.resizer.default')->end()
                                 ->scalarNode('filesystem')->defaultValue('sonata.media.filesystem.local')->end()
                                 ->scalarNode('cdn')->defaultValue('sonata.media.cdn.server')->end()
                                 ->scalarNode('generator')->defaultValue('sonata.media.generator.default')->end()
                                 ->scalarNode('thumbnail')->defaultValue('sonata.media.thumbnail.format')->end()
-                                ->scalarNode('adapter')->defaultValue('sonata.media.adapter.image.gd')->end()
+                                ->scalarNode('adapter')->defaultValue('sonata.media.adapter.image.default')->end()
                                 ->arrayNode('allowed_extensions')
                                     ->prototype('scalar')->end()
                                     ->defaultValue(array('jpg', 'png', 'jpeg'))
@@ -352,7 +353,7 @@ class Configuration implements ConfigurationInterface
                             ->addDefaultsIfNotSet()
                             ->children()
                                 ->scalarNode('service')->defaultValue('sonata.media.provider.youtube')->end()
-                                ->scalarNode('resizer')->defaultValue('sonata.media.resizer.simple')->end()
+                                ->scalarNode('resizer')->defaultValue('sonata.media.resizer.default')->end()
                                 ->scalarNode('filesystem')->defaultValue('sonata.media.filesystem.local')->end()
                                 ->scalarNode('cdn')->defaultValue('sonata.media.cdn.server')->end()
                                 ->scalarNode('generator')->defaultValue('sonata.media.generator.default')->end()
@@ -365,7 +366,7 @@ class Configuration implements ConfigurationInterface
                             ->addDefaultsIfNotSet()
                             ->children()
                                 ->scalarNode('service')->defaultValue('sonata.media.provider.dailymotion')->end()
-                                ->scalarNode('resizer')->defaultValue('sonata.media.resizer.simple')->end()
+                                ->scalarNode('resizer')->defaultValue('sonata.media.resizer.default')->end()
                                 ->scalarNode('filesystem')->defaultValue('sonata.media.filesystem.local')->end()
                                 ->scalarNode('cdn')->defaultValue('sonata.media.cdn.server')->end()
                                 ->scalarNode('generator')->defaultValue('sonata.media.generator.default')->end()
@@ -377,7 +378,7 @@ class Configuration implements ConfigurationInterface
                             ->addDefaultsIfNotSet()
                             ->children()
                                 ->scalarNode('service')->defaultValue('sonata.media.provider.vimeo')->end()
-                                ->scalarNode('resizer')->defaultValue('sonata.media.resizer.simple')->end()
+                                ->scalarNode('resizer')->defaultValue('sonata.media.resizer.default')->end()
                                 ->scalarNode('filesystem')->defaultValue('sonata.media.filesystem.local')->end()
                                 ->scalarNode('cdn')->defaultValue('sonata.media.cdn.server')->end()
                                 ->scalarNode('generator')->defaultValue('sonata.media.generator.default')->end()
@@ -478,6 +479,29 @@ class Configuration implements ConfigurationInterface
                                 ->scalarNode('mode')->defaultValue('inset')->end()
                             ->end()
                         ->end()
+                    ->end()
+                ->end()
+                ->arrayNode('resizers')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('default')->defaultValue('sonata.media.resizer.simple')->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    /**
+     * @param ArrayNodeDefinition $node
+     */
+    private function addAdapterSection(ArrayNodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->arrayNode('adapters')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('default')->defaultValue('sonata.media.adapter.image.gd')->end()
                     ->end()
                 ->end()
             ->end()

--- a/Resizer/SquareResizer.php
+++ b/Resizer/SquareResizer.php
@@ -29,12 +29,12 @@ use Sonata\MediaBundle\Model\MediaInterface;
 class SquareResizer implements ResizerInterface
 {
     /**
-     * ImagineInterface.
+     * @var ImagineInterface
      */
     protected $adapter;
 
     /**
-     * string.
+     * @var string
      */
     protected $mode;
 
@@ -48,6 +48,22 @@ class SquareResizer implements ResizerInterface
         $this->adapter = $adapter;
         $this->mode = $mode;
         $this->metadata = $metadata;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAdapter()
+    {
+        return $this->adapter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setAdapter(ImagineInterface $adapter)
+    {
+        $this->adapter = $adapter;
     }
 
     /**

--- a/Resources/config/media.xml
+++ b/Resources/config/media.xml
@@ -3,22 +3,11 @@
     <parameters>
         <parameter key="sonata.media.resizer.simple.class">Sonata\MediaBundle\Resizer\SimpleResizer</parameter>
         <parameter key="sonata.media.resizer.square.class">Sonata\MediaBundle\Resizer\SquareResizer</parameter>
+        <parameter key="sonata.media.adapter.image.gd.class">Imagine\Gd\Imagine</parameter>
+        <parameter key="sonata.media.adapter.image.imagick.class">Imagine\Imagick\Imagine</parameter>
+        <parameter key="sonata.media.adapter.image.gmagick.class">Imagine\Gmagick\Imagine</parameter>
     </parameters>
     <services>
-        <!-- image manipulation service -->
-        <service id="sonata.media.adapter.image.gd" class="Imagine\Gd\Imagine"/>
-        <service id="sonata.media.adapter.image.imagick" class="Imagine\Imagick\Imagine"/>
-        <service id="sonata.media.adapter.image.gmagick" class="Imagine\Gmagick\Imagine"/>
-        <service id="sonata.media.resizer.simple" class="%sonata.media.resizer.simple.class%">
-            <argument type="service" id="sonata.media.adapter.image.gd"/>
-            <argument>%sonata.media.resizer.simple.adapter.mode%</argument>
-            <argument type="service" id="sonata.media.metadata.proxy"/>
-        </service>
-        <service id="sonata.media.resizer.square" class="%sonata.media.resizer.square.class%">
-            <argument type="service" id="sonata.media.adapter.image.gd"/>
-            <argument>%sonata.media.resizer.square.adapter.mode%</argument>
-            <argument type="service" id="sonata.media.metadata.proxy"/>
-        </service>
         <!-- CDN abstraction service -->
         <service id="sonata.media.cdn.server" class="Sonata\MediaBundle\CDN\Server">
             <argument/>

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -9,29 +9,39 @@
  * file that was distributed with this source code.
  */
 
-namespace Sonata\MediaBundle\Tests;
+namespace Sonata\MediaBundle\Tests\DependencyInjection;
 
 use Sonata\MediaBundle\DependencyInjection\Configuration;
 use Symfony\Component\Config\Definition\Processor;
 
 class ConfigurationTest extends \PHPUnit_Framework_TestCase
 {
-    public function testAdminFormat()
-    {
-        $processor = new Processor();
+    /**
+     * @var array
+     */
+    protected $config;
 
-        $config = $processor->processConfiguration(new Configuration(), array(
-            array(
-                'db_driver' => 'foo',
+    public function setUp()
+    {
+        $configs = array(
+            'sonata_media' => array(
+                'db_driver' => 'doctrine_orm',
                 'default_context' => 'default',
             ),
-        ));
+        );
+        $processor = new Processor();
+        $configuration = new Configuration();
+        $this->config = $processor->processConfiguration($configuration, $configs);
+    }
 
-        $this->assertNotNull($config['admin_format']);
-        $this->assertSame(200, $config['admin_format']['width']);
-        $this->assertSame(false, $config['admin_format']['height']);
-        $this->assertSame(90, $config['admin_format']['quality']);
-        $this->assertSame('jpg', $config['admin_format']['format']);
-        $this->assertSame(true, $config['admin_format']['constraint']);
+    public function testProcess()
+    {
+        $this->assertArrayHasKey('resizers', $this->config);
+        $this->assertArrayHasKey('default', $this->config['resizers']);
+        $this->assertEquals('sonata.media.resizer.simple', $this->config['resizers']['default']);
+
+        $this->assertArrayHasKey('adapters', $this->config);
+        $this->assertArrayHasKey('default', $this->config['adapters']);
+        $this->assertEquals('sonata.media.adapter.image.gd', $this->config['adapters']['default']);
     }
 }

--- a/Tests/DependencyInjection/SonataMediaExtensionTest.php
+++ b/Tests/DependencyInjection/SonataMediaExtensionTest.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\DependencyInjection;
+
+use Sonata\MediaBundle\DependencyInjection\SonataMediaExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class SonataMediaExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var SonataMediaExtension
+     */
+    private $extension;
+
+    /**
+     * Root name of the configuration.
+     *
+     * @var ContainerBuilder
+     */
+    private $container;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        $configs = $this->getConfigs();
+
+        $this->container = new ContainerBuilder();
+        $this->container->setParameter('kernel.bundles', array());
+
+        $this->extension = $this->getExtension();
+        $this->extension->load($configs, $this->container);
+    }
+
+    public function testDefaultAdapter()
+    {
+        $this->assertTrue($this->container->hasAlias('sonata.media.adapter.image.default'));
+        $this->assertEquals('sonata.media.adapter.image.gd', $this->container->getAlias('sonata.media.adapter.image.default'));
+    }
+
+    /**
+     * @param string $serviceId
+     * @param string $extension
+     * @param string $type
+     *
+     * @dataProvider dataAdapter
+     */
+    public function testAdapter($serviceId, $extension, $type)
+    {
+        $this->assertTrue($this->container->has($serviceId));
+
+        if (extension_loaded($extension)) {
+            $this->isInstanceOf($type, $this->container->get($serviceId));
+        }
+    }
+
+    public function dataAdapter()
+    {
+        return array(
+            array('sonata.media.adapter.image.gd', 'gd', 'Imagine\\Gd\\Imagine'),
+            array('sonata.media.adapter.image.gmagick', 'gmagick', 'Imagine\\Gmagick\\Imagine'),
+            array('sonata.media.adapter.image.imagick', 'imagick', 'Imagine\\Imagick\\Imagine'),
+        );
+    }
+
+    public function testDefaultResizer()
+    {
+        $this->assertTrue($this->container->hasAlias('sonata.media.resizer.default'));
+        $this->assertEquals('sonata.media.resizer.simple', $this->container->getAlias('sonata.media.resizer.default'));
+        if (extension_loaded('gd')) {
+            $this->isInstanceOf('Sonata\\MediaBundle\\Resizer\\SimpleResizer', $this->container->get('sonata.media.resizer.default'));
+        }
+    }
+
+    /**
+     * @param $serviceId
+     * @param $type
+     *
+     * @dataProvider dataResizer
+     */
+    public function testResizer($serviceId, $type)
+    {
+        $this->assertTrue($this->container->has($serviceId));
+        if (extension_loaded('gd')) {
+            $this->isInstanceOf($type, $this->container->get($serviceId));
+        }
+    }
+
+    public function dataResizer()
+    {
+        return array(
+            array('sonata.media.resizer.simple', 'Sonata\\MediaBundle\\Resizer\\SimpleResizer'),
+            array('sonata.media.resizer.square', 'Sonata\\MediaBundle\\Resizer\\SquareResizer'),
+        );
+    }
+
+    /**
+     * @return SonataMediaExtension
+     */
+    protected function getExtension()
+    {
+        return new SonataMediaExtension();
+    }
+
+    /**
+     * @return ContainerBuilder
+     */
+    protected function getContainer()
+    {
+        return new ContainerBuilder();
+    }
+
+    /**
+     * @return array
+     */
+    protected function getConfigs()
+    {
+        $configs = array(
+            'sonata_media' => array(
+                'db_driver' => 'doctrine_orm',
+                'default_context' => 'default',
+                'contexts' => array(
+                    'default' => array(
+                        'providers' => array(
+                            'sonata.media.provider.image',
+                        ),
+                        'formats' => array(
+                            'default' => array(
+                                'width' => 100,
+                                'quality' => 100,
+                            ),
+                        ),
+                    ),
+                ),
+                'cdn' => array(
+                    'server' => array(
+                        'path' => '/uploads/media',
+                    ),
+                ),
+                'filesystem' => array(
+                    'local' => array(
+                        'directory' => '%kernel.root_dir%/../web/uploads/media',
+                    ),
+                ),
+            ),
+        );
+
+        return $configs;
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this feature is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Rebase of #721
Closes #700

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added config key to define default resizer
- Added config key to define default resizer adapter
```

## Subject

Added two new config keys to define default resizer and resizer adapters to reduce duplicate configuration on each provider.

