### PR TITLE
add listener for console.terminate to allow publishing events on comm…

### DIFF
--- a/Tests/Thumbnail/ConsumerThumbnailTest.php
+++ b/Tests/Thumbnail/ConsumerThumbnailTest.php
@@ -12,8 +12,6 @@
 namespace Sonata\MediaBundle\Tests\Thumbnail;
 
 use Sonata\MediaBundle\Thumbnail\ConsumerThumbnail;
-use Symfony\Component\Console\ConsoleEvents;
-use Symfony\Component\HttpKernel\KernelEvents;
 
 class ConsumerThumbnailTest extends \PHPUnit_Framework_TestCase
 {
@@ -27,11 +25,11 @@ class ConsumerThumbnailTest extends \PHPUnit_Framework_TestCase
         $dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $dispatcher->expects($this->at(0))
             ->method('addListener')
-            ->with($this->equalTo(KernelEvents::FINISH_REQUEST), $this->anything());
+            ->with($this->equalTo('kernel.finish_request'), $this->anything());
 
         $dispatcher->expects($this->at(1))
             ->method('addListener')
-            ->with($this->equalTo(ConsoleEvents::TERMINATE), $this->anything());
+            ->with($this->equalTo('console.terminate'), $this->anything());
 
         $consumer = new ConsumerThumbnail('foo', $thumbnail, $backend, $dispatcher);
         $consumer->generate($provider, $media);

--- a/Tests/Thumbnail/ConsumerThumbnailTest.php
+++ b/Tests/Thumbnail/ConsumerThumbnailTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\Thumbnail;
+
+use Sonata\MediaBundle\Thumbnail\ConsumerThumbnail;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class ConsumerThumbnailTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGenerateDispatchesEvents()
+    {
+        $thumbnail = $this->getMock('Sonata\MediaBundle\Thumbnail\ThumbnailInterface');
+        $backend = $this->getMock('Sonata\NotificationBundle\Backend\BackendInterface');
+        $provider = $this->getMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+
+        $dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $dispatcher->expects($this->at(0))
+            ->method('addListener')
+            ->with($this->equalTo(KernelEvents::FINISH_REQUEST), $this->anything());
+
+        $dispatcher->expects($this->at(1))
+            ->method('addListener')
+            ->with($this->equalTo(ConsoleEvents::TERMINATE), $this->anything());
+
+        $consumer = new ConsumerThumbnail('foo', $thumbnail, $backend, $dispatcher);
+        $consumer->generate($provider, $media);
+    }
+}

--- a/Thumbnail/ConsumerThumbnail.php
+++ b/Thumbnail/ConsumerThumbnail.php
@@ -14,9 +14,7 @@ namespace Sonata\MediaBundle\Thumbnail;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\NotificationBundle\Backend\BackendInterface;
-use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\HttpKernel\KernelEvents;
 
 class ConsumerThumbnail implements ThumbnailInterface
 {
@@ -94,8 +92,8 @@ class ConsumerThumbnail implements ThumbnailInterface
             @trigger_error('Since version 2.3.3, passing an empty parameter in argument 4 for __construct() in '.__CLASS__.' is deprecated and the workaround for it will be removed in 3.0.', E_USER_DEPRECATED);
             $publish();
         } else {
-            $this->dispatcher->addListener(KernelEvents::FINISH_REQUEST, $publish);
-            $this->dispatcher->addListener(ConsoleEvents::TERMINATE, $publish);
+            $this->dispatcher->addListener('kernel.finish_request', $publish);
+            $this->dispatcher->addListener('console.terminate', $publish);
         }
     }
 

--- a/Thumbnail/ConsumerThumbnail.php
+++ b/Thumbnail/ConsumerThumbnail.php
@@ -14,7 +14,9 @@ namespace Sonata\MediaBundle\Thumbnail;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\NotificationBundle\Backend\BackendInterface;
+use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
 
 class ConsumerThumbnail implements ThumbnailInterface
 {
@@ -92,8 +94,8 @@ class ConsumerThumbnail implements ThumbnailInterface
             @trigger_error('Since version 2.3.3, passing an empty parameter in argument 4 for __construct() in '.__CLASS__.' is deprecated and the workaround for it will be removed in 3.0.', E_USER_DEPRECATED);
             $publish();
         } else {
-            $this->dispatcher->addListener('kernel.finish_request', $publish);
-            $this->dispatcher->addListener('console.terminate', $publish);
+            $this->dispatcher->addListener(KernelEvents::FINISH_REQUEST, $publish);
+            $this->dispatcher->addListener(ConsoleEvents::TERMINATE, $publish);
         }
     }
 

--- a/Thumbnail/ConsumerThumbnail.php
+++ b/Thumbnail/ConsumerThumbnail.php
@@ -93,6 +93,7 @@ class ConsumerThumbnail implements ThumbnailInterface
             $publish();
         } else {
             $this->dispatcher->addListener('kernel.finish_request', $publish);
+            $this->dispatcher->addListener('console.terminate', $publish);
         }
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because we should really generate thumbnails on console commands.
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Added
- Generate thumbnails asynchronously if creating Media on console commands.
```
## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->
- [x] Update the tests
- [x] Add an upgrade note
## Subject

<!-- Describe your Pull Request content here -->

I just found a missing event listener while generating thumbnails asynchronously (via SonataNotificationBundle) on console commands.
On web everything works fine, but while generating media using commands any notification will be sent to the messaging queue.
