### PR TITLE
fix empty argument in RolesDownloadStrategy

### DIFF
--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -9,8 +9,7 @@
         </service>
         <service id="sonata.media.security.superadmin_strategy" class="Sonata\MediaBundle\Security\RolesDownloadStrategy">
             <argument type="service" id="translator"/>
-            <argument/>
-            <!-- Either security.context or security.authorization_checker -->
+            <argument type="service" id="security.authorization_checker"/>
             <argument type="collection">
                 <argument>ROLE_SUPER_ADMIN</argument>
                 <argument>ROLE_ADMIN</argument>
@@ -23,8 +22,7 @@
         </service>
         <service id="sonata.media.security.connected_strategy" class="Sonata\MediaBundle\Security\RolesDownloadStrategy">
             <argument type="service" id="translator"/>
-            <argument/>
-            <!-- Either security.context or security.authorization_checker -->
+            <argument type="service" id="security.authorization_checker"/>
             <argument type="collection">
                 <argument>IS_AUTHENTICATED_FULLY</argument>
                 <argument>IS_AUTHENTICATED_REMEMBERED</argument>

--- a/Security/RolesDownloadStrategy.php
+++ b/Security/RolesDownloadStrategy.php
@@ -15,7 +15,6 @@ use Sonata\MediaBundle\Model\MediaInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class RolesDownloadStrategy implements DownloadStrategyInterface
@@ -26,7 +25,7 @@ class RolesDownloadStrategy implements DownloadStrategyInterface
     protected $roles;
 
     /**
-     * @var AuthorizationCheckerInterface|SecurityContextInterface
+     * @var AuthorizationCheckerInterface
      */
     protected $security;
 
@@ -36,16 +35,12 @@ class RolesDownloadStrategy implements DownloadStrategyInterface
     protected $translator;
 
     /**
-     * @param TranslatorInterface                                    $translator
-     * @param AuthorizationCheckerInterface|SecurityContextInterface $security
-     * @param string[]                                               $roles
+     * @param TranslatorInterface           $translator
+     * @param AuthorizationCheckerInterface $security
+     * @param string[]                      $roles
      */
-    public function __construct(TranslatorInterface $translator, $security, array $roles = array())
+    public function __construct(TranslatorInterface $translator, AuthorizationCheckerInterface $security, array $roles = array())
     {
-        if (!$security instanceof AuthorizationCheckerInterface && !$security instanceof SecurityContextInterface) {
-            throw new \InvalidArgumentException('Argument 2 should be an instance of Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface or Symfony\Component\Security\Core\SecurityContextInterface');
-        }
-
         $this->roles = $roles;
         $this->security = $security;
         $this->translator = $translator;

--- a/Tests/DependencyInjection/SonataMediaExtensionTest.php
+++ b/Tests/DependencyInjection/SonataMediaExtensionTest.php
@@ -213,7 +213,7 @@ class SonataMediaExtensionTest extends \PHPUnit_Framework_TestCase
         $container = new ContainerBuilder();
         $container->setParameter('kernel.bundles', array('SonataAdminBundle' => true));
         $container->setDefinition('translator', new Definition('\stdClass'));
-        $container->setDefinition('security.context', new Definition('\stdClass'));
+        $container->setDefinition('security.authorization_checker', new Definition('\stdClass'));
         $container->setDefinition('doctrine', new Definition('\stdClass'));
         $container->setDefinition('session', new Definition('\stdClass'));
 

--- a/Tests/Security/RolesDownloadStrategyTest.php
+++ b/Tests/Security/RolesDownloadStrategyTest.php
@@ -20,13 +20,7 @@ class RolesDownloadStrategyTest extends \PHPUnit_Framework_TestCase
         $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
-
-        // Prefer the Symfony 2.6+ API if available
-        if (interface_exists('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')) {
-            $security = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
-        } else {
-            $security = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
-        }
+        $security = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
 
         $security->expects($this->any())
             ->method('isGranted')
@@ -43,13 +37,7 @@ class RolesDownloadStrategyTest extends \PHPUnit_Framework_TestCase
         $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
         $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
-
-        // Prefer the Symfony 2.6+ API if available
-        if (interface_exists('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')) {
-            $security = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
-        } else {
-            $security = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
-        }
+        $security = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
 
         $security->expects($this->any())
             ->method('isGranted')


### PR DESCRIPTION
I am targetting this branch, because this branch an error which was introduced in #1165

## Changelog

```markdown
### Fixed
- Using the `SecurityContext` is not possible with Symfony >=2.8
```

## Subject

```
[InvalidArgumentException]                                                                                                                                                    
  Argument 2 should be an instance of Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface or Symfony\Component\Security\Core\SecurityContextInterface  
```

Fix error after merge #1165 
