### PR TITLE
Close an unclosed tag in translation file

### DIFF
--- a/Resources/translations/SonataMediaBundle.sl.xliff
+++ b/Resources/translations/SonataMediaBundle.sl.xliff
@@ -565,7 +565,7 @@
             </trans-unit>
             <trans-unit id="form.label_class">
                 <source>form.label_class</source>
-                <target>CSS razred<target>
+                <target>CSS razred</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
I am targetting this branch, because there's only one change, in a translation file. It's just an omitted end tag, there's no BC-break.

## Changelog

```markdown
### Fixed
- Close an unclosed XML tag in a translation file. 

## Subject

The last <target> tag, in <trans-unit id="form.label_class">,  was not closed in Resources/translations/SonataMediaBundle.sl.xliff.