### PR TITLE
Deprecate Guzzle and Buzz dependency and replace it with HTTPlug

### DIFF
--- a/Client/ClientInterface.php
+++ b/Client/ClientInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Client;
+
+interface ClientInterface
+{
+    /**
+     * Creates a http request and sends it to the server.
+     */
+    public function sendRequest(string $method, string $url): string;
+}

--- a/Client/GuzzleClient.php
+++ b/Client/GuzzleClient.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Client;
+
+final class GuzzleClient implements ClientInterface
+{
+    /**
+     * @var Browser
+     */
+    private $browser;
+
+    public function __construct(Browser $browser)
+    {
+        $this->browser = $browser;
+    }
+
+    public function sendRequest(string $method, string $url): string
+    {
+        return $this->browser->call($url, $method)->getContent();
+    }
+}

--- a/Client/HTTPlugClient.php
+++ b/Client/HTTPlugClient.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Client;
+
+use Http\Client\HttpClient;
+use Http\Message\MessageFactory;
+
+final class HTTPlugClient implements ClientInterface
+{
+    /**
+     * @var HttpClient
+     */
+    private $client;
+
+    /**
+     * @var MessageFactory
+     */
+    private $messageFactory;
+
+    public function __construct(HttpClient $client, MessageFactory $messageFactory)
+    {
+        $this->client = $client;
+        $this->messageFactory = $messageFactory;
+    }
+
+    public function sendRequest(string $method, string $url): string
+    {
+        return $this->client->sendRequest(
+            $this->messageFactory->createRequest($method, $url)
+        )->getBody();
+    }
+}

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -9,6 +9,10 @@ Doctrine ORM join columns from GalleryHasMedia entity towards both Gallery and M
 they include the `onDelete="CASCADE"` option: this allows to delete a media if included in a gallery (and vice-versa).
 You should upgrade your database in a safe way after upgrading your vendors.
 
+## BaseVideoProvider uses HTTPlug
+
+The `Guzzle` and `Buzz` dependency are deprecated and will be replaced with the abstract `HTTPlug` client, so you can choose your prefered client implementation. You should adapt the new `BaseVideoProvider::__construct` signature.
+
 UPGRADE FROM 3.4 to 3.5
 =======================
 

--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
         "friendsofsymfony/rest-bundle": "<2.1 || >=3.0",
         "jms/serializer": "<0.13",
         "liip/imagine-bundle": "<1.9",
+        "php-http/httplug-bundle": "<1.1",
         "sonata-project/block-bundle": "<3.14 || >=4.0",
         "sonata-project/classification-bundle": "<3.0 || >= 5.0",
         "sonata-project/formatter-bundle": "<3.4",
@@ -70,6 +71,7 @@
     },
     "require-dev": {
         "aws/aws-sdk-php": "^2.8",
+        "core23/mime-util": "^0.1 || ^0.2",
         "friendsofsymfony/rest-bundle": "^2.1",
         "jackalope/jackalope-doctrine-dbal": "^1.1",
         "liip/imagine-bundle": "^1.9",
@@ -86,7 +88,11 @@
         "symfony/security-csrf": "^2.8 || ^3.2 || ^4.0"
     },
     "suggest": {
+        "core23/mime-util": "For using abstract HTTPlug client",
         "liip/imagine-bundle": "If you want on-the-fly thumbnail generation or image filtering (scale, crop, watermark...)",
+        "php-http/buzz-adapter": "Buzz HTTP client implementation",
+        "php-http/guzzle6-adapter": "Guzzle HTTP client implementation",
+        "php-http/httplug-bundle": "For using abstract HTTPlug client",
         "rackspace/php-opencloud": "^1.6",
         "sonata-project/classification-bundle": "If you want to categorize your media items.",
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",

--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -172,5 +172,11 @@ Full configuration options:
                 generator:  sonata.media.generator.default
                 thumbnail:  sonata.media.thumbnail.format
 
+        # The buzz implementation is deprecated, use HTTPlug instead
         buzz:
             connector:  sonata.media.buzz.connector.file_get_contents # sonata.media.buzz.connector.curl
+
+        http:
+            # If you want to use a custom client, have a look at http://docs.php-http.org
+            client:             httplug.client.default
+            message_factory:    httplug.message_factory.default

--- a/docs/reference/creating_a_provider_class.rst
+++ b/docs/reference/creating_a_provider_class.rst
@@ -291,7 +291,7 @@ added to the provider pool.
         <argument type="service" id="sonata.media.cdn.server" />
         <argument type="service" id="sonata.media.generator.default" />
         <argument type="service" id="sonata.media.thumbnail.format" />
-        <argument type="service" id="sonata.media.buzz.browser" />
+        <argument type="service" id="sonata.media.http.client" />
         <argument type="service" id="sonata.media.metadata.proxy" />
         <call method="setTemplates">
             <argument type="collection">

--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -25,6 +25,8 @@ Retrieve the bundle with composer:
 .. code-block:: bash
 
     $ composer require sonata-project/media-bundle
+    $ composer require php-http/guzzle6-adapter # recommended HTTP client
+    $ composer require sonata-project/classification-bundle # (optional: if you need media classification)
 
 Register these bundles in your ``bundles.php`` file:
 
@@ -59,7 +61,8 @@ Register these bundles in your ``bundles.php`` file:
           new Sonata\MediaBundle\SonataMediaBundle(),
           new Sonata\EasyExtendsBundle\SonataEasyExtendsBundle(),
 
-          // You need to add this dependency to make media functional
+          // You need to add these dependencies to make media functional
+          new Http\HttplugBundle\HttplugBundle(),
           new JMS\SerializerBundle\JMSSerializerBundle(),
           // ...
       );

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -82,6 +82,7 @@ class Configuration implements ConfigurationInterface
         $this->addExtraSection($node);
         $this->addModelSection($node);
         $this->addBuzzSection($node);
+        $this->addHttpClientSection($node);
         $this->addResizerSection($node);
         $this->addAdapterSection($node);
 
@@ -183,9 +184,6 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
-    /**
-     * @param ArrayNodeDefinition $node
-     */
     private function addFilesystemSection(ArrayNodeDefinition $node)
     {
         $node
@@ -478,6 +476,27 @@ class Configuration implements ConfigurationInterface
                             ->booleanNode('verify_peer')->defaultValue(true)->end()
                             ->scalarNode('proxy')->defaultNull()->end()
                         ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    /**
+     * @param ArrayNodeDefinition $node
+     */
+    private function addHttpClientSection(ArrayNodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->arrayNode('http')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('client')
+                            ->info('any service implementing Sonata\MediaBundle\Client\ClientInterface')
+                            ->defaultValue('httplug.client.default')
+                        ->end()
+                        ->scalarNode('message_factory')->defaultValue('httplug.message_factory.default')->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -204,6 +204,7 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
         $this->configureParameterClass($container, $config);
         $this->configureExtra($container, $config);
         $this->configureBuzz($container, $config);
+        $this->configureHttpClient($container, $config);
         $this->configureProviders($container, $config);
         $this->configureAdapters($container, $config);
         $this->configureResizers($container, $config);
@@ -680,5 +681,11 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
         }
 
         $container->setAlias('sonata.media.resizer.default', $config['resizers']['default']);
+    }
+
+    private function configureHttpClient(ContainerBuilder $container, array $config)
+    {
+        $container->setAlias('sonata.media.http.client', $config['http']['client']);
+        $container->setAlias('sonata.media.http.message_factory', $config['http']['message_factory']);
     }
 }

--- a/src/Metadata/AmazonMetadataBuilder.php
+++ b/src/Metadata/AmazonMetadataBuilder.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Metadata;
 
+use Core23\MimeUtil\MimeUtil;
 use GuzzleHttp\Psr7;
 use Sonata\MediaBundle\Model\MediaInterface;
 
@@ -116,6 +117,18 @@ class AmazonMetadataBuilder implements MetadataBuilderInterface
      */
     protected function getContentType($filename)
     {
+        // NEXT_MAJOR: Remove this BC hack
+        if (class_exists(MimeUtil::class)) {
+            return [
+                'contentType' => MimeUtil::getInstance()->getTypeFromFilename($filename),
+            ];
+        }
+
+        @trigger_error(
+            'Using the native Guzzle dependency is deprecated since 3.x and will be removed in 4.0',
+            E_USER_DEPRECATED
+        );
+
         $extension = pathinfo($filename, PATHINFO_EXTENSION);
         $contentType = Psr7\mimetype_from_extension($extension);
 

--- a/src/Provider/YouTubeProvider.php
+++ b/src/Provider/YouTubeProvider.php
@@ -16,6 +16,7 @@ namespace Sonata\MediaBundle\Provider;
 use Buzz\Browser;
 use Gaufrette\Filesystem;
 use Sonata\MediaBundle\CDN\CDNInterface;
+use Sonata\MediaBundle\Client\ClientInterface;
 use Sonata\MediaBundle\Generator\GeneratorInterface;
 use Sonata\MediaBundle\Metadata\MetadataBuilderInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
@@ -35,13 +36,13 @@ class YouTubeProvider extends BaseVideoProvider
      * @param CDNInterface             $cdn
      * @param GeneratorInterface       $pathGenerator
      * @param ThumbnailInterface       $thumbnail
-     * @param Browser                  $browser
+     * @param Browser|ClientInterface  $client
      * @param MetadataBuilderInterface $metadata
      * @param bool                     $html5
      */
-    public function __construct($name, Filesystem $filesystem, CDNInterface $cdn, GeneratorInterface $pathGenerator, ThumbnailInterface $thumbnail, Browser $browser, MetadataBuilderInterface $metadata = null, $html5 = false)
+    public function __construct($name, Filesystem $filesystem, CDNInterface $cdn, GeneratorInterface $pathGenerator, ThumbnailInterface $thumbnail, $client, MetadataBuilderInterface $metadata = null, $html5 = false)
     {
-        parent::__construct($name, $filesystem, $cdn, $pathGenerator, $thumbnail, $browser, $metadata);
+        parent::__construct($name, $filesystem, $cdn, $pathGenerator, $thumbnail, $client, $metadata);
         $this->html5 = $html5;
     }
 

--- a/src/Resources/config/provider.xml
+++ b/src/Resources/config/provider.xml
@@ -64,7 +64,7 @@
             <argument/>
             <argument/>
             <argument type="service" id="sonata.media.thumbnail.format"/>
-            <argument type="service" id="sonata.media.buzz.browser"/>
+            <argument type="service" id="sonata.media.http.client"/>
             <argument type="service" id="sonata.media.metadata.proxy"/>
             <argument/>
             <call method="setTemplates">
@@ -81,7 +81,7 @@
             <argument/>
             <argument/>
             <argument type="service" id="sonata.media.thumbnail.format"/>
-            <argument type="service" id="sonata.media.buzz.browser"/>
+            <argument type="service" id="sonata.media.http.client"/>
             <argument type="service" id="sonata.media.metadata.proxy"/>
             <call method="setTemplates">
                 <argument type="collection">
@@ -97,7 +97,7 @@
             <argument/>
             <argument/>
             <argument type="service" id="sonata.media.thumbnail.format"/>
-            <argument type="service" id="sonata.media.buzz.browser"/>
+            <argument type="service" id="sonata.media.http.client"/>
             <argument type="service" id="sonata.media.metadata.proxy"/>
             <call method="setTemplates">
                 <argument type="collection">

--- a/tests/Provider/DailyMotionProviderTest.php
+++ b/tests/Provider/DailyMotionProviderTest.php
@@ -13,12 +13,11 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Tests\Provider;
 
-use Buzz\Browser;
-use Buzz\Message\AbstractMessage;
-use Buzz\Message\Response;
 use Gaufrette\Adapter;
 use Gaufrette\File;
 use Gaufrette\Filesystem;
+use Http\Client\HttpClient;
+use Http\Message\MessageFactory;
 use Imagine\Image\Box;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Form\FormMapper;
@@ -32,10 +31,14 @@ use Sonata\MediaBundle\Thumbnail\FormatThumbnail;
 
 class DailyMotionProviderTest extends AbstractProviderTest
 {
-    public function getProvider(Browser $browser = null)
+    public function getProvider(HttpClient $client = null, MessageFactory $messageFactory = null)
     {
-        if (!$browser) {
-            $browser = $this->createMock(Browser::class);
+        if (null === $client) {
+            $client = $this->createMock('Http\Client\HttpClient');
+        }
+
+        if (null === $messageFactory) {
+            $messageFactory = $this->createMock('Http\Message\MessageFactory');
         }
 
         $resizer = $this->createMock(ResizerInterface::class);
@@ -61,7 +64,7 @@ class DailyMotionProviderTest extends AbstractProviderTest
 
         $metadata = $this->createMock(MetadataBuilderInterface::class);
 
-        $provider = new DailyMotionProvider('file', $filesystem, $cdn, $generator, $thumbnail, $browser, $metadata);
+        $provider = new DailyMotionProvider('file', $filesystem, $cdn, $generator, $thumbnail, $client, $messageFactory, $metadata);
         $provider->setResizer($resizer);
 
         return $provider;
@@ -88,14 +91,18 @@ class DailyMotionProviderTest extends AbstractProviderTest
 
     public function testThumbnail()
     {
-        $response = $this->createMock(AbstractMessage::class);
-        $response->expects($this->once())->method('getContent')->will($this->returnValue('content'));
+        $request = $this->createMock('Psr\Http\Message\RequestInterface');
 
-        $browser = $this->createMock(Browser::class);
+        $messageFactory = $this->createMock('Http\Message\MessageFactory');
+        $messageFactory->expects($this->once())->method('createRequest')->will($this->returnValue($request));
 
-        $browser->expects($this->once())->method('get')->will($this->returnValue($response));
+        $response = $this->createMock('Psr\Http\Message\ResponseInterface');
+        $response->expects($this->once())->method('getBody')->will($this->returnValue('content'));
 
-        $provider = $this->getProvider($browser);
+        $client = $this->createMock('Http\Client\HttpClient');
+        $client->expects($this->once())->method('sendRequest')->with($this->equalTo($request))->will($this->returnValue($response));
+
+        $provider = $this->getProvider($client, $messageFactory);
 
         $media = new Media();
         $media->setName('les tests fonctionnels - Symfony Live 2009');
@@ -119,13 +126,20 @@ class DailyMotionProviderTest extends AbstractProviderTest
 
     public function testTransformWithSig()
     {
-        $response = new Response();
-        $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_dailymotion.txt'));
+        $request = $this->createMock('Psr\Http\Message\RequestInterface');
 
-        $browser = $this->createMock(Browser::class);
-        $browser->expects($this->once())->method('get')->will($this->returnValue($response));
+        $messageFactory = $this->createMock('Http\Message\MessageFactory');
+        $messageFactory->expects($this->once())->method('createRequest')->will($this->returnValue($request));
 
-        $provider = $this->getProvider($browser);
+        $response = $this->createMock('Psr\Http\Message\ResponseInterface');
+        $response->expects($this->once())->method('getBody')->will($this->returnValue(
+            file_get_contents(__DIR__.'/../fixtures/valid_dailymotion.txt')
+        ));
+
+        $client = $this->createMock('Http\Client\HttpClient');
+        $client->expects($this->once())->method('sendRequest')->with($this->equalTo($request))->will($this->returnValue($response));
+
+        $provider = $this->getProvider($client, $messageFactory);
 
         $provider->addFormat('big', ['width' => 200, 'height' => null, 'constraint' => true]);
 
@@ -145,13 +159,20 @@ class DailyMotionProviderTest extends AbstractProviderTest
      */
     public function testTransformWithUrl($url)
     {
-        $response = new Response();
-        $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_dailymotion.txt'));
+        $request = $this->createMock('Psr\Http\Message\RequestInterface');
 
-        $browser = $this->createMock(Browser::class);
-        $browser->expects($this->once())->method('get')->will($this->returnValue($response));
+        $messageFactory = $this->createMock('Http\Message\MessageFactory');
+        $messageFactory->expects($this->once())->method('createRequest')->will($this->returnValue($request));
 
-        $provider = $this->getProvider($browser);
+        $response = $this->createMock('Psr\Http\Message\ResponseInterface');
+        $response->expects($this->once())->method('getBody')->will($this->returnValue(
+            file_get_contents(__DIR__.'/../fixtures/valid_dailymotion.txt')
+        ));
+
+        $client = $this->createMock('Http\Client\HttpClient');
+        $client->expects($this->once())->method('sendRequest')->with($this->equalTo($request))->will($this->returnValue($response));
+
+        $provider = $this->getProvider($client, $messageFactory);
 
         $provider->addFormat('big', ['width' => 200, 'height' => null, 'constraint' => true]);
 

--- a/tests/Provider/YouTubeProviderTest.php
+++ b/tests/Provider/YouTubeProviderTest.php
@@ -13,12 +13,11 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Tests\Provider;
 
-use Buzz\Browser;
-use Buzz\Message\AbstractMessage;
-use Buzz\Message\Response;
 use Gaufrette\Adapter;
 use Gaufrette\File;
 use Gaufrette\Filesystem;
+use Http\Client\HttpClient;
+use Http\Message\MessageFactory;
 use Imagine\Image\Box;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Form\FormMapper;
@@ -32,10 +31,14 @@ use Sonata\MediaBundle\Thumbnail\FormatThumbnail;
 
 class YouTubeProviderTest extends AbstractProviderTest
 {
-    public function getProvider(Browser $browser = null)
+    public function getProvider(HttpClient $client = null, MessageFactory $messageFactory = null)
     {
-        if (!$browser) {
-            $browser = $this->createMock(Browser::class);
+        if (null === $client) {
+            $client = $this->createMock('Http\Client\HttpClient');
+        }
+
+        if (null === $messageFactory) {
+            $messageFactory = $this->createMock('Http\Message\MessageFactory');
         }
 
         $resizer = $this->createMock(ResizerInterface::class);
@@ -61,7 +64,7 @@ class YouTubeProviderTest extends AbstractProviderTest
 
         $metadata = $this->createMock(MetadataBuilderInterface::class);
 
-        $provider = new YouTubeProvider('file', $filesystem, $cdn, $generator, $thumbnail, $browser, $metadata);
+        $provider = new YouTubeProvider('file', $filesystem, $cdn, $generator, $thumbnail, $client, $messageFactory, $metadata);
         $provider->setResizer($resizer);
 
         return $provider;
@@ -88,14 +91,18 @@ class YouTubeProviderTest extends AbstractProviderTest
 
     public function testThumbnail()
     {
-        $response = $this->createMock(AbstractMessage::class);
-        $response->expects($this->once())->method('getContent')->will($this->returnValue('content'));
+        $request = $this->createMock('Psr\Http\Message\RequestInterface');
 
-        $browser = $this->createMock(Browser::class);
+        $messageFactory = $this->createMock('Http\Message\MessageFactory');
+        $messageFactory->expects($this->once())->method('createRequest')->will($this->returnValue($request));
 
-        $browser->expects($this->once())->method('get')->will($this->returnValue($response));
+        $response = $this->createMock('Psr\Http\Message\ResponseInterface');
+        $response->expects($this->once())->method('getBody')->will($this->returnValue('content'));
 
-        $provider = $this->getProvider($browser);
+        $client = $this->createMock('Http\Client\HttpClient');
+        $client->expects($this->once())->method('sendRequest')->with($this->equalTo($request))->will($this->returnValue($response));
+
+        $provider = $this->getProvider($client, $messageFactory);
 
         $media = new Media();
         $media->setProviderName('youtube');
@@ -118,13 +125,20 @@ class YouTubeProviderTest extends AbstractProviderTest
 
     public function testTransformWithSig()
     {
-        $response = new Response();
-        $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_youtube.txt'));
+        $request = $this->createMock('Psr\Http\Message\RequestInterface');
 
-        $browser = $this->createMock(Browser::class);
-        $browser->expects($this->once())->method('get')->will($this->returnValue($response));
+        $messageFactory = $this->createMock('Http\Message\MessageFactory');
+        $messageFactory->expects($this->once())->method('createRequest')->will($this->returnValue($request));
 
-        $provider = $this->getProvider($browser);
+        $response = $this->createMock('Psr\Http\Message\ResponseInterface');
+        $response->expects($this->once())->method('getBody')->will($this->returnValue(
+            file_get_contents(__DIR__.'/../fixtures/valid_youtube.txt')
+        ));
+
+        $client = $this->createMock('Http\Client\HttpClient');
+        $client->expects($this->once())->method('sendRequest')->with($this->equalTo($request))->will($this->returnValue($response));
+
+        $provider = $this->getProvider($client, $messageFactory);
 
         $provider->addFormat('big', ['width' => 200, 'height' => 100, 'constraint' => true]);
 
@@ -144,13 +158,20 @@ class YouTubeProviderTest extends AbstractProviderTest
      */
     public function testTransformWithUrl($url)
     {
-        $response = new Response();
-        $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_youtube.txt'));
+        $request = $this->createMock('Psr\Http\Message\RequestInterface');
 
-        $browser = $this->createMock(Browser::class);
-        $browser->expects($this->once())->method('get')->will($this->returnValue($response));
+        $messageFactory = $this->createMock('Http\Message\MessageFactory');
+        $messageFactory->expects($this->once())->method('createRequest')->will($this->returnValue($request));
 
-        $provider = $this->getProvider($browser);
+        $response = $this->createMock('Psr\Http\Message\ResponseInterface');
+        $response->expects($this->once())->method('getBody')->will($this->returnValue(
+            file_get_contents(__DIR__.'/../fixtures/valid_youtube.txt')
+        ));
+
+        $client = $this->createMock('Http\Client\HttpClient');
+        $client->expects($this->once())->method('sendRequest')->with($this->equalTo($request))->will($this->returnValue($response));
+
+        $provider = $this->getProvider($client, $messageFactory);
 
         $provider->addFormat('big', ['width' => 200, 'height' => 100, 'constraint' => true]);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this will be BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Backport of #1060
Closes #1160

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `HTTPlug` dependency for abstract client calls.

### Deprecated
 - Deprecate `Guzzle` and `Buzz` usage in  dependency in `BaseVideoProvider`
```

## Subject

Today we use both dependencies for http connection. This change removed both dependencies completly and replaces them with some abstract library.

This PR suggest using the new `HTTPlug` dependency instead of `Guzzle` and `Buzz`.
