### PR TITLE
Set category id as value for category filter

### DIFF
--- a/Controller/MediaAdminController.php
+++ b/Controller/MediaAdminController.php
@@ -77,9 +77,8 @@ class MediaAdminController extends Controller
         $datagrid->setValue('context', null, $context);
 
         // retrieve the main category for the tree view
-        $rootCategory = $this->container->get('sonata.classification.manager.category')->getRootCategory($context);
-        // This should be safe as the root category has to exist for a given context but I do not like fatal errors
-        $rootCategoryId = !empty($rootCategory) ? $rootCategory->getId() : null;
+        $rootCategory = $this->container->get('sonata.classification.manager.category')->getRootCategory($context); 
+        $rootCategoryId = $rootCategory->getId(); // This is safe
 
         if (!$filters) {
             $datagrid->setValue('category', null, $rootCategoryId);

--- a/Controller/MediaAdminController.php
+++ b/Controller/MediaAdminController.php
@@ -77,10 +77,12 @@ class MediaAdminController extends Controller
         $datagrid->setValue('context', null, $context);
 
         // retrieve the main category for the tree view
-        $category = $this->container->get('sonata.classification.manager.category')->getRootCategory($context);
+        $rootCategory = $this->container->get('sonata.classification.manager.category')->getRootCategory($context);
+        // This should be safe as the root category has to exist for a given context but I do not like fatal errors
+        $rootCategoryId = !empty($rootCategory) ? $rootCategory->getId() : null;
 
         if (!$filters) {
-            $datagrid->setValue('category', null, $category);
+            $datagrid->setValue('category', null, $rootCategoryId);
         }
         if ($request->get('category')) {
             $categoryByContext = $this->container->get('sonata.classification.manager.category')->findOneBy(array(
@@ -89,9 +91,9 @@ class MediaAdminController extends Controller
             ));
 
             if (!empty($categoryByContext)) {
-                $datagrid->setValue('category', null, $categoryByContext);
+                $datagrid->setValue('category', null, $categoryByContext->getId());
             } else {
-                $datagrid->setValue('category', null, $category);
+                $datagrid->setValue('category', null, $rootCategoryId);
             }
         }
 
@@ -104,7 +106,7 @@ class MediaAdminController extends Controller
             'action' => 'list',
             'form' => $formView,
             'datagrid' => $datagrid,
-            'root_category' => $category,
+            'root_category' => $rootCategory,
             'csrf_token' => $this->getCsrfToken('sonata.batch'),
         ));
     }

--- a/Resources/views/MediaAdmin/list.html.twig
+++ b/Resources/views/MediaAdmin/list.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% extends 'SonataAdminBundle:CRUD:base_list.html.twig' %}
 
 {% import _self as tree %}
-{% macro navigate_child(collection, admin, root, current_category, depth) %}
+{% macro navigate_child(collection, admin, root, current_category_id, depth) %}
     {% if root and collection|length == 0 %}
         <div>
             <p class="bg-warning">{{ 'warning_no_category'|trans({}, admin.translationdomain) }}</p>
@@ -21,7 +21,7 @@ file that was distributed with this source code.
     <ul{% if root %} class="sonata-tree sonata-tree--small js-treeview sonata-tree--toggleable"{% endif %}>
         {% for element in collection %}
             <li>
-                <div class="sonata-tree__item{% if element.id == current_category.id %} is-active{% endif %}"{% if depth < 2 %} data-treeview-toggled{% endif %}>
+                <div class="sonata-tree__item{% if element.id == current_category_id %} is-active{% endif %}"{% if depth < 2 %} data-treeview-toggled{% endif %}>
                     {% if element.parent or root %}<i class="fa fa-caret-right" data-treeview-toggler></i>{% endif %}
                     <a class="sonata-tree__item__edit" href="{{ url(app.request.attributes.get('_route'), app.request.query.all|merge({category: element.id})) }}">{{ element.name }}</a>
                 </div>


### PR DESCRIPTION
I am targetting this branch, because the commit fixes the original intention of MediaAdminController code : be able to filter the media list by category.

Closes #1054

## Changelog

```markdown
### Fixed
- fix the handling of `category` query parameter in MediaAdminController that prevents medias to be filtered by category
```

## Subject

MediaAdminController was modified to use category id as datagrid value instead of the related entity. The associated twig template was also modified to match the new nature of the category datagrid value.