### PR TITLE
Revert a BC-break introduced by 22b20c5af

### DIFF
--- a/Tests/Twig/Extension/MediaExtensionTest.php
+++ b/Tests/Twig/Extension/MediaExtensionTest.php
@@ -41,7 +41,7 @@ class MediaExtensionTest extends \PHPUnit_Framework_TestCase
      */
     private $media;
 
-    public function testThumbnailCanRenderHtmlAttributesGivenByTheProvider()
+    public function testThumbnailHasAllNecessaryAttributes()
     {
         $mediaExtension = new MediaExtension($this->getMediaService(), $this->getMediaManager());
         $mediaExtension->initRuntime($this->getEnvironment());
@@ -54,12 +54,8 @@ class MediaExtensionTest extends \PHPUnit_Framework_TestCase
         );
 
         $provider = $this->getProvider();
-        $provider->expects($this->once())->method('getHelperProperties')->with($media, $format, $options)
-            ->willReturn(array(
-                'title' => 'Test title',
-                'alt' => 'Test title',
-                'data-custom' => 'foo',
-            ));
+        $provider->expects($this->once())->method('generatePublicUrl')->with($media, $format)
+            ->willReturn('http://some.url.com');
 
         $template = $this->getTemplate();
         $template->expects($this->once())
@@ -71,7 +67,7 @@ class MediaExtensionTest extends \PHPUnit_Framework_TestCase
                         'options' => array(
                             'title' => 'Test title',
                             'alt' => 'Test title',
-                            'data-custom' => 'foo',
+                            'src' => 'http://some.url.com',
                         ),
                     )
                 )

--- a/Twig/Extension/MediaExtension.php
+++ b/Twig/Extension/MediaExtension.php
@@ -146,7 +146,7 @@ class MediaExtension extends \Twig_Extension implements \Twig_Extension_InitRunt
 
         $options = array_merge($defaultOptions, $options);
 
-        $options = $provider->getHelperProperties($media, $format, $options);
+        $options['src'] = $provider->generatePublicUrl($media, $format);
 
         return $this->render($provider->getTemplate('helper_thumbnail'), array(
             'media' => $media,


### PR DESCRIPTION
I am targetting this branch, even though this is major

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Ability to provide custom attributes for a thumbnail
```
## Subject

Reverting a BC-break is a BC-break, but I demand that this gets merged
anyway. If someone wants to restore this behavior, they will need to do it **properly**.
Fixes #1065