### PR TITLE
compatibility with Twig 2.0

### DIFF
--- a/Twig/Extension/FormatterMediaExtension.php
+++ b/Twig/Extension/FormatterMediaExtension.php
@@ -61,9 +61,9 @@ class FormatterMediaExtension extends BaseProxyExtension
     public function getTokenParsers()
     {
         return array(
-            new MediaTokenParser($this->getName()),
-            new ThumbnailTokenParser($this->getName()),
-            new PathTokenParser($this->getName()),
+            new MediaTokenParser(get_class()),
+            new ThumbnailTokenParser(get_class()),
+            new PathTokenParser(get_class()),
         );
     }
 
@@ -73,14 +73,6 @@ class FormatterMediaExtension extends BaseProxyExtension
     public function getTwigExtension()
     {
         return $this->twigExtension;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'sonata_formatter_media';
     }
 
     /**

--- a/Twig/Extension/MediaExtension.php
+++ b/Twig/Extension/MediaExtension.php
@@ -56,9 +56,9 @@ class MediaExtension extends \Twig_Extension implements \Twig_Extension_InitRunt
     public function getTokenParsers()
     {
         return array(
-            new MediaTokenParser($this->getName()),
-            new ThumbnailTokenParser($this->getName()),
-            new PathTokenParser($this->getName()),
+            new MediaTokenParser(get_class()),
+            new ThumbnailTokenParser(get_class()),
+            new PathTokenParser(get_class()),
         );
     }
 
@@ -68,14 +68,6 @@ class MediaExtension extends \Twig_Extension implements \Twig_Extension_InitRunt
     public function initRuntime(\Twig_Environment $environment)
     {
         $this->environment = $environment;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'sonata_media';
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
         "symfony/security":"^2.3 || ^3.0",
         "symfony/templating":"^2.3 || ^3.0",
         "symfony/translation": "^2.3 || ^3.0",
-        "symfony/validator": "^2.3 || ^3.0"
+        "symfony/validator": "^2.3 || ^3.0",
+        "twig/twig": "^1.28 || ^2.0"
     },
     "require-dev": {
         "aws/aws-sdk-php": "^2.7",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Refs #1183 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- support for Twig 2.0
```

## Subject

<!-- Describe your Pull Request content here -->

I was wondering, as there wasn't any dependency for twig...