### PR TITLE
Fixed BlockBundle deprecation messages

### DIFF
--- a/Block/GalleryBlockService.php
+++ b/Block/GalleryBlockService.php
@@ -14,8 +14,8 @@ namespace Sonata\MediaBundle\Block;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\CoreBundle\Model\ManagerInterface;
 use Sonata\CoreBundle\Model\Metadata;
@@ -30,7 +30,7 @@ use Symfony\Component\Templating\EngineInterface;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class GalleryBlockService extends BaseBlockService
+class GalleryBlockService extends AbstractBlockService
 {
     /**
      * @var ManagerInterface

--- a/Block/GalleryListBlockService.php
+++ b/Block/GalleryListBlockService.php
@@ -12,8 +12,8 @@
 namespace Sonata\MediaBundle\Block;
 
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\CoreBundle\Model\Metadata;
 use Sonata\MediaBundle\Model\GalleryManagerInterface;
@@ -22,7 +22,7 @@ use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class GalleryListBlockService extends BaseBlockService
+class GalleryListBlockService extends AbstractBlockService
 {
     /**
      * @var GalleryManagerInterface

--- a/Block/MediaBlockService.php
+++ b/Block/MediaBlockService.php
@@ -13,8 +13,8 @@ namespace Sonata\MediaBundle\Block;
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\CoreBundle\Model\ManagerInterface;
 use Sonata\CoreBundle\Model\Metadata;
@@ -30,7 +30,7 @@ use Symfony\Component\Templating\EngineInterface;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class MediaBlockService extends BaseBlockService
+class MediaBlockService extends AbstractBlockService
 {
     /**
      * @var BaseMediaAdmin

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "nelmio/api-doc-bundle": "^2.11",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/admin-bundle": "^3.1",
-        "sonata-project/block-bundle": "^3.1.1",
+        "sonata-project/block-bundle": "^3.2",
         "sonata-project/datagrid-bundle": "^2.2.1",
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
         "sonata-project/formatter-bundle": "^3.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed BlockBundle deprecation messages
```

## Subject

<!-- Describe your Pull Request content here -->

`BaseBlockService` is deprecated since 3.2 of SonataBlockBundle, changed to `AbstractBlockService`.

Not sure about why SonataBlockBundle is a require-dev. Should I add it to suggest?
