### PR TITLE
Fixed wrong phpdoc

### DIFF
--- a/Provider/MediaProviderInterface.php
+++ b/Provider/MediaProviderInterface.php
@@ -18,6 +18,7 @@ use Sonata\CoreBundle\Validator\ErrorElement;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Resizer\ResizerInterface;
 use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\HttpFoundation\Response;
 
 interface MediaProviderInterface
 {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is pedantic.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown


### Fixed
 - fixed missing import for PHPdoc
```

## Subject

Import is missing for https://github.com/core23/SonataMediaBundle/blob/92840a6fac0155030520ac02eeff5cdbd2d21ba1/Provider/MediaProviderInterface.php#L213.
