### PR TITLE
Fixed compatibility with SF3

### DIFF
--- a/Admin/BaseMediaAdmin.php
+++ b/Admin/BaseMediaAdmin.php
@@ -106,7 +106,16 @@ abstract class BaseMediaAdmin extends AbstractAdmin
 
         if ($this->hasRequest()) {
             if ($this->getRequest()->isMethod('POST')) {
-                $media->setProviderName($this->getRequest()->get(sprintf('%s[providerName]', $this->getUniqid()), null, true));
+                if (method_exists('Symfony\Component\HttpFoundation\JsonResponse', 'transformJsonError')) {
+                    // NEXT_MAJOR remove this block when dropping sf < 2.8 compatibility
+                    $media->setProviderName(
+                        $this->getRequest()->get(sprintf('%s[providerName]', $this->getUniqid()), null, true)
+                    );
+                } else {
+                    $media->setProviderName(
+                        $this->getRequest()->get($this->getUniqid()['providerName'])
+                    );
+                }
             } else {
                 $media->setProviderName($this->getRequest()->get('provider'));
             }

--- a/Admin/GalleryAdmin.php
+++ b/Admin/GalleryAdmin.php
@@ -127,16 +127,13 @@ class GalleryAdmin extends AbstractAdmin
                 ->add('defaultFormat', 'choice', array('choices' => $formats))
             ->end()
             ->with('Gallery')
-                ->add('galleryHasMedias', 'sonata_type_collection', array(
-                        'cascade_validation' => true,
-                    ), array(
-                        'edit' => 'inline',
-                        'inline' => 'table',
-                        'sortable' => 'position',
-                        'link_parameters' => array('context' => $context),
-                        'admin_code' => 'sonata.media.admin.gallery_has_media',
-                    )
-                )
+                ->add('galleryHasMedias', 'sonata_type_collection', array(), array(
+                    'edit' => 'inline',
+                    'inline' => 'table',
+                    'sortable' => 'position',
+                    'link_parameters' => array('context' => $context),
+                    'admin_code' => 'sonata.media.admin.gallery_has_media',
+                ))
             ->end()
         ;
     }

--- a/Model/Media.php
+++ b/Model/Media.php
@@ -13,8 +13,10 @@ namespace Sonata\MediaBundle\Model;
 
 use Imagine\Image\Box;
 use Sonata\ClassificationBundle\Model\CategoryInterface;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\ExecutionContextInterface as LegacyExecutionContextInterface;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 abstract class Media implements MediaInterface
 {
@@ -609,6 +611,21 @@ abstract class Media implements MediaInterface
     public function getPreviousProviderReference()
     {
         return $this->previousProviderReference;
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method when bumping Symfony requirement to 2.8+.
+     *
+     * @param ClassMetadata $metadata
+     */
+    public static function loadValidatorMetadata(ClassMetadata $metadata)
+    {
+        if (class_exists('Symfony\Component\Validator\Constraints\Expression')) {
+            $method = 'isStatusErroneous';
+        } else {
+            $method = array('methods' => array('isStatusErroneous'));
+        }
+        $metadata->addConstraint(new Assert\Callback($method));
     }
 
     /**

--- a/Resources/config/validation.xml
+++ b/Resources/config/validation.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping         http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
     <class name="Sonata\MediaBundle\Model\Media">
-        <constraint name="Callback">
-            <option name="methods">
-                <value>isStatusErroneous</value>
-            </option>
-        </constraint>
+        <!-- NEXT_MAJOR: Uncomment Following line
+        <constraint name="Callback">isStatusErroneous</constraint>
+        -->
         <constraint name="Sonata\CoreBundle\Validator\Constraints\InlineConstraint">
             <option name="service">sonata.media.pool</option>
             <option name="method">validate</option>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1115 #1101 #1148 #1111 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- `cascade_validation` from `GalleryAdmin`

### Fixed
- Callback contraint is not a valid callable on Symfony 3
- `BaseAdmin` incorrectly retrieved `providerName`
```

## Subject

Essentially the same as #1115 and #1148. But trying to do it in a BC way. Not sure about the Callback constraint, don't know if it is BC. Don't merge until we know.
<!-- Describe your Pull Request content here -->
