### PR TITLE
Documented empty `formats`

### DIFF
--- a/Admin/GalleryAdmin.php
+++ b/Admin/GalleryAdmin.php
@@ -134,8 +134,9 @@ class GalleryAdmin extends AbstractAdmin
                 ))
                 ->add('enabled', null, array('required' => false))
                 ->add('name')
-                ->add('defaultFormat', $choiceType, array('choices' => $formats))
-            ->end()
+                ->ifTrue($formats)
+                    ->add('defaultFormat', $choiceType, array('choices' => $formats))
+                ->ifEnd()
             ->with('Gallery')
                 ->add('galleryHasMedias', $collectionType, array(), array(
                     'edit' => 'inline',

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -85,7 +85,6 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                             ->arrayNode('formats')
-                                ->isRequired()
                                 ->useAttributeAsKey('id')
                                 ->prototype('array')
                                     ->children()

--- a/Model/Gallery.php
+++ b/Model/Gallery.php
@@ -43,7 +43,7 @@ abstract class Gallery implements GalleryInterface
     /**
      * @var string
      */
-    protected $defaultFormat;
+    protected $defaultFormat = 'reference';
 
     /**
      * @var GalleryHasMediaInterface[]

--- a/Resources/config/validation.xml
+++ b/Resources/config/validation.xml
@@ -34,9 +34,5 @@
             <constraint name="NotNull"/>
             <constraint name="NotBlank"/>
         </property>
-        <property name="defaultFormat">
-            <constraint name="NotNull"/>
-            <constraint name="NotBlank"/>
-        </property>
     </class>
 </constraint-mapping>

--- a/Resources/doc/reference/troubleshooting.rst
+++ b/Resources/doc/reference/troubleshooting.rst
@@ -92,7 +92,12 @@ Finally your settings in your ``sonata_media`` parameters will look like this:
                     - sonata.media.provider.youtube
                     - sonata.media.provider.image
                     - sonata.media.provider.file
-
+                # If you omit this section the only format generated will be the `admin` format
+                # which is needed for the backend. This is useful if you use a third party service to create
+                # thumbnails and don't need to create static one using this bundle.
+                #
+                # You can use the helper `media` with `reference` as format to access the media
+                # {% media media, 'reference' %}
                 formats:
                     small: { width: 100 , quality: 70  }
                     big:   { width: 500 , quality: 70  }

--- a/Tests/Validator/FormatValidatorTest.php
+++ b/Tests/Validator/FormatValidatorTest.php
@@ -45,13 +45,40 @@ class FormatValidatorTest extends PHPUnit_Framework_TestCase
         $validator->validate($gallery, new ValidMediaFormat());
     }
 
-    public function testValidateWithValidContext()
+    public function testValidateNotValidDefaultFormat()
+    {
+        $pool = new Pool('defaultContext');
+        $pool->addContext('test', array(), array('format1' => array()));
+
+        $gallery = $this->createMock('Sonata\MediaBundle\Model\GalleryInterface');
+        $gallery->expects($this->once())->method('getDefaultFormat')->will($this->returnValue('non_existing_format'));
+        $gallery->expects($this->once())->method('getContext')->will($this->returnValue('test'));
+
+        // Prefer the Symfony 2.5+ API if available
+        if (class_exists('Symfony\Component\Validator\Context\ExecutionContext')) {
+            $contextClass = 'Symfony\Component\Validator\Context\ExecutionContext';
+        } else {
+            $contextClass = 'Symfony\Component\Validator\ExecutionContext';
+        }
+
+        $context = $this->getMockBuilder($contextClass)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $context->expects($this->once())->method('addViolation');
+
+        $validator = new FormatValidator($pool);
+        $validator->initialize($context);
+
+        $validator->validate($gallery, new ValidMediaFormat());
+    }
+
+    public function testValidateOnlyReferenceIsAllowedIfNotFormats()
     {
         $pool = new Pool('defaultContext');
         $pool->addContext('test');
 
         $gallery = $this->createMock('Sonata\MediaBundle\Model\GalleryInterface');
-        $gallery->expects($this->once())->method('getDefaultFormat')->will($this->returnValue('format1'));
+        $gallery->expects($this->once())->method('getDefaultFormat')->will($this->returnValue('format_that_is_not_reference'));
         $gallery->expects($this->once())->method('getContext')->will($this->returnValue('test'));
 
         // Prefer the Symfony 2.5+ API if available

--- a/Validator/FormatValidator.php
+++ b/Validator/FormatValidator.php
@@ -50,7 +50,10 @@ class FormatValidator extends ConstraintValidator
             }
         }
 
-        if (!array_key_exists($value->getDefaultFormat(), $formats)) {
+        $galleryDefaultFormat = $value->getDefaultFormat();
+
+        if ($galleryDefaultFormat !== 'reference'
+            && !($formats && array_key_exists($galleryDefaultFormat, $formats))) {
             $this->context->addViolation('invalid format');
         }
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this PR only change a file in the documentation so it's backward compatible.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1135

## Subject

<!-- Describe your Pull Request content here -->

Documented the possibility to leave `formats` empty. This PR closes #1135