### PR TITLE
medias are not filtered by category

### DIFF
--- a/Controller/MediaAdminController.php
+++ b/Controller/MediaAdminController.php
@@ -83,7 +83,7 @@ class MediaAdminController extends Controller
         }
 
         if (null !== $category && !$filters) {
-            $datagrid->setValue('category', null, $category);
+            $datagrid->setValue('category', null, $category->getId());
         }
         if ($this->container->has('sonata.media.manager.category') && $request->get('category')) {
             $categoryByContext = $this->container->get('sonata.media.manager.category')->findOneBy(array(
@@ -92,9 +92,9 @@ class MediaAdminController extends Controller
             ));
 
             if (!empty($categoryByContext)) {
-                $datagrid->setValue('category', null, $categoryByContext);
+                $datagrid->setValue('category', null, $categoryByContext->getId());
             } else {
-                $datagrid->setValue('category', null, $category);
+                $datagrid->setValue('category', null, $category->getId());
             }
         }
 

--- a/Resources/views/MediaAdmin/list.html.twig
+++ b/Resources/views/MediaAdmin/list.html.twig
@@ -21,7 +21,7 @@ file that was distributed with this source code.
     <ul{% if root %} class="sonata-tree sonata-tree--small js-treeview sonata-tree--toggleable"{% endif %}>
         {% for element in collection if element is not null %}
             <li>
-                <div class="sonata-tree__item{% if element.id == current_category.id %} is-active{% endif %}"{% if depth < 2 %} data-treeview-toggled{% endif %}>
+                <div class="sonata-tree__item{% if element.id == current_category %} is-active{% endif %}"{% if depth < 2 %} data-treeview-toggled{% endif %}>
                     {% if element.parent or root %}<i class="fa fa-caret-right" data-treeview-toggler></i>{% endif %}
                     <a class="sonata-tree__item__edit" href="{{ url(app.request.attributes.get('_route'), app.request.query.all|merge({category: element.id})) }}">{{ element.name }}</a>
                 </div>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because…

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Rebase of #1055
Fixes #1054

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
- Changed datagrid value of category from object to id of category

### Fixed
- Medias are not filtered by category

