### PR TITLE
use addDownloadStrategy instead of deprecated addDownloadSecurity

### DIFF
--- a/DependencyInjection/SonataMediaExtension.php
+++ b/DependencyInjection/SonataMediaExtension.php
@@ -138,7 +138,7 @@ class SonataMediaExtension extends Extension
         $strategies = array_unique($strategies);
 
         foreach ($strategies as $strategyId) {
-            $pool->addMethodCall('addDownloadSecurity', array($strategyId, new Reference($strategyId)));
+            $pool->addMethodCall('addDownloadStrategy', array($strategyId, new Reference($strategyId)));
         }
 
         if ('doctrine_orm' == $config['db_driver']) {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Deprecation warning for `addDownloadSecurity`
```

## Subject

The method `addDownloadSecurity` is deprecated, we should use the new `addDownloadStrategy` in `SonataMediaExtension`

