### PR TITLE
Remove deprecated translation logic

### DIFF
--- a/Resources/views/MediaAdmin/list.html.twig
+++ b/Resources/views/MediaAdmin/list.html.twig
@@ -15,7 +15,7 @@ file that was distributed with this source code.
 {% macro navigate_child(collection, admin, root, current_category, depth) %}
     {% if root and collection|length == 0 %}
         <div>
-            <p class="bg-warning">{{ admin.trans('warning_no_category', {}, admin.translationdomain) }}</p>
+            <p class="bg-warning">{{ 'warning_no_category'|trans({}, admin.translationdomain) }}</p>
         </div>
     {% endif %}
     <ul{% if root %} class="sonata-tree sonata-tree--small js-treeview sonata-tree--toggleable"{% endif %}>


### PR DESCRIPTION
I am targetting this branch, because this is BC.

Partially closes sonata-project/SonataAdminBundle#4229

## Changelog

```markdown
### Changed
- translation in twig templates now uses the twig translation filter
```

## Subject

Removes deprecated translations calls from the `AdminInterface::trans` method.
