### PR TITLE
Api groups moved from string to array

### DIFF
--- a/Controller/Api/GalleryController.php
+++ b/Controller/Api/GalleryController.php
@@ -77,15 +77,14 @@ class GalleryController
      *
      * @ApiDoc(
      *  resource=true,
-     *  output={"class"="Sonata\DatagridBundle\Pager\PagerInterface", "groups"="sonata_api_read"}
+     *  output={"class"="Sonata\DatagridBundle\Pager\PagerInterface", "groups"={"sonata_api_read"}}
      * )
      *
      * @QueryParam(name="page", requirements="\d+", default="1", description="Page for gallery list pagination")
      * @QueryParam(name="count", requirements="\d+", default="10", description="Number of galleries by page")
      * @QueryParam(name="enabled", requirements="0|1", nullable=true, strict=true, description="Enabled/Disabled galleries filter")
-     * @QueryParam(name="orderBy", array=true, requirements="ASC|DESC", nullable=true, strict=true, description="Order by array (key is field, value is direction)")
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @param ParamFetcherInterface $paramFetcher
      *
@@ -93,6 +92,20 @@ class GalleryController
      */
     public function getGalleriesAction(ParamFetcherInterface $paramFetcher)
     {
+        $orderByQueryParam = new QueryParam();
+        $orderByQueryParam->name = 'orderBy';
+        $orderByQueryParam->requirements = 'ASC|DESC';
+        $orderByQueryParam->nullable = true;
+        $orderByQueryParam->strict = true;
+        $orderByQueryParam->description = 'Query groups order by clause (key is field, value is direction)';
+        if (property_exists($orderByQueryParam, 'map')) {
+            $orderByQueryParam->map = true;
+        } else {
+            $orderByQueryParam->array = true;
+        }
+
+        $paramFetcher->addParam($orderByQueryParam);
+
         $supportedCriteria = array(
             'enabled' => '',
         );
@@ -124,14 +137,14 @@ class GalleryController
      *  requirements={
      *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="gallery id"}
      *  },
-     *  output={"class"="sonata_media_api_form_gallery", "groups"="sonata_api_read"},
+     *  output={"class"="sonata_media_api_form_gallery", "groups"={"sonata_api_read"}},
      *  statusCodes={
      *      200="Returned when successful",
      *      404="Returned when gallery is not found"
      *  }
      * )
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @param $id
      *
@@ -149,14 +162,14 @@ class GalleryController
      *  requirements={
      *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="gallery id"}
      *  },
-     *  output={"class"="Sonata\MediaBundle\Model\Media", "groups"="sonata_api_read"},
+     *  output={"class"="Sonata\MediaBundle\Model\Media", "groups"={"sonata_api_read"}},
      *  statusCodes={
      *      200="Returned when successful",
      *      404="Returned when gallery is not found"
      *  }
      * )
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @param $id
      *
@@ -181,14 +194,14 @@ class GalleryController
      *  requirements={
      *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="gallery id"}
      *  },
-     *  output={"class"="Sonata\MediaBundle\Model\GalleryHasMedia", "groups"="sonata_api_read"},
+     *  output={"class"="Sonata\MediaBundle\Model\GalleryHasMedia", "groups"={"sonata_api_read"}},
      *  statusCodes={
      *      200="Returned when successful",
      *      404="Returned when gallery is not found"
      *  }
      * )
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @param $id
      *

--- a/Controller/Api/MediaController.php
+++ b/Controller/Api/MediaController.php
@@ -76,15 +76,14 @@ class MediaController
      *
      * @ApiDoc(
      *  resource=true,
-     *  output={"class"="Sonata\DatagridBundle\Pager\PagerInterface", "groups"="sonata_api_read"}
+     *  output={"class"="Sonata\DatagridBundle\Pager\PagerInterface", "groups"={"sonata_api_read"}}
      * )
      *
      * @QueryParam(name="page", requirements="\d+", default="1", description="Page for media list pagination")
      * @QueryParam(name="count", requirements="\d+", default="10", description="Number of medias by page")
      * @QueryParam(name="enabled", requirements="0|1", nullable=true, strict=true, description="Enabled/Disabled medias filter")
-     * @QueryParam(name="orderBy", array=true, requirements="ASC|DESC", nullable=true, strict=true, description="Order by array (key is field, value is direction)")
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @param ParamFetcherInterface $paramFetcher
      *
@@ -92,6 +91,20 @@ class MediaController
      */
     public function getMediaAction(ParamFetcherInterface $paramFetcher)
     {
+        $orderByQueryParam = new QueryParam();
+        $orderByQueryParam->name = 'orderBy';
+        $orderByQueryParam->requirements = 'ASC|DESC';
+        $orderByQueryParam->nullable = true;
+        $orderByQueryParam->strict = true;
+        $orderByQueryParam->description = 'Query groups order by clause (key is field, value is direction)';
+        if (property_exists($orderByQueryParam, 'map')) {
+            $orderByQueryParam->map = true;
+        } else {
+            $orderByQueryParam->array = true;
+        }
+
+        $paramFetcher->addParam($orderByQueryParam);
+
         $supportedCriteria = array(
             'enabled' => '',
         );
@@ -123,14 +136,14 @@ class MediaController
      *  requirements={
      *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="media id"}
      *  },
-     *  output={"class"="Sonata\MediaBundle\Model\Media", "groups"="sonata_api_read"},
+     *  output={"class"="Sonata\MediaBundle\Model\Media", "groups"={"sonata_api_read"}},
      *  statusCodes={
      *      200="Returned when successful",
      *      404="Returned when media is not found"
      *  }
      * )
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @param $id
      *
@@ -324,14 +337,14 @@ class MediaController
      *
      * @ApiDoc(
      *  input={"class"="Sonata\MediaBundle\Model\Media", "groups"={"sonata_api_write"}},
-     *  output={"class"="Sonata\MediaBundle\Model\Media", "groups"="sonata_api_read"},
+     *  output={"class"="Sonata\MediaBundle\Model\Media", "groups"={"sonata_api_read"}},
      *  statusCodes={
      *      200="Returned when successful",
      *      404="Returned when media is not found"
      *  }
      * )
      *
-     * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
+     * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
      * @param $id
      * @param Request $request A Symfony request

--- a/Tests/Controller/Api/GalleryControllerTest.php
+++ b/Tests/Controller/Api/GalleryControllerTest.php
@@ -38,11 +38,13 @@ class GalleryControllerTest extends \PHPUnit_Framework_TestCase
 
         $gController = new GalleryController($gManager, $mediaManager, $formFactory, 'test');
 
-        $params = $this->getMock('FOS\RestBundle\Request\ParamFetcherInterface');
-        $params->expects($this->once())->method('all')->will($this->returnValue(array('page' => 1, 'count' => 10, 'orderBy' => array('id' => 'ASC'))));
-        $params->expects($this->exactly(3))->method('get');
+        $paramFetcher = $this->getMockBuilder('FOS\RestBundle\Request\ParamFetcher')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $paramFetcher->expects($this->exactly(3))->method('get');
+        $paramFetcher->expects($this->once())->method('all')->will($this->returnValue(array()));
 
-        $this->assertSame(array(), $gController->getGalleriesAction($params));
+        $this->assertSame(array(), $gController->getGalleriesAction($paramFetcher));
     }
 
     public function testGetGalleryAction()

--- a/Tests/Controller/Api/MediaControllerTest.php
+++ b/Tests/Controller/Api/MediaControllerTest.php
@@ -206,7 +206,7 @@ class MediaControllerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @expectedException \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
     public function testPostProviderActionNotFound()
     {

--- a/Tests/Controller/Api/MediaControllerTest.php
+++ b/Tests/Controller/Api/MediaControllerTest.php
@@ -31,11 +31,13 @@ class MediaControllerTest extends \PHPUnit_Framework_TestCase
 
         $mController = $this->createMediaController($mManager);
 
-        $params = $this->getMock('FOS\RestBundle\Request\ParamFetcherInterface');
-        $params->expects($this->once())->method('all')->will($this->returnValue(array('page' => 1, 'count' => 10, 'orderBy' => array('id' => 'ASC'))));
-        $params->expects($this->exactly(3))->method('get');
+        $paramFetcher = $this->getMockBuilder('FOS\RestBundle\Request\ParamFetcher')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $paramFetcher->expects($this->exactly(3))->method('get');
+        $paramFetcher->expects($this->once())->method('all')->will($this->returnValue(array()));
 
-        $this->assertSame(array($media), $mController->getMediaAction($params));
+        $this->assertSame(array($media), $mController->getMediaAction($paramFetcher));
     }
 
     public function testGetMediumAction()


### PR DESCRIPTION
Following [this](https://github.com/sonata-project/SonataUserBundle/pull/805) and [this](https://github.com/sonata-project/SonataClassificationBundle/pull/245). 

Closes https://github.com/sonata-project/SonataMediaBundle/issues/1056

## Changelog
```markdown
### Changed
- Moved ApiDoc groups from string to array. 

### Fixed
- Moved FosRest groups from string to array and reimplemented the orderBy parameter enabling support for FosRestBundle>=2.0.
```

## Subject

FosRestBundle>=2.0 requirest api groups declared as array and requires a new implementation of the orderBy parameter in the controller which has to be bc-compatible. This fix enable the support for both FosRest 1 and 2, following the two pull requests.

I uniformed the annotations in ApiDoc groups either. This seemed right to do because nelmio-apidoc usually expects groups as an array, and they convert it in ApiDocExtractor with this

```php
// normalize groups
if (isset($input['groups']) && is_string($input['groups'])) {
$input['groups'] = array_map('trim', explode(',', $input['groups']));
}
```
so, given the array need of fos-rest, this also seemed right to do to prevent further work ahead in case they deprecate that one. It does not break BC.


