### PR TITLE
Replaced form types for the FQCN's

### DIFF
--- a/Admin/BaseMediaAdmin.php
+++ b/Admin/BaseMediaAdmin.php
@@ -184,7 +184,12 @@ abstract class BaseMediaAdmin extends AbstractAdmin
             return;
         }
 
-        $formMapper->add('providerName', 'hidden');
+        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
+        $hiddenType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
+            : 'hidden';
+
+        $formMapper->add('providerName', $hiddenType);
 
         $formMapper->getFormBuilder()->addModelTransformer(new ProviderDataTransformer($this->pool, $this->getClass()), true);
 
@@ -196,7 +201,12 @@ abstract class BaseMediaAdmin extends AbstractAdmin
             $provider->buildCreateForm($formMapper);
         }
 
-        $formMapper->add('category', 'sonata_type_model_list', array(), array(
+        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
+        $modelListType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Sonata\AdminBundle\Form\Type\ModelListType'
+            : 'sonata_type_model_list';
+
+        $formMapper->add('category', $modelListType, array(), array(
             'link_parameters' => array(
                 'context' => $media->getContext(),
                 'hide_context' => true,

--- a/Admin/BaseMediaAdmin.php
+++ b/Admin/BaseMediaAdmin.php
@@ -106,14 +106,16 @@ abstract class BaseMediaAdmin extends AbstractAdmin
 
         if ($this->hasRequest()) {
             if ($this->getRequest()->isMethod('POST')) {
+                $uniqid = $this->getUniqid();
+
                 if (method_exists('Symfony\Component\HttpFoundation\JsonResponse', 'transformJsonError')) {
                     // NEXT_MAJOR remove this block when dropping sf < 2.8 compatibility
                     $media->setProviderName(
-                        $this->getRequest()->get(sprintf('%s[providerName]', $this->getUniqid()), null, true)
+                        $this->getRequest()->get(sprintf('%s[providerName]', $uniqid), null, true)
                     );
                 } else {
                     $media->setProviderName(
-                        $this->getRequest()->get($this->getUniqid()['providerName'])
+                        $this->getRequest()->get($uniqid['providerName'])
                     );
                 }
             } else {

--- a/Admin/GalleryAdmin.php
+++ b/Admin/GalleryAdmin.php
@@ -116,18 +116,28 @@ class GalleryAdmin extends AbstractAdmin
             $contexts[$contextItem] = $contextItem;
         }
 
+        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
+        $choiceType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Sonata\AdminBundle\Form\Type\ChoiceType'
+            : 'choice';
+
+        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
+        $collectionType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Sonata\AdminBundle\Form\Type\CollectionType'
+            : 'sonata_type_collection';
+
         $formMapper
             ->with('Options')
-                ->add('context', 'choice', array(
+                ->add('context', $choiceType, array(
                     'choices' => $contexts,
                     'translation_domain' => 'SonataMediaBundle',
                 ))
                 ->add('enabled', null, array('required' => false))
                 ->add('name')
-                ->add('defaultFormat', 'choice', array('choices' => $formats))
+                ->add('defaultFormat', $choiceType, array('choices' => $formats))
             ->end()
             ->with('Gallery')
-                ->add('galleryHasMedias', 'sonata_type_collection', array(), array(
+                ->add('galleryHasMedias', $collectionType, array(), array(
                     'edit' => 'inline',
                     'inline' => 'table',
                     'sortable' => 'position',

--- a/Admin/GalleryHasMediaAdmin.php
+++ b/Admin/GalleryHasMediaAdmin.php
@@ -36,12 +36,22 @@ class GalleryHasMediaAdmin extends AbstractAdmin
             }
         }
 
+        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
+        $modelListType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Sonata\AdminBundle\Form\Type\ModelListType'
+            : 'sonata_type_model_list';
+
+        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
+        $hiddenType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
+            : 'hidden';
+
         $formMapper
-            ->add('media', 'sonata_type_model_list', array('required' => false), array(
+            ->add('media', $modelListType, array('required' => false), array(
                 'link_parameters' => $link_parameters,
             ))
             ->add('enabled', null, array('required' => false))
-            ->add('position', 'hidden')
+            ->add('position', $hiddenType)
         ;
     }
 

--- a/Admin/ORM/MediaAdmin.php
+++ b/Admin/ORM/MediaAdmin.php
@@ -51,7 +51,12 @@ class MediaAdmin extends Admin
             $providers[$name] = $name;
         }
 
-        $datagridMapper->add('providerName', 'doctrine_orm_choice', array(
+        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
+        $ormChoiceType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Sonata\DoctrineORMAdminBundle\Filter\ChoiceFilter'
+            : 'doctrine_orm_choice';
+
+        $datagridMapper->add('providerName', $ormChoiceType, array(
             'field_options' => array(
                 'choices' => $providers,
                 'required' => false,

--- a/Block/FeatureMediaBlockService.php
+++ b/Block/FeatureMediaBlockService.php
@@ -45,17 +45,30 @@ class FeatureMediaBlockService extends MediaBlockService
     {
         $formatChoices = $this->getFormatChoices($block->getSetting('mediaId'));
 
-        $formMapper->add('settings', 'sonata_type_immutable_array', array(
+        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $immutableArrayType = 'Sonata\CoreBundle\Form\Type\ImmutableArrayType';
+            $textType = 'Symfony\Component\Form\Extension\Core\Type\TextType';
+            $textareaType = 'Symfony\Component\Form\Extension\Core\Type\TextareaType';
+            $choiceType = 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
+        } else {
+            $immutableArrayType = 'sonata_type_immutable_array';
+            $textType = 'text';
+            $textareaType = 'textarea';
+            $choiceType = 'choice';
+        }
+
+        $formMapper->add('settings', $immutableArrayType, array(
             'keys' => array(
-                array('title', 'text', array(
+                array('title', $textType, array(
                     'required' => false,
                     'label' => 'form.label_title',
                 )),
-                array('content', 'textarea', array(
+                array('content', $textareaType, array(
                     'required' => false,
                     'label' => 'form.label_content',
                 )),
-                array('orientation', 'choice', array(
+                array('orientation', $choiceType, array(
                     'required' => false,
                     'choices' => array(
                         'left' => 'form.label_orientation_left',
@@ -64,7 +77,7 @@ class FeatureMediaBlockService extends MediaBlockService
                     'label' => 'form.label_orientation',
                 )),
                 array($this->getMediaBuilder($formMapper), null, array()),
-                array('format', 'choice', array(
+                array('format', $choiceType, array(
                     'required' => count($formatChoices) > 0,
                     'choices' => $formatChoices,
                     'label' => 'form.label_format',

--- a/Block/GalleryBlockService.php
+++ b/Block/GalleryBlockService.php
@@ -126,38 +126,55 @@ class GalleryBlockService extends AbstractBlockService
         $fieldDescription->setOption('edit', 'list');
         $fieldDescription->setAssociationMapping(array('fieldName' => 'gallery', 'type' => ClassMetadataInfo::MANY_TO_ONE));
 
-        $builder = $formMapper->create('galleryId', 'sonata_type_model_list', array(
+        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $modelListType = 'Sonata\AdminBundle\Form\Type\ModelListType';
+            $immutableArrayType = 'Sonata\CoreBundle\Form\Type\ImmutableArrayType';
+            $textType = 'Symfony\Component\Form\Extension\Core\Type\TextType';
+            $choiceType = 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
+            $numberType = 'Symfony\Component\Form\Extension\Core\Type\NumberType';
+            $checkboxType = 'Symfony\Component\Form\Extension\Core\Type\CheckboxType';
+        } else {
+            $modelListType = 'sonata_type_model_list';
+            $immutableArrayType = 'sonata_type_immutable_array';
+            $textType = 'text';
+            $choiceType = 'choice';
+            $numberType = 'number';
+            $checkboxType = 'checkbox';
+        }
+
+        $builder = $formMapper->create('galleryId', $modelListType, array(
             'sonata_field_description' => $fieldDescription,
             'class' => $this->getGalleryAdmin()->getClass(),
             'model_manager' => $this->getGalleryAdmin()->getModelManager(),
             'label' => 'form.label_gallery',
         ));
 
-        $formMapper->add('settings', 'sonata_type_immutable_array', array(
+        $formMapper->add('settings', $immutableArrayType, array(
             'keys' => array(
-                array('title', 'text', array(
+                array('title', $textType, array(
                     'required' => false,
                     'label' => 'form.label_title',
                 )),
-                array('context', 'choice', array(
+                array('context', $choiceType, array(
                     'required' => true,
                     'choices' => $contextChoices,
                     'label' => 'form.label_context',
                 )),
-                array('format', 'choice', array(
+                array('format', $choiceType, array(
                     'required' => count($formatChoices) > 0,
                     'choices' => $formatChoices,
                     'label' => 'form.label_format',
                 )),
                 array($builder, null, array()),
-                array('pauseTime', 'number', array(
+                array('pauseTime', $numberType, array(
                     'label' => 'form.label_pause_time',
                 )),
-                array('startPaused', 'checkbox', array(
+                array('startPaused', $checkboxType, array(
                     'required' => false,
                     'label' => 'form.label_start_paused',
                 )),
-                array('wrap', 'checkbox', array(
+                array('wrap', $checkboxType, array(
                     'required' => false,
                     'label' => 'form.label_wrap',
                 )),

--- a/Block/GalleryListBlockService.php
+++ b/Block/GalleryListBlockService.php
@@ -59,29 +59,42 @@ class GalleryListBlockService extends AbstractBlockService
             $contextChoices[$name] = $name;
         }
 
-        $formMapper->add('settings', 'sonata_type_immutable_array', array(
+        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $immutableArrayType = 'Sonata\CoreBundle\Form\Type\ImmutableArrayType';
+            $textType = 'Symfony\Component\Form\Extension\Core\Type\TextType';
+            $integerType = 'Symfony\Component\Form\Extension\Core\Type\IntegerType';
+            $choiceType = 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
+        } else {
+            $immutableArrayType = 'sonata_type_immutable_array';
+            $textType = 'text';
+            $integerType = 'integer';
+            $choiceType = 'choice';
+        }
+
+        $formMapper->add('settings', $immutableArrayType, array(
             'keys' => array(
-                array('title', 'text', array(
+                array('title', $textType, array(
                     'label' => 'form.label_title',
                     'required' => false,
                 )),
-                array('number', 'integer', array(
+                array('number', $integerType, array(
                     'label' => 'form.label_number',
                     'required' => true,
                 )),
-                array('context', 'choice', array(
+                array('context', $choiceType, array(
                     'required' => true,
                     'label' => 'form.label_context',
                     'choices' => $contextChoices,
                 )),
-                array('mode', 'choice', array(
+                array('mode', $choiceType, array(
                     'label' => 'form.label_mode',
                     'choices' => array(
                         'public' => 'form.label_mode_public',
                         'admin' => 'form.label_mode_admin',
                     ),
                 )),
-                array('order', 'choice',  array(
+                array('order', $choiceType,  array(
                     'label' => 'form.label_order',
                     'choices' => array(
                         'name' => 'form.label_order_name',
@@ -89,7 +102,7 @@ class GalleryListBlockService extends AbstractBlockService
                         'updatedAt' => 'form.label_order_updated_at',
                     ),
                 )),
-                array('sort', 'choice', array(
+                array('sort', $choiceType, array(
                     'label' => 'form.label_sort',
                     'choices' => array(
                         'desc' => 'form.label_sort_desc',

--- a/Block/MediaBlockService.php
+++ b/Block/MediaBlockService.php
@@ -102,14 +102,25 @@ class MediaBlockService extends AbstractBlockService
 
         $formatChoices = $this->getFormatChoices($block->getSetting('mediaId'));
 
-        $formMapper->add('settings', 'sonata_type_immutable_array', array(
+        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $immutableArrayType = 'Sonata\CoreBundle\Form\Type\ImmutableArrayType';
+            $textType = 'Symfony\Component\Form\Extension\Core\Type\TextType';
+            $choiceType = 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
+        } else {
+            $immutableArrayType = 'sonata_type_immutable_array';
+            $textType = 'text';
+            $choiceType = 'choice';
+        }
+
+        $formMapper->add('settings', $immutableArrayType, array(
             'keys' => array(
-                array('title', 'text', array(
+                array('title', $textType, array(
                     'required' => false,
                     'label' => 'form.label_title',
                 )),
                 array($this->getMediaBuilder($formMapper), null, array()),
-                array('format', 'choice', array(
+                array('format', $choiceType, array(
                     'required' => count($formatChoices) > 0,
                     'choices' => $formatChoices,
                     'label' => 'form.label_format',

--- a/Tests/Admin/BaseMediaAdminTest.php
+++ b/Tests/Admin/BaseMediaAdminTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\Admin;
+
+use Sonata\MediaBundle\Admin\BaseMediaAdmin;
+
+class TestMediaAdmin extends BaseMediaAdmin
+{
+}
+
+class BaseMediaAdminTest extends \PHPUnit_Framework_TestCase
+{
+    private $pool;
+    private $categoryManager;
+    private $mediaAdmin;
+
+    protected function setUp()
+    {
+        $this->pool = $this->prophesize('Sonata\MediaBundle\Provider\Pool');
+        $this->categoryManager = $this->prophesize('Sonata\ClassificationBundle\Entity\CategoryManager');
+
+        $this->mediaAdmin = new TestMediaAdmin(
+            null,
+            'Sonata\MediaBundle\Entity\BaseMedia',
+            'SonataMediaBundle:MediaAdmin',
+            $this->pool->reveal(),
+            $this->categoryManager->reveal()
+        );
+    }
+
+    public function testItIsInstantiable()
+    {
+        $this->assertNotNull($this->mediaAdmin);
+    }
+}

--- a/Tests/Admin/GalleryAdminTest.php
+++ b/Tests/Admin/GalleryAdminTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\Admin;
+
+use Sonata\MediaBundle\Admin\GalleryAdmin;
+
+class GalleryAdminTest extends \PHPUnit_Framework_TestCase
+{
+    protected $pool;
+    protected $categoryManager;
+    protected $mediaAdmin;
+
+    protected function setUp()
+    {
+        $this->pool = $this->prophesize('Sonata\MediaBundle\Provider\Pool');
+        $this->categoryManager = $this->prophesize('Sonata\ClassificationBundle\Entity\CategoryManager');
+
+        $this->mediaAdmin = new GalleryAdmin(
+            null,
+            'Sonata\MediaBundle\Entity\BaseGallery',
+            'SonataMediaBundle:GalleryAdmin',
+            $this->pool->reveal(),
+            $this->categoryManager->reveal()
+        );
+    }
+
+    public function testItIsInstantiable()
+    {
+        $this->assertNotNull($this->mediaAdmin);
+    }
+}

--- a/Tests/Admin/GalleryHasMediaAdminTest.php
+++ b/Tests/Admin/GalleryHasMediaAdminTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\Admin;
+
+use Sonata\MediaBundle\Admin\GalleryHasMediaAdmin;
+
+class GalleryHasMediaAdminTest extends \PHPUnit_Framework_TestCase
+{
+    private $mediaAdmin;
+
+    protected function setUp()
+    {
+        $this->mediaAdmin = new GalleryHasMediaAdmin(
+            null,
+            'Sonata\MediaBundle\Entity\BaseGallery',
+            'SonataMediaBundle:GalleryAdmin'
+        );
+    }
+
+    public function testItIsInstantiable()
+    {
+        $this->assertNotNull($this->mediaAdmin);
+    }
+}

--- a/Tests/Admin/ORM/MediaAdminTest.php
+++ b/Tests/Admin/ORM/MediaAdminTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\Admin\ORM;
+
+use Sonata\MediaBundle\Admin\ORM\MediaAdmin;
+
+class MediaAdminTest extends \PHPUnit_Framework_TestCase
+{
+    private $pool;
+    private $categoryManager;
+    private $mediaAdmin;
+
+    protected function setUp()
+    {
+        $this->pool = $this->prophesize('Sonata\MediaBundle\Provider\Pool');
+        $this->categoryManager = $this->prophesize('Sonata\ClassificationBundle\Entity\CategoryManager');
+
+        $this->mediaAdmin = new MediaAdmin(
+            null,
+            'Sonata\MediaBundle\Entity\BaseMedia',
+            'SonataMediaBundle:MediaAdmin',
+            $this->pool->reveal(),
+            $this->categoryManager->reveal()
+        );
+    }
+
+    public function testItIsInstantiable()
+    {
+        $this->assertNotNull($this->mediaAdmin);
+    }
+}

--- a/Tests/Block/FeatureMediaBlockServiceTest.php
+++ b/Tests/Block/FeatureMediaBlockServiceTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\Block\Service;
+
+use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
+use Sonata\MediaBundle\Block\FeatureMediaBlockService;
+
+class FeatureMediaBlockServiceTest extends AbstractBlockServiceTestCase
+{
+    protected $container;
+    private $galleryManager;
+    private $blockService;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->container = $this->prophesize('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->galleryManager = $this->prophesize('Sonata\MediaBundle\Model\GalleryManagerInterface');
+
+        $this->blockService = new FeatureMediaBlockService(
+            'block.service',
+            $this->templating,
+            $this->container->reveal(),
+            $this->galleryManager->reveal()
+        );
+    }
+
+    public function testDefaultSettings()
+    {
+        $blockContext = $this->getBlockContext($this->blockService);
+
+        $this->assertSettings(array(
+            'attr' => array(),
+            'content' => false,
+            'context' => false,
+            'extra_cache_keys' => array(),
+            'format' => false,
+            'media' => false,
+            'mediaId' => null,
+            'orientation' => 'left',
+            'template' => 'SonataMediaBundle:Block:block_feature_media.html.twig',
+            'title' => false,
+            'ttl' => 0,
+            'use_cache' => true,
+        ), $blockContext);
+    }
+}

--- a/Tests/Block/GalleryBlockServiceTest.php
+++ b/Tests/Block/GalleryBlockServiceTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\Block\Service;
+
+use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
+use Sonata\MediaBundle\Block\GalleryBlockService;
+
+class GalleryBlockServiceTest extends AbstractBlockServiceTestCase
+{
+    protected $container;
+    private $galleryManager;
+    private $blockService;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->container = $this->prophesize('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->galleryManager = $this->prophesize('Sonata\MediaBundle\Model\GalleryManagerInterface');
+
+        $this->blockService = new GalleryBlockService(
+            'block.service',
+            $this->templating,
+            $this->container->reveal(),
+            $this->galleryManager->reveal()
+        );
+    }
+
+    public function testExecute()
+    {
+        $block = $this->prophesize('Sonata\BlockBundle\Model\Block');
+        $gallery = $this->prophesize('Sonata\MediaBundle\Model\GalleryInterface');
+        $blockContext = $this->prophesize('Sonata\BlockBundle\Block\BlockContext');
+
+        $blockContext->getBlock()->willReturn($block->reveal());
+        $blockContext->getSettings()->willReturn(array('settings'));
+        $blockContext->getTemplate()->willReturn('template');
+        $block->getSetting('galleryId')->willReturn($gallery->reveal());
+        $gallery->getGalleryHasMedias()->willReturn(array());
+
+        $this->blockService->execute($blockContext->reveal());
+
+        $this->assertSame('template', $this->templating->view);
+        $this->assertInternalType('array', $this->templating->parameters['settings']);
+        $this->assertInternalType('array', $this->templating->parameters['elements']);
+        $this->assertSame($gallery->reveal(), $this->templating->parameters['gallery']);
+        $this->assertSame($block->reveal(), $this->templating->parameters['block']);
+    }
+
+    public function testDefaultSettings()
+    {
+        $blockContext = $this->getBlockContext($this->blockService);
+
+        $this->assertSettings(array(
+            'attr' => array(),
+            'context' => false,
+            'extra_cache_keys' => array(),
+            'format' => false,
+            'gallery' => false,
+            'galleryId' => null,
+            'pauseTime' => 3000,
+            'startPaused' => false,
+            'template' => 'SonataMediaBundle:Block:block_gallery.html.twig',
+            'title' => false,
+            'ttl' => 0,
+            'use_cache' => true,
+            'wrap' => true,
+        ), $blockContext);
+    }
+}

--- a/Tests/Block/MediaBlockServiceTest.php
+++ b/Tests/Block/MediaBlockServiceTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\Block\Service;
+
+use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
+use Sonata\MediaBundle\Block\MediaBlockService;
+
+class MediaBlockServiceTest extends AbstractBlockServiceTestCase
+{
+    protected $container;
+    private $galleryManager;
+    private $blockService;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->container = $this->prophesize('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->galleryManager = $this->prophesize('Sonata\MediaBundle\Model\GalleryManagerInterface');
+
+        $this->blockService = new MediaBlockService(
+            'block.service',
+            $this->templating,
+            $this->container->reveal(),
+            $this->galleryManager->reveal()
+        );
+    }
+
+    public function testExecute()
+    {
+        $block = $this->prophesize('Sonata\BlockBundle\Model\Block');
+        $media = $this->prophesize('Sonata\MediaBundle\Model\MediaInterface');
+        $blockContext = $this->prophesize('Sonata\BlockBundle\Block\BlockContext');
+
+        $this->configureGetFormatChoices($media, array('format1' => 'format1'));
+        $blockContext->getBlock()->willReturn($block->reveal());
+        $blockContext->getSetting('format')->willReturn('format');
+        $blockContext->setSetting('format', 'format1')->shouldBeCalled();
+        $blockContext->getSettings()->willReturn(array());
+        $blockContext->getTemplate()->willReturn('template');
+        $blockContext->getSetting('mediaId')->willReturn($media->reveal());
+        $block->getSetting('mediaId')->willReturn($media->reveal());
+
+        $this->blockService->execute($blockContext->reveal());
+
+        $this->assertSame('template', $this->templating->view);
+        $this->assertInternalType('array', $this->templating->parameters['settings']);
+        $this->assertSame($media->reveal(), $this->templating->parameters['media']);
+        $this->assertSame($block->reveal(), $this->templating->parameters['block']);
+    }
+
+    public function testDefaultSettings()
+    {
+        $blockContext = $this->getBlockContext($this->blockService);
+
+        $this->assertSettings(array(
+            'attr' => array(),
+            'context' => false,
+            'extra_cache_keys' => array(),
+            'format' => false,
+            'media' => false,
+            'mediaId' => null,
+            'template' => 'SonataMediaBundle:Block:block_media.html.twig',
+            'title' => false,
+            'ttl' => 0,
+            'use_cache' => true,
+        ), $blockContext);
+    }
+
+    private function configureGetFormatChoices($media, $choices)
+    {
+        $mediaAdmin = $this->prophesize('Sonata\MediaBundle\Admin\BaseMediaAdmin');
+        $pool = $this->prophesize('Sonata\MediaBundle\Provider\Pool');
+
+        $this->container->get('sonata.media.admin.media')->willReturn($mediaAdmin->reveal());
+        $mediaAdmin->getPool()->willReturn($pool->reveal());
+        $media->getContext()->willReturn('context');
+        $pool->getFormatNamesByContext('context')->willReturn($choices);
+    }
+}

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -21,7 +21,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
      */
     protected $config;
 
-    public function setUp()
+    protected function setUp()
     {
         $configs = array(
             'sonata_media' => array(

--- a/Tests/DependencyInjection/SonataMediaExtensionTest.php
+++ b/Tests/DependencyInjection/SonataMediaExtensionTest.php
@@ -31,7 +31,7 @@ class SonataMediaExtensionTest extends \PHPUnit_Framework_TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp()
     {
         $configs = $this->getConfigs();
 

--- a/Tests/Metadata/AmazonMetadataBuilderTest.php
+++ b/Tests/Metadata/AmazonMetadataBuilderTest.php
@@ -16,7 +16,7 @@ use Sonata\MediaBundle\Metadata\AmazonMetadataBuilder;
 
 class AmazonMetadataBuilderTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         if (!class_exists('Aws\S3\Enum\CannedAcl')) {
             $this->markTestSkipped('Missing Aws\\S3\\Enum\\CannedAcl');

--- a/Tests/Metadata/ProxyMetadataBuilderTest.php
+++ b/Tests/Metadata/ProxyMetadataBuilderTest.php
@@ -19,7 +19,7 @@ use Sonata\MediaBundle\Metadata\ProxyMetadataBuilder;
 
 class ProxyMetadataBuilderTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         if (!class_exists('AmazonS3', true)) {
             $this->markTestSkipped('The class AmazonS3 does not exist');

--- a/Tests/Provider/AbstractProviderTest.php
+++ b/Tests/Provider/AbstractProviderTest.php
@@ -41,7 +41,7 @@ abstract class AbstractProviderTest extends \PHPUnit_Framework_TestCase
      */
     protected $provider;
 
-    public function setUp()
+    protected function setUp()
     {
         // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
         $that = $this;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Replaced form types for the FQCN's
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Finish replacements
- [x] Update the tests

## Subject

<!-- Describe your Pull Request content here -->

Trying to make SF3 work with this bundle. I think this is mandatory for SF3, am I wrong? Because I get a lot of deprecations in SF2.8.
Is there a way, or it is implemented in another way in other sonata bundles to avoid all this code?
Also, do I need to replace DataGridMapper types and ListMapper types?
