### PR TITLE
Refactor on media edit image size and measures, SonataIntlBundle is not needed anymore

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -8,7 +8,6 @@ This bundle is mainly dependant of:
 
 * Classification: https://sonata-project.org/bundles/classification
 * Core: https://sonata-project.org/bundles/core
-* Intl: https://sonata-project.org/bundles/intl
 
 This bundle has optional dependancies of:
 
@@ -40,7 +39,6 @@ Register these bundles in your AppKernel:
           // ...
           new Sonata\MediaBundle\SonataMediaBundle(),
           new Sonata\EasyExtendsBundle\SonataEasyExtendsBundle(),
-          new Sonata\IntlBundle\SonataIntlBundle(),
 
           // You need to add this dependency to make media functional
           new JMS\SerializerBundle\JMSSerializerBundle(),

--- a/Resources/views/MediaAdmin/edit.html.twig
+++ b/Resources/views/MediaAdmin/edit.html.twig
@@ -9,6 +9,23 @@ file that was distributed with this source code.
 
 #}
 
+{% import _self as macros %}
+
+{% macro bytesToSize(bytes) %}
+{% spaceless %}
+    {% set kilobyte = 1024 %}
+    {% set megabyte = kilobyte * 1024 %}
+
+    {% if bytes < kilobyte %}
+        {{ bytes ~ ' B' }}
+    {% elseif bytes < megabyte %}
+        {{ (bytes / kilobyte)|number_format(2) ~ ' KB' }}
+    {% else %}
+        {{ (bytes / megabyte)|number_format(2) ~ ' MB' }}
+    {% endif %}
+{% endspaceless %}
+{% endmacro %}
+
 {% extends 'SonataAdminBundle:CRUD:base_edit.html.twig' %}
 
 {% block stylesheets %}
@@ -50,8 +67,10 @@ file that was distributed with this source code.
                             <table class="table">
                                 <tr>
                                     <th>{{ 'label.size'|trans({}, 'SonataMediaBundle') }}</th>
-                                    <td>{{ object.width|number_format_decimal }}px x {{ object.height|number_format_decimal }}px
-                                        {% if object.size > 0 %}({{ object.size|number_format_decimal }}o){% endif %}</td>
+                                    <td>
+                                        {{ object.width }} x {{ object.height }}
+                                        {% if object.size > 0 %}({{ macros.bytesToSize(object.size) }}){% endif %}
+                                    </td>
                                 </tr>
                                 <tr>
                                     <th>{{ 'label.content_type'|trans({}, 'SonataMediaBundle') }}</th>

--- a/Tests/Block/Breadcrumb/BreadcrumbTest.php
+++ b/Tests/Block/Breadcrumb/BreadcrumbTest.php
@@ -11,8 +11,8 @@
 
 namespace Sonata\MediaBundle\Tests\Block\Breadcrumb;
 
+use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
 use Sonata\MediaBundle\Block\Breadcrumb\BaseGalleryBreadcrumbBlockService;
-use Sonata\SeoBundle\Tests\Block\BaseBlockTest;
 
 class BreadcrumbGalleryBlockService_Test extends BaseGalleryBreadcrumbBlockService
 {
@@ -21,7 +21,7 @@ class BreadcrumbGalleryBlockService_Test extends BaseGalleryBreadcrumbBlockServi
 /**
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
  */
-class BreadcrumbTest extends BaseBlockTest
+class BreadcrumbTest extends AbstractBlockServiceTestCase
 {
     public function testBlockService()
     {

--- a/composer.json
+++ b/composer.json
@@ -41,8 +41,7 @@
         "knplabs/gaufrette": "^0.1.6 || ^0.2",
         "imagine/imagine": "^0.6",
         "kriswallsmith/buzz": "^0.15",
-        "jms/serializer-bundle": "^0.13 || ^1.0",
-        "sonata-project/intl-bundle": "^2.2"
+        "jms/serializer-bundle": "^0.13 || ^1.0"
     },
     "require-dev": {
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "sonata-project/formatter-bundle": "^3.0",
         "sonata-project/datagrid-bundle": "^2.2",
         "sonata-project/block-bundle": "^3.1.1",
-        "sonata-project/seo-bundle": "^2.0",
+        "sonata-project/seo-bundle": "^2.1",
         "aws/aws-sdk-php": "^2.7",
         "jackalope/jackalope-doctrine-dbal": "^1.1",
         "symfony/phpunit-bridge": "^2.7 || ^3.0",
@@ -62,13 +62,13 @@
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
         "liip/imagine-bundle": "^0.9",
         "rackspace/php-opencloud": "^1.6",
-        "sonata-project/seo-bundle": "^2.0",
+        "sonata-project/seo-bundle": "^2.1",
         "tilleuls/ckeditor-sonata-media-bundle": "^1.0"
     },
     "conflict": {
         "friendsofsymfony/rest-bundle": "<1.7.4 || >=3.0",
         "jms/serializer": "<0.13",
-        "sonata-project/seo-bundle": "<2.0 || >=3.0",
+        "sonata-project/seo-bundle": "<2.1 || >=3.0",
         "sonata-project/block-bundle": "<3.1.1 || >=4.0"
     },
     "autoload": {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because I think there is no BC break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
- Media edit size calculations

### Removed
- SonataIntlBundle dependency
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the documentation

## Subject

<!-- Describe your Pull Request content here -->

SonataIntlBundle was only used to render sizes of images (300px x 400px) and image size (140 KB). We don't need to pass a filter to parse decimals on the image height and width since there are pixels. Depending on a bundle just to filter image size doesn't make much sense IMO, so I rewrited the size calculation as a macro without decimals.

On a image with size: 130,677 bytes

Before: 
350px x 500px (130,677o)

After:
350 x 500 (127.61 KB)
