### PR TITLE
Fix "callback constraint is not a valid callable" and the error of BaseMediaAdmin incorrectly retrieving providerName

### DIFF
--- a/Admin/BaseMediaAdmin.php
+++ b/Admin/BaseMediaAdmin.php
@@ -106,7 +106,7 @@ abstract class BaseMediaAdmin extends AbstractAdmin
 
         if ($this->hasRequest()) {
             if ($this->getRequest()->isMethod('POST')) {
-                $media->setProviderName($this->getRequest()->get(sprintf('%s[providerName]', $this->getUniqid()), null, true));
+                $media->setProviderName($this->getRequest()->get(sprintf('%s', $this->getUniqid()), null, true)['providerName']);
             } else {
                 $media->setProviderName($this->getRequest()->get('provider'));
             }
@@ -154,8 +154,7 @@ abstract class BaseMediaAdmin extends AbstractAdmin
             ->addIdentifier('name')
             ->add('description')
             ->add('enabled')
-            ->add('size')
-        ;
+            ->add('size');
     }
 
     /**

--- a/Resources/config/validation.xml
+++ b/Resources/config/validation.xml
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping         http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
     <class name="Sonata\MediaBundle\Model\Media">
-        <constraint name="Callback">
-            <option name="methods">
-                <value>isStatusErroneous</value>
-            </option>
-        </constraint>
+        <constraint name="Callback">isStatusErroneous</constraint>
         <constraint name="Sonata\CoreBundle\Validator\Constraints\InlineConstraint">
             <option name="service">sonata.media.pool</option>
             <option name="method">validate</option>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch to fix issue #1101 and this is BC.
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

``` markdown
### Changed
- invalid markup in **../Resources/config/validation.xml**
- invalid request param retrieval in **../Admin/BaseMediaAdmin.php**
```

**Change No 1** 
in **../Resources/config/validation.xml** to fix "callback constraint is not a valid callable" 
changed

```
        <constraint name="Callback">
            <option name="methods">
                <value>isStatusErroneous</value>
            </option>
        </constraint>
```

to 
`<constraint name="Callback">isStatusErroneous</constraint>`

**Change No 2**
in **../Admin/BaseMediaAdmin.php** to fix "callback constraint is not a valid callable" and the error of BaseMediaAdmin incorrectly retrieving providerName

changed
`$media->setProviderName($this->getRequest()->get(sprintf('%s[providerName]', $this->getUniqid()), null, true));`
to 
`$media->setProviderName($this->getRequest()->get(sprintf('%s', $this->getUniqid()), null, true)['providerName']);`
## To do
- [ ] Update the tests
