### PR TITLE
Remove Dependecy to  Classification Bundle

### DIFF
--- a/Model/Media.php
+++ b/Model/Media.php
@@ -12,8 +12,8 @@
 namespace Sonata\MediaBundle\Model;
 
 use Imagine\Image\Box;
+use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
-use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\ExecutionContextInterface as LegacyExecutionContextInterface;
 
 abstract class Media implements MediaInterface
@@ -646,7 +646,7 @@ abstract class Media implements MediaInterface
     public function setCategory($category = null)
     {
         if (null !== $category && $category instanceof CategoryInterface) {
-            throw new UnexpectedTypeException();
+            throw new \InvalidArgumentException('Argument 1 should be an instance of Sonata\ClassificationBundle\Model\CategoryInterface or null');
         }
         $this->category = $category;
     }

--- a/Model/Media.php
+++ b/Model/Media.php
@@ -12,7 +12,6 @@
 namespace Sonata\MediaBundle\Model;
 
 use Imagine\Image\Box;
-use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\ExecutionContextInterface as LegacyExecutionContextInterface;
 
@@ -643,8 +642,10 @@ abstract class Media implements MediaInterface
     /**
      * @param CategoryInterface $category|null
      */
-    public function setCategory(CategoryInterface $category = null)
+    public function setCategory($category = null)
     {
-        $this->category = $category;
+        if($category instanceof CategoryInterface) {
+            $this->category = $category;
+        }
     }
 }

--- a/Model/Media.php
+++ b/Model/Media.php
@@ -13,6 +13,7 @@ namespace Sonata\MediaBundle\Model;
 
 use Imagine\Image\Box;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\ExecutionContextInterface as LegacyExecutionContextInterface;
 
 abstract class Media implements MediaInterface
@@ -644,8 +645,9 @@ abstract class Media implements MediaInterface
      */
     public function setCategory($category = null)
     {
-        if($category instanceof CategoryInterface) {
-            $this->category = $category;
+        if (null !== $category && $category instanceof CategoryInterface) {
+            throw new UnexpectedTypeException();
         }
+        $this->category = $category;
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because the undependecy process of classification-bundle left a minor bug.

Closes #1133
Fixes #1133
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Removed
Type hinting of a variable with a Class of the an optional Bundle
```
## Subject

Remove Dependecy to  Classification Bundle
