### PR TITLE
Fixed ACL configuration not passed to S3 Filesystem

### DIFF
--- a/Metadata/AmazonMetadataBuilder.php
+++ b/Metadata/AmazonMetadataBuilder.php
@@ -73,7 +73,7 @@ class AmazonMetadataBuilder implements MetadataBuilderInterface
         //merge acl
         $output = array();
         if (isset($this->settings['acl']) && !empty($this->settings['acl'])) {
-            $output['ACL'] = $this->acl[$this->settings['acl']];
+            $output['ACL'] = $this->settings['acl'];
         }
 
         //merge storage

--- a/Tests/Metadata/AmazonMetadataBuilderTest.php
+++ b/Tests/Metadata/AmazonMetadataBuilderTest.php
@@ -17,36 +17,82 @@ use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 class AmazonMetadataBuilderTest extends PHPUnit_Framework_TestCase
 {
-    public function testAmazon()
-    {
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
-        $filename = '/test/folder/testfile.png';
+    /**
+     * @var \Sonata\MediaBundle\Model\MediaInterface
+     */
+    private $media;
 
-        foreach ($this->provider() as $provider) {
-            list($a, $b) = $provider;
-            $amazonmetadatabuilder = new AmazonMetadataBuilder($a);
-            $this->assertSame($b, $amazonmetadatabuilder->get($media, $filename));
-        }
+    protected function setUp()
+    {
+        $this->media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+    }
+
+    /**
+     * @dataProvider metadataProvider
+     *
+     * @param array $a
+     * @param array $b
+     */
+    public function testAmazon(array $a, array $b)
+    {
+        $amazonMetadataBuilder = new AmazonMetadataBuilder($a);
+        $this->assertSame($b, $amazonMetadataBuilder->get($this->media, '/test/folder/testfile.png'));
     }
 
     /**
      * @return array
      */
-    public function provider()
+    public function metadataProvider()
     {
         return array(
-            array(array('acl' => 'private'), array('ACL' => AmazonMetadataBuilder::PRIVATE_ACCESS, 'contentType' => 'image/png')),
-            array(array('acl' => 'public'), array('ACL' => AmazonMetadataBuilder::PUBLIC_READ, 'contentType' => 'image/png')),
-            array(array('acl' => 'open'), array('ACL' => AmazonMetadataBuilder::PUBLIC_READ_WRITE, 'contentType' => 'image/png')),
-            array(array('acl' => 'auth_read'), array('ACL' => AmazonMetadataBuilder::AUTHENTICATED_READ, 'contentType' => 'image/png')),
-            array(array('acl' => 'owner_read'), array('ACL' => AmazonMetadataBuilder::BUCKET_OWNER_READ, 'contentType' => 'image/png')),
-            array(array('acl' => 'owner_full_control'), array('ACL' => AmazonMetadataBuilder::BUCKET_OWNER_FULL_CONTROL, 'contentType' => 'image/png')),
-            array(array('storage' => 'standard'), array('storage' => AmazonMetadataBuilder::STORAGE_STANDARD, 'contentType' => 'image/png')),
-            array(array('storage' => 'reduced'), array('storage' => AmazonMetadataBuilder::STORAGE_REDUCED, 'contentType' => 'image/png')),
-            array(array('cache_control' => 'max-age=86400'), array('CacheControl' => 'max-age=86400', 'contentType' => 'image/png')),
-            array(array('encryption' => 'aes256'), array('encryption' => 'AES256', 'contentType' => 'image/png')),
-            array(array('meta' => array('key' => 'value')), array('meta' => array('key' => 'value'), 'contentType' => 'image/png')),
-            array(array('acl' => 'public', 'storage' => 'standard', 'cache_control' => 'max-age=86400', 'encryption' => 'aes256', 'meta' => array('key' => 'value')), array('ACL' => AmazonMetadataBuilder::PUBLIC_READ, 'storage' => Storage::STANDARD, 'meta' => array('key' => 'value'), 'CacheControl' => 'max-age=86400', 'encryption' => 'AES256', 'contentType' => 'image/png')),
+            array(
+                array('acl' => AmazonMetadataBuilder::PRIVATE_ACCESS),
+                array('ACL' => AmazonMetadataBuilder::PRIVATE_ACCESS, 'contentType' => 'image/png'),
+            ),
+            array(
+                array('acl' => AmazonMetadataBuilder::PUBLIC_READ),
+                array('ACL' => AmazonMetadataBuilder::PUBLIC_READ, 'contentType' => 'image/png'),
+            ),
+            array(
+                array('acl' => AmazonMetadataBuilder::PUBLIC_READ_WRITE),
+                array('ACL' => AmazonMetadataBuilder::PUBLIC_READ_WRITE, 'contentType' => 'image/png'),
+            ),
+            array(
+                array('acl' => AmazonMetadataBuilder::AUTHENTICATED_READ),
+                array('ACL' => AmazonMetadataBuilder::AUTHENTICATED_READ, 'contentType' => 'image/png'),
+            ),
+            array(
+                array('acl' => AmazonMetadataBuilder::BUCKET_OWNER_READ),
+                array('ACL' => AmazonMetadataBuilder::BUCKET_OWNER_READ, 'contentType' => 'image/png'),
+            ),
+            array(
+                array('acl' => AmazonMetadataBuilder::BUCKET_OWNER_FULL_CONTROL),
+                array('ACL' => AmazonMetadataBuilder::BUCKET_OWNER_FULL_CONTROL, 'contentType' => 'image/png'),
+            ),
+            array(
+                array('storage' => 'standard'),
+                array('storage' => AmazonMetadataBuilder::STORAGE_STANDARD, 'contentType' => 'image/png'),
+            ),
+            array(
+                array('storage' => 'reduced'),
+                array('storage' => AmazonMetadataBuilder::STORAGE_REDUCED, 'contentType' => 'image/png'),
+            ),
+            array(
+                array('cache_control' => 'max-age=86400'),
+                array('CacheControl' => 'max-age=86400', 'contentType' => 'image/png'),
+            ),
+            array(
+                array('encryption' => 'aes256'),
+                array('encryption' => 'AES256', 'contentType' => 'image/png'),
+            ),
+            array(
+                array('meta' => array('key' => 'value')),
+                array('meta' => array('key' => 'value'), 'contentType' => 'image/png'),
+            ),
+            array(
+                array('acl' => AmazonMetadataBuilder::PUBLIC_READ, 'storage' => 'standard', 'cache_control' => 'max-age=86400', 'encryption' => 'aes256', 'meta' => array('key' => 'value')),
+                array('ACL' => AmazonMetadataBuilder::PUBLIC_READ, 'storage' => Storage::STANDARD, 'meta' => array('key' => 'value'), 'CacheControl' => 'max-age=86400', 'encryption' => 'AES256', 'contentType' => 'image/png'),
+            ),
         );
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because we use version 3.3 & we cannot upload some files correctly on S3.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed ACL configuration not passed to S3 Filesystem
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests

## Subject

In code it uses lowercase `acl` which here it was `ACL`, which lead to always setting `private`.
Also after that change it got error about wrong `acl` due too fact it was not "translated" too Amazon SDK format.