### PR TITLE
Display responsive images with the ImageProvider

### DIFF
--- a/Admin/BaseMediaAdmin.php
+++ b/Admin/BaseMediaAdmin.php
@@ -17,6 +17,7 @@ use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\CoreBundle\Model\Metadata;
 use Sonata\MediaBundle\Form\DataTransformer\ProviderDataTransformer;
 use Sonata\MediaBundle\Model\CategoryManagerInterface;
+use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\MediaBundle\Provider\Pool;
 
 abstract class BaseMediaAdmin extends AbstractAdmin
@@ -150,7 +151,10 @@ abstract class BaseMediaAdmin extends AbstractAdmin
     {
         $provider = $this->pool->getProvider($object->getProviderName());
 
-        $url = $provider->generatePublicUrl($object, $provider->getFormatName($object, 'admin'));
+        $url = $provider->generatePublicUrl(
+            $object,
+            $provider->getFormatName($object, MediaProviderInterface::FORMAT_ADMIN)
+        );
 
         return new Metadata($object->getName(), $object->getDescription(), $url);
     }

--- a/Controller/Api/MediaController.php
+++ b/Controller/Api/MediaController.php
@@ -172,7 +172,7 @@ class MediaController
     {
         $media = $this->getMedium($id);
 
-        $formats = array('reference');
+        $formats = array(MediaProviderInterface::FORMAT_REFERENCE);
         $formats = array_merge($formats, array_keys($this->mediaPool->getFormatNamesByContext($media->getContext())));
 
         $provider = $this->mediaPool->getProvider($media->getProviderName());

--- a/Controller/MediaController.php
+++ b/Controller/MediaController.php
@@ -49,7 +49,7 @@ class MediaController extends Controller
      *
      * @return Response
      */
-    public function downloadAction($id, $format = 'reference')
+    public function downloadAction($id, $format = MediaProviderInterface::FORMAT_REFERENCE)
     {
         $media = $this->getMedia($id);
 
@@ -78,7 +78,7 @@ class MediaController extends Controller
      *
      * @return Response
      */
-    public function viewAction($id, $format = 'reference')
+    public function viewAction($id, $format = MediaProviderInterface::FORMAT_REFERENCE)
     {
         $media = $this->getMedia($id);
 

--- a/DependencyInjection/Compiler/AddProviderCompilerPass.php
+++ b/DependencyInjection/Compiler/AddProviderCompilerPass.php
@@ -12,6 +12,7 @@
 namespace Sonata\MediaBundle\DependencyInjection\Compiler;
 
 use Sonata\MediaBundle\DependencyInjection\Configuration;
+use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -37,7 +38,10 @@ class AddProviderCompilerPass implements CompilerPassInterface
         $format = $container->getParameter('sonata.media.admin_format');
 
         foreach ($container->findTaggedServiceIds('sonata.media.provider') as $id => $attributes) {
-            $container->getDefinition($id)->addMethodCall('addFormat', array('admin', $format));
+            $container->getDefinition($id)->addMethodCall(
+                'addFormat',
+                array(MediaProviderInterface::FORMAT_ADMIN, $format)
+            );
         }
     }
 

--- a/Extra/Pixlr.php
+++ b/Extra/Pixlr.php
@@ -13,6 +13,7 @@ namespace Sonata\MediaBundle\Extra;
 
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Model\MediaManagerInterface;
+use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -117,7 +118,7 @@ class Pixlr
             's' => 'c', // ??
             'referrer' => $this->referrer,
             'exit' => $this->router->generate('sonata_media_pixlr_exit', array('hash' => $hash, 'id' => $media->getId()), UrlGeneratorInterface::ABSOLUTE_URL),
-            'image' => $provider->generatePublicUrl($media, 'reference'),
+            'image' => $provider->generatePublicUrl($media, MediaProviderInterface::FORMAT_REFERENCE),
             'title' => $media->getName(),
             'target' => $this->router->generate('sonata_media_pixlr_target', array('hash' => $hash, 'id' => $media->getId()), UrlGeneratorInterface::ABSOLUTE_URL),
             'locktitle' => true,

--- a/Model/Gallery.php
+++ b/Model/Gallery.php
@@ -12,6 +12,7 @@
 namespace Sonata\MediaBundle\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Sonata\MediaBundle\Provider\MediaProviderInterface;
 
 abstract class Gallery implements GalleryInterface
 {
@@ -43,7 +44,7 @@ abstract class Gallery implements GalleryInterface
     /**
      * @var string
      */
-    protected $defaultFormat = 'reference';
+    protected $defaultFormat = MediaProviderInterface::FORMAT_REFERENCE;
 
     /**
      * @var GalleryHasMediaInterface[]

--- a/Provider/BaseProvider.php
+++ b/Provider/BaseProvider.php
@@ -99,7 +99,8 @@ abstract class BaseProvider implements MediaProviderInterface
         if ($media->getId() && $this->requireThumbnails() && !$media->getCdnIsFlushable()) {
             $flushPaths = array();
             foreach ($this->getFormats() as $format => $settings) {
-                if ('admin' === $format || substr($format, 0, strlen($media->getContext())) === $media->getContext()) {
+                if (MediaProviderInterface::FORMAT_ADMIN === $format ||
+                    substr($format, 0, strlen($media->getContext())) === $media->getContext()) {
                     $flushPaths[] = $this->getFilesystem()->get($this->generatePrivateUrl($media, $format), true)->getKey();
                 }
             }
@@ -157,12 +158,12 @@ abstract class BaseProvider implements MediaProviderInterface
      */
     public function getFormatName(MediaInterface $media, $format)
     {
-        if ($format == 'admin') {
-            return 'admin';
+        if (MediaProviderInterface::FORMAT_ADMIN === $format) {
+            return MediaProviderInterface::FORMAT_ADMIN;
         }
 
-        if ($format == 'reference') {
-            return 'reference';
+        if (MediaProviderInterface::FORMAT_REFERENCE === $format) {
+            return MediaProviderInterface::FORMAT_REFERENCE;
         }
 
         $baseName = $media->getContext().'_';

--- a/Provider/BaseVideoProvider.php
+++ b/Provider/BaseVideoProvider.php
@@ -80,7 +80,7 @@ abstract class BaseVideoProvider extends BaseProvider
      */
     public function getReferenceFile(MediaInterface $media)
     {
-        $key = $this->generatePrivateUrl($media, 'reference');
+        $key = $this->generatePrivateUrl($media, MediaProviderInterface::FORMAT_REFERENCE);
 
         // the reference file is remote, get it and store it with the 'reference' format
         if ($this->getFilesystem()->has($key)) {
@@ -251,7 +251,7 @@ abstract class BaseVideoProvider extends BaseProvider
      */
     protected function getBoxHelperProperties(MediaInterface $media, $format, $options = array())
     {
-        if ($format == 'reference') {
+        if (MediaProviderInterface::FORMAT_REFERENCE === $format) {
             return $media->getBox();
         }
 

--- a/Provider/FileProvider.php
+++ b/Provider/FileProvider.php
@@ -221,7 +221,7 @@ class FileProvider extends BaseProvider
      */
     public function generatePublicUrl(MediaInterface $media, $format)
     {
-        if ($format == 'reference') {
+        if (MediaProviderInterface::FORMAT_REFERENCE === $format) {
             $path = $this->getReferenceImage($media);
         } else {
             // @todo: fix the asset path
@@ -248,7 +248,7 @@ class FileProvider extends BaseProvider
      */
     public function generatePrivateUrl(MediaInterface $media, $format)
     {
-        if ($format == 'reference') {
+        if (MediaProviderInterface::FORMAT_REFERENCE === $format) {
             return $this->getReferenceImage($media);
         }
 
@@ -271,7 +271,7 @@ class FileProvider extends BaseProvider
         }
 
         if ($mode == 'http') {
-            if ($format == 'reference') {
+            if (MediaProviderInterface::FORMAT_REFERENCE === $format) {
                 $file = $this->getReferenceFile($media);
             } else {
                 $file = $this->getFilesystem()->get($this->generatePrivateUrl($media, $format));

--- a/Provider/ImageProvider.php
+++ b/Provider/ImageProvider.php
@@ -60,7 +60,7 @@ class ImageProvider extends FileProvider
      */
     public function getHelperProperties(MediaInterface $media, $format, $options = array())
     {
-        if ($format == 'reference') {
+        if (MediaProviderInterface::FORMAT_REFERENCE === $format) {
             $box = $media->getBox();
         } else {
             $resizerFormat = $this->getFormat($format);
@@ -82,7 +82,7 @@ class ImageProvider extends FileProvider
             'height' => $box->getHeight(),
         );
 
-        if ($format !== 'admin') {
+        if ($format !== MediaProviderInterface::FORMAT_ADMIN) {
             $srcSet = array();
 
             foreach ($this->getFormats() as $providerFormat => $settings) {
@@ -95,7 +95,11 @@ class ImageProvider extends FileProvider
             }
 
             // The reference format is not in the formats list
-            $srcSet[] = sprintf('%s %dw', $this->generatePublicUrl($media, 'reference'), $media->getBox()->getWidth());
+            $srcSet[] = sprintf(
+                '%s %dw',
+                $this->generatePublicUrl($media, MediaProviderInterface::FORMAT_REFERENCE),
+                $media->getBox()->getWidth()
+            );
 
             $params['srcset'] = implode(', ', $srcSet);
             $params['sizes'] = sprintf('(max-width: %1$dpx) 100vw, %1$dpx', $mediaWidth);
@@ -150,7 +154,7 @@ class ImageProvider extends FileProvider
      */
     public function generatePublicUrl(MediaInterface $media, $format)
     {
-        if ($format == 'reference') {
+        if (MediaProviderInterface::FORMAT_REFERENCE === $format) {
             $path = $this->getReferenceImage($media);
         } else {
             $path = $this->thumbnail->generatePublicUrl($this, $media, $format);

--- a/Provider/MediaProviderInterface.php
+++ b/Provider/MediaProviderInterface.php
@@ -22,6 +22,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 interface MediaProviderInterface
 {
+    // This format is used to display thumbnails in Sonata Admin
+    const FORMAT_ADMIN = 'admin';
+
+    // This format holds the original media
+    const FORMAT_REFERENCE = 'reference';
+
     /**
      * @param string $name
      * @param array  $format

--- a/Resources/doc/reference/helpers.rst
+++ b/Resources/doc/reference/helpers.rst
@@ -59,13 +59,25 @@ Render the path:
 .. code-block:: jinja
 
     {% path media, 'small' %}
-    
+
 Render the path to a ``sonata.media.provider.file`` context:
 
 .. code-block:: jinja
-    
+
     {% path media, 'reference' %}
-    
+
+Media helper for images
+-----------------------
+
+The media helper for the ``sonata.media.provider.image`` provider renders a responsive image tag with sensible defaults for ``srcset`` and ``sizes``.
+The size configured will be the one used for the default fallback ``src``.
+
+To override the ``sizes`` to fit your particular design, just pass a ``sizes`` option to the helper.
+
+.. code-block:: jinja
+
+    {% media media, 'large' with {'sizes': '(min-width: 20em) 50vw, 100vw'} %}
+
 
 Thumbnails for files
 --------------------

--- a/Thumbnail/FormatThumbnail.php
+++ b/Thumbnail/FormatThumbnail.php
@@ -34,7 +34,7 @@ class FormatThumbnail implements ThumbnailInterface
      */
     public function generatePublicUrl(MediaProviderInterface $provider, MediaInterface $media, $format)
     {
-        if ($format == 'reference') {
+        if (MediaProviderInterface::FORMAT_REFERENCE === $format) {
             $path = $provider->getReferenceImage($media);
         } else {
             $path = sprintf('%s/thumb_%s_%s.%s', $provider->generatePath($media), $media->getId(), $format, $this->getExtension($media));
@@ -48,7 +48,7 @@ class FormatThumbnail implements ThumbnailInterface
      */
     public function generatePrivateUrl(MediaProviderInterface $provider, MediaInterface $media, $format)
     {
-        if ('reference' === $format) {
+        if (MediaProviderInterface::FORMAT_REFERENCE === $format) {
             return $provider->getReferenceImage($media);
         }
 
@@ -77,7 +77,8 @@ class FormatThumbnail implements ThumbnailInterface
         }
 
         foreach ($provider->getFormats() as $format => $settings) {
-            if (substr($format, 0, strlen($media->getContext())) == $media->getContext() || $format === 'admin') {
+            if (substr($format, 0, strlen($media->getContext())) == $media->getContext() ||
+                MediaProviderInterface::FORMAT_ADMIN === $format) {
                 $provider->getResizer()->resize(
                     $media,
                     $referenceFile,

--- a/Thumbnail/LiipImagineThumbnail.php
+++ b/Thumbnail/LiipImagineThumbnail.php
@@ -35,7 +35,7 @@ class LiipImagineThumbnail implements ThumbnailInterface
      */
     public function generatePublicUrl(MediaProviderInterface $provider, MediaInterface $media, $format)
     {
-        if ($format == 'reference') {
+        if (MediaProviderInterface::FORMAT_REFERENCE === $format) {
             $path = $provider->getReferenceImage($media);
         } else {
             $path = $this->router->generate(
@@ -52,7 +52,7 @@ class LiipImagineThumbnail implements ThumbnailInterface
      */
     public function generatePrivateUrl(MediaProviderInterface $provider, MediaInterface $media, $format)
     {
-        if ($format != 'reference') {
+        if ($format !== MediaProviderInterface::FORMAT_REFERENCE) {
             throw new \RuntimeException('No private url for LiipImagineThumbnail');
         }
 

--- a/Validator/FormatValidator.php
+++ b/Validator/FormatValidator.php
@@ -12,6 +12,7 @@
 namespace Sonata\MediaBundle\Validator;
 
 use Sonata\MediaBundle\Model\GalleryInterface;
+use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -52,7 +53,7 @@ class FormatValidator extends ConstraintValidator
 
         $galleryDefaultFormat = $value->getDefaultFormat();
 
-        if ($galleryDefaultFormat !== 'reference'
+        if ($galleryDefaultFormat !== MediaProviderInterface::FORMAT_REFERENCE
             && !($formats && array_key_exists($galleryDefaultFormat, $formats))) {
             $this->context->addViolation('invalid format');
         }


### PR DESCRIPTION
I am targeting this branch, because this feature is Backwards compatible.

## Changelog

```markdown
### Added
- The Image Provider returns responsive images to the twig media helper.
```

## To do

- [x] Add unit tests
- [x] Update documentation

## Subject

The Image providers getHelperProperties() function returns srcset and sizes attributes based on the current image's available sizes.

It only returns sizes smaller than the specified format. This way it is perfectly BC and the format let us control the returned sizes.

Browsers that don't support this feature will just serve the image defined by the 'format' option.

Passing a 'sizes' option to the media tag, easily overrides the predefined sizes to tailor for current template.

I'll update the docs if you are happy with the change.
