### PR TITLE
[BUGFIX] Fixed issue when filtering by category from classification

### DIFF
--- a/Admin/ORM/MediaAdmin.php
+++ b/Admin/ORM/MediaAdmin.php
@@ -36,7 +36,7 @@ class MediaAdmin extends Admin
             ->add('context', null, array(
                 'show_filter' => $this->getPersistentParameter('hide_context') !== true,
             ), 'choice', $options)
-            ->add('category', null, array(
+            ->add('category', 'doctrine_orm_choice', array(
                 'show_filter' => false,
             ))
             ->add('width')


### PR DESCRIPTION
[BUGFIX] Fixed issue when filtering by category from classification bundle.

Prerequisite: You have Sonata Sandbox installed, there is a SonataClassificationBundle, there are some Categories already inserted, lets say in "default" context

Steps necessary to reproduce:

Go to: [YOUR_APP_DOMAIN]/app_dev.php/admin/app/media-media/list
You will be displayed with a list of medias on right and categories in tree view on the left
Click on any category
Expected result: displayed media within selected category
Actual result: See Symfony debug toolbar, section [Forms], go to details, see "category" form field, expand it, see "value" field -> click on it.

You will get the following:

"Vrednost je nevalidna" (It means invalid value - translated).	value
Symfony\Component\Validator\ConstraintViolation
Object(Symfony\Component\Form\Form).children[category].children[value] = Object(AppBundle\Entity\Classification\Category)
Caused by:
Symfony\Component\Form\Exception\TransformationFailedException
Unable to reverse value for property path "[value]": Expected a string or null.
Caused by:
Symfony\Component\Form\Exception\TransformationFailedException
Expected a string or null.

By stating that 'category' filter field is type of 'doctrine_orm_choice' -> it expects Entity as well.

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because: all tests passes.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes: No related issue

```markdown
### Fixed
See diff
```

## To do
- N/A
## Subject
Changed form type of classification field in filters builder in MediaAdmin 