### PR TITLE
Remove use of request from container directly

### DIFF
--- a/Tests/Controller/MediaControllerTest.php
+++ b/Tests/Controller/MediaControllerTest.php
@@ -1,0 +1,170 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\Controller;
+
+use Sonata\MediaBundle\Controller\MediaController;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
+
+class MediaControllerTest extends PHPUnit_Framework_TestCase
+{
+    protected $container;
+    protected $controller;
+
+    protected function setUp()
+    {
+        $this->container = $this->prophesize('Symfony\Component\DependencyInjection\Container');
+
+        $this->controller = new MediaController();
+        $this->controller->setContainer($this->container->reveal());
+    }
+
+    public function testDownloadActionWithNotFoundMedia()
+    {
+        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+
+        $this->configureGetMedia(1, null);
+
+        $this->controller->downloadAction(1);
+    }
+
+    public function testDownloadActionAccessDenied()
+    {
+        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
+
+        $request = $this->prophesize('Symfony\Component\HttpFoundation\Request');
+        $media = $this->prophesize('Sonata\MediaBundle\Model\Media');
+        $pool = $this->prophesize('Sonata\MediaBundle\Provider\Pool');
+
+        $this->configureGetCurrentRequest($request->reveal());
+        $this->configureGetMedia(1, $media->reveal());
+        $this->configureDownloadSecurity($pool, $media->reveal(), $request->reveal(), false);
+        $this->container->get('sonata.media.pool')->willReturn($pool->reveal());
+
+        $this->controller->downloadAction(1);
+    }
+
+    public function testDownloadActionBinaryFile()
+    {
+        $media = $this->prophesize('Sonata\MediaBundle\Model\Media');
+        $pool = $this->prophesize('Sonata\MediaBundle\Provider\Pool');
+        $provider = $this->prophesize('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $request = $this->prophesize('Symfony\Component\HttpFoundation\Request');
+        $response = $this->prophesize('Symfony\Component\HttpFoundation\BinaryFileResponse');
+
+        $this->configureGetMedia(1, $media->reveal());
+        $this->configureDownloadSecurity($pool, $media->reveal(), $request->reveal(), true);
+        $this->configureGetProvider($pool, $media, $provider->reveal());
+        $this->configureGetCurrentRequest($request->reveal());
+        $this->container->get('sonata.media.pool')->willReturn($pool->reveal());
+        $pool->getDownloadMode($media->reveal())->willReturn('mode');
+        $provider->getDownloadResponse($media->reveal(), 'format', 'mode')->willReturn($response->reveal());
+        $response->prepare($request->reveal())->shouldBeCalled();
+
+        $result = $this->controller->downloadAction(1, 'format');
+
+        $this->assertSame($response->reveal(), $result);
+    }
+
+    public function testViewActionWithNotFoundMedia()
+    {
+        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+
+        $this->configureGetMedia(1, null);
+
+        $this->controller->viewAction(1);
+    }
+
+    public function testViewActionAccessDenied()
+    {
+        $this->expectException('Symfony\Component\Security\Core\Exception\AccessDeniedException');
+
+        $media = $this->prophesize('Sonata\MediaBundle\Model\Media');
+        $pool = $this->prophesize('Sonata\MediaBundle\Provider\Pool');
+        $request = $this->prophesize('Symfony\Component\HttpFoundation\Request');
+
+        $this->configureGetMedia(1, $media->reveal());
+        $this->configureGetCurrentRequest($request->reveal());
+        $this->configureDownloadSecurity($pool, $media->reveal(), $request->reveal(), false);
+        $this->container->get('sonata.media.pool')->willReturn($pool->reveal());
+
+        $this->controller->viewAction(1);
+    }
+
+    public function testViewActionRendersView()
+    {
+        $media = $this->prophesize('Sonata\MediaBundle\Model\Media');
+        $pool = $this->prophesize('Sonata\MediaBundle\Provider\Pool');
+        $request = $this->prophesize('Symfony\Component\HttpFoundation\Request');
+
+        $this->configureGetMedia(1, $media->reveal());
+        $this->configureGetCurrentRequest($request->reveal());
+        $this->configureDownloadSecurity($pool, $media->reveal(), $request->reveal(), true);
+        $this->configureRender('SonataMediaBundle:Media:view.html.twig', array(
+            'media' => $media->reveal(),
+            'formats' => array('format'),
+            'format' => 'format',
+        ), 'renderResponse');
+        $this->container->get('sonata.media.pool')->willReturn($pool->reveal());
+        $media->getContext()->willReturn('context');
+        $pool->getFormatNamesByContext('context')->willReturn(array('format'));
+
+        $response = $this->controller->viewAction(1, 'format');
+
+        $this->assertSame('renderResponse', $response);
+    }
+
+    private function configureDownloadSecurity($pool, $media, $request, $isGranted)
+    {
+        $strategy = $this->prophesize('Sonata\MediaBundle\Security\DownloadStrategyInterface');
+
+        $pool->getDownloadSecurity($media)->willReturn($strategy->reveal());
+        $strategy->isGranted($media, $request)->willReturn($isGranted);
+    }
+
+    private function configureGetMedia($id, $media)
+    {
+        $mediaManager = $this->prophesize('Sonata\CoreBundle\Model\BaseEntityManager');
+
+        $this->container->get('sonata.media.manager.media')->willReturn($mediaManager->reveal());
+        $mediaManager->find($id)->willReturn($media);
+    }
+
+    private function configureGetProvider($pool, $media, $provider)
+    {
+        $pool->getProvider('provider')->willReturn($provider);
+        $media->getProviderName()->willReturn('provider');
+    }
+
+    private function configureGetCurrentRequest($request)
+    {
+        // NEXT_MAJOR: Remove this trick when bumping Symfony requirement to 2.8+.
+        if (class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
+            $requestStack = $this->prophesize('Symfony\Component\HttpFoundation\RequestStack');
+
+            $this->container->has('request_stack')->willReturn(true);
+            $this->container->get('request_stack')->willReturn($requestStack->reveal());
+            $requestStack->getCurrentRequest()->willReturn($request);
+        } else {
+            $this->container->has('request_stack')->willReturn(false);
+            $this->container->get('request')->willReturn($request);
+        }
+    }
+
+    private function configureRender($template, $data, $rendered)
+    {
+        $templating = $this->prophesize('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+
+        $this->container->has('templating')->willReturn(true);
+        $this->container->get('templating')->willReturn($templating->reveal());
+        $templating->renderResponse($template, $data, null)->willReturn($rendered);
+    }
+}

--- a/Tests/Helpers/PHPUnit_Framework_TestCase.php
+++ b/Tests/Helpers/PHPUnit_Framework_TestCase.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\Helpers;
+
+/**
+ * This is helpers class for supporting old and new PHPUnit versions.
+ *
+ * @todo NEXT_MAJOR: Remove this class when dropping support for < PHPUnit 5.4.
+ *
+ * @author Oleksandr Savchenko <savchenko.oleksandr.ua@gmail.com>
+ */
+class PHPUnit_Framework_TestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function expectException($exception, $message = '', $code = null)
+    {
+        if (is_callable('parent::expectException')) {
+            parent::expectException($exception);
+
+            if ($message !== '') {
+                parent::expectExceptionMessage($message);
+            }
+
+            if ($code !== null) {
+                parent::expectExceptionCode($code);
+            }
+        }
+
+        return parent::setExpectedException($exception, $message, $code);
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1069 #1068 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `getRequest` method on controller for BC with Symfony 2.3+
```


## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests

## Subject

<!-- Describe your Pull Request content here -->
This is essentially same as #1069. Since the user didn't answer, I created another PR with the same code.

It just fixes the compatibility with SF3, where you can't obtain request from the container, you have to use request_stack, available since SF2.8

~The build will fail until #1188 gets merged.~