### PR TITLE
Removed getMock deprecations

### DIFF
--- a/Tests/Block/Breadcrumb/BreadcrumbTest.php
+++ b/Tests/Block/Breadcrumb/BreadcrumbTest.php
@@ -28,9 +28,9 @@ class BreadcrumbTest extends AbstractBlockServiceTestCase
         $blockService = new BreadcrumbGalleryBlockService_Test(
             'context',
             'name',
-            $this->getMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface'),
-            $this->getMock('Knp\Menu\Provider\MenuProviderInterface'),
-            $this->getMock('Knp\Menu\FactoryInterface')
+            $this->prophesize('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface')->reveal(),
+            $this->prophesize('Knp\Menu\Provider\MenuProviderInterface')->reveal(),
+            $this->prophesize('Knp\Menu\FactoryInterface')->reveal()
         );
 
         $this->assertTrue($blockService->handleContext('context'));

--- a/Tests/Block/GalleryListBlockServiceTest.php
+++ b/Tests/Block/GalleryListBlockServiceTest.php
@@ -34,13 +34,13 @@ class GalleryListBlockServiceTest extends AbstractBlockServiceTestCase
     {
         parent::setUp();
 
-        $this->galleryManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $this->galleryManager = $this->getMockBuilder('Sonata\MediaBundle\Model\GalleryManagerInterface')->getMock();
         $this->pool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
     }
 
     public function testExecute()
     {
-        $pager = $this->getMock('Sonata\DatagridBundle\Pager\PagerInterface');
+        $pager = $this->getMockBuilder('Sonata\DatagridBundle\Pager\PagerInterface')->getMock();
         $this->galleryManager->expects($this->once())->method('getPager')->will($this->returnValue($pager));
 
         $block = new Block();

--- a/Tests/CDN/CloudFrontTest.php
+++ b/Tests/CDN/CloudFrontTest.php
@@ -11,29 +11,29 @@
 
 namespace Sonata\MediaBundle\Tests\CDN;
 
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
+
 /**
  * @author Javier Spagnoletti <phansys@gmail.com>
  */
-class CloudFrontTest extends \PHPUnit_Framework_TestCase
+class CloudFrontTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @group legacy
      */
     public function testLegacyCloudFront()
     {
-        $client = $this->getMock(
-            'Sonata\MediaBundle\Tests\CDN\CloudFrontClientSpy',
-            array('createInvalidation'),
-            array(),
-            '',
-            false
-        );
+        $client = $this->getMockBuilder('Sonata\MediaBundle\Tests\CDN\CloudFrontClientSpy')
+            ->setMethods(array('createInvalidation'))
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $client->expects($this->exactly(3))->method('createInvalidation')->will($this->returnValue(new CloudFrontResultSpy()));
 
         $cloudFront = $this->getMockBuilder('Sonata\MediaBundle\CDN\CloudFront')
-                    ->setConstructorArgs(array('/foo', 'secret', 'key', 'xxxxxxxxxxxxxx'))
-                    ->setMethods(null)
-                    ->getMock();
+            ->setConstructorArgs(array('/foo', 'secret', 'key', 'xxxxxxxxxxxxxx'))
+            ->setMethods(null)
+            ->getMock();
         $cloudFront->setClient($client);
 
         $this->assertSame('/foo/bar.jpg', $cloudFront->getPath('bar.jpg', true));
@@ -51,18 +51,15 @@ class CloudFrontTest extends \PHPUnit_Framework_TestCase
     public function testLegacyException()
     {
         $this->setExpectedException('\RuntimeException', 'Unable to flush : ');
-        $client = $this->getMock(
-            'Sonata\MediaBundle\Tests\CDN\CloudFrontClientSpy',
-            array('createInvalidation'),
-            array(),
-            '',
-            false
-        );
+        $client = $this->getMockBuilder('Sonata\MediaBundle\Tests\CDN\CloudFrontClientSpy')
+            ->setMethods(array('createInvalidation'))
+            ->disableOriginalConstructor()
+            ->getMock();
         $client->expects($this->exactly(1))->method('createInvalidation')->will($this->returnValue(new CloudFrontResultSpy(true)));
         $cloudFront = $this->getMockBuilder('Sonata\MediaBundle\CDN\CloudFront')
-                    ->setConstructorArgs(array('/foo', 'secret', 'key', 'xxxxxxxxxxxxxx'))
-                    ->setMethods(null)
-                    ->getMock();
+            ->setConstructorArgs(array('/foo', 'secret', 'key', 'xxxxxxxxxxxxxx'))
+            ->setMethods(null)
+            ->getMock();
         $cloudFront->setClient($client);
         $cloudFront->flushPaths(array('boom'));
     }

--- a/Tests/CDN/PantherPortalTest.php
+++ b/Tests/CDN/PantherPortalTest.php
@@ -12,12 +12,13 @@
 namespace Sonata\MediaBundle\Tests\CDN;
 
 use Sonata\MediaBundle\CDN\PantherPortal;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class PantherPortalTest extends \PHPUnit_Framework_TestCase
+class PantherPortalTest extends PHPUnit_Framework_TestCase
 {
     public function testPortal()
     {
-        $client = $this->getMock(
+        $client = $this->createMock(
             'Sonata\MediaBundle\Tests\CDN\ClientSpy',
             array('flush'),
             array(),
@@ -42,7 +43,7 @@ class PantherPortalTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('\RuntimeException', 'Unable to flush : Failed!!');
 
-        $client = $this->getMock(
+        $client = $this->createMock(
             'Sonata\MediaBundle\Tests\CDN\ClientSpy',
             array('flush'),
             array(),

--- a/Tests/Command/CleanMediaCommandTest.php
+++ b/Tests/Command/CleanMediaCommandTest.php
@@ -80,7 +80,7 @@ class CleanMediaCommandTest extends TestCase
     {
         parent::setUp();
 
-        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
 
         $this->command = new CleanMediaCommand();
         $this->command->setContainer($this->container);
@@ -92,7 +92,7 @@ class CleanMediaCommandTest extends TestCase
 
         $this->pool = $pool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
 
-        $this->mediaManager = $mediaManager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $this->mediaManager = $mediaManager = $this->getMockBuilder('Sonata\MediaBundle\Model\MediaManagerInterface')->getMock();
 
         $this->fileSystemLocal = $fileSystemLocal = $this->getMockBuilder('Sonata\MediaBundle\Filesystem\Local')->disableOriginalConstructor()->getMock();
         $this->fileSystemLocal->expects($this->once())->method('getDirectory')->will($this->returnValue($this->workspace));
@@ -167,7 +167,7 @@ class CleanMediaCommandTest extends TestCase
         $this->pool->expects($this->any())->method('getContexts')->will($this->returnValue(array('foo' => $context)));
         $this->pool->expects($this->any())->method('getProviders')->will($this->returnValue(array($provider)));
 
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->getMockBuilder('Sonata\MediaBundle\Model\MediaInterface')->getMock();
 
         $this->mediaManager->expects($this->once())->method('findOneBy')
             ->with($this->equalTo(array('id' => 1, 'context' => 'foo')))
@@ -201,7 +201,7 @@ class CleanMediaCommandTest extends TestCase
         $this->pool->expects($this->any())->method('getContexts')->will($this->returnValue(array('foo' => $context)));
         $this->pool->expects($this->any())->method('getProviders')->will($this->returnValue(array($provider)));
 
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->getMockBuilder('Sonata\MediaBundle\Model\MediaInterface')->getMock();
 
         $this->mediaManager->expects($this->once())->method('findOneBy')
             ->with($this->equalTo(array('id' => 1, 'context' => 'foo')))

--- a/Tests/Command/FixMediaContextCommandTest.php
+++ b/Tests/Command/FixMediaContextCommandTest.php
@@ -61,7 +61,7 @@ class FixMediaContextCommandTest extends CommandTest
      */
     protected function setUp()
     {
-        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
 
         $this->command = new FixMediaContextCommand();
         $this->command->setContainer($this->container);
@@ -73,7 +73,7 @@ class FixMediaContextCommandTest extends CommandTest
 
         $this->pool = $pool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
 
-        $this->contextManger = $contextManger = $this->getMock('Sonata\ClassificationBundle\Model\ContextManagerInterface');
+        $this->contextManger = $contextManger = $this->getMockBuilder('Sonata\ClassificationBundle\Model\ContextManagerInterface')->getMock();
 
         $this->categoryManger = $categoryManger = $this->getMockBuilder('Sonata\ClassificationBundle\Entity\CategoryManager')->disableOriginalConstructor()->getMock();
 
@@ -103,11 +103,11 @@ class FixMediaContextCommandTest extends CommandTest
 
         $this->pool->expects($this->any())->method('getContexts')->will($this->returnValue(array('foo' => $context)));
 
-        $contextModel = $this->getMock('Sonata\ClassificationBundle\Model\ContextInterface');
+        $contextModel = $this->getMockBuilder('Sonata\ClassificationBundle\Model\ContextInterface')->getMock();
 
         $this->contextManger->expects($this->once())->method('findOneBy')->with($this->equalTo(array('id' => 'foo')))->will($this->returnValue($contextModel));
 
-        $category = $this->getMock('Sonata\ClassificationBundle\Model\CategoryInterface');
+        $category = $this->getMockBuilder('Sonata\ClassificationBundle\Model\CategoryInterface')->getMock();
 
         $this->categoryManger->expects($this->once())->method('getRootCategory')->with($this->equalTo($contextModel))->will($this->returnValue($category));
 
@@ -128,11 +128,11 @@ class FixMediaContextCommandTest extends CommandTest
 
         $this->pool->expects($this->any())->method('getContexts')->will($this->returnValue(array('foo' => $context)));
 
-        $contextModel = $this->getMock('Sonata\ClassificationBundle\Model\ContextInterface');
+        $contextModel = $this->getMockBuilder('Sonata\ClassificationBundle\Model\ContextInterface')->getMock();
 
         $this->contextManger->expects($this->once())->method('findOneBy')->with($this->equalTo(array('id' => 'foo')))->will($this->returnValue($contextModel));
 
-        $category = $this->getMock('Sonata\ClassificationBundle\Model\CategoryInterface');
+        $category = $this->getMockBuilder('Sonata\ClassificationBundle\Model\CategoryInterface')->getMock();
 
         $this->categoryManger->expects($this->once())->method('getRootCategory')->with($this->equalTo($contextModel))->will($this->returnValue(null));
         $this->categoryManger->expects($this->once())->method('create')->will($this->returnValue($category));
@@ -155,13 +155,13 @@ class FixMediaContextCommandTest extends CommandTest
 
         $this->pool->expects($this->any())->method('getContexts')->will($this->returnValue(array('foo' => $context)));
 
-        $contextModel = $this->getMock('Sonata\ClassificationBundle\Model\ContextInterface');
+        $contextModel = $this->getMockBuilder('Sonata\ClassificationBundle\Model\ContextInterface')->getMock();
 
         $this->contextManger->expects($this->once())->method('findOneBy')->with($this->equalTo(array('id' => 'foo')))->will($this->returnValue(null));
         $this->contextManger->expects($this->once())->method('create')->will($this->returnValue($contextModel));
         $this->contextManger->expects($this->once())->method('save')->with($this->equalTo($contextModel));
 
-        $category = $this->getMock('Sonata\ClassificationBundle\Model\CategoryInterface');
+        $category = $this->getMockBuilder('Sonata\ClassificationBundle\Model\CategoryInterface')->getMock();
 
         $this->categoryManger->expects($this->once())->method('getRootCategory')->with($this->equalTo($contextModel))->will($this->returnValue(null));
         $this->categoryManger->expects($this->once())->method('create')->will($this->returnValue($category));

--- a/Tests/Controller/Api/GalleryControllerTest.php
+++ b/Tests/Controller/Api/GalleryControllerTest.php
@@ -14,6 +14,7 @@ namespace Sonata\MediaBundle\Tests\Controller\Api;
 use Doctrine\Common\Collections\ArrayCollection;
 use Sonata\MediaBundle\Controller\Api\GalleryController;
 use Sonata\MediaBundle\Model\GalleryHasMedia;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 class GalleryTest extends GalleryHasMedia
@@ -23,13 +24,13 @@ class GalleryTest extends GalleryHasMedia
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-class GalleryControllerTest extends \PHPUnit_Framework_TestCase
+class GalleryControllerTest extends PHPUnit_Framework_TestCase
 {
     public function testGetGalleriesAction()
     {
-        $gManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
-        $mediaManager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $gManager = $this->createMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $mediaManager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
 
         $gManager->expects($this->once())->method('getPager')->will($this->returnValue(array()));
 
@@ -46,10 +47,10 @@ class GalleryControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetGalleryAction()
     {
-        $gManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
-        $mediaManager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
-        $gallery = $this->getMock('Sonata\MediaBundle\Model\GalleryInterface');
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $gManager = $this->createMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $mediaManager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $gallery = $this->createMock('Sonata\MediaBundle\Model\GalleryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
 
         $gManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
 
@@ -64,10 +65,10 @@ class GalleryControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetGalleryNotFoundAction()
     {
-        $gManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
-        $mediaManager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $gManager = $this->createMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $mediaManager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
 
         $gManager->expects($this->once())->method('findOneBy');
 
@@ -78,16 +79,16 @@ class GalleryControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetGalleryGalleryhasmediasAction()
     {
-        $gManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
-        $galleryHasMedia = $this->getMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
-        $gallery = $this->getMock('Sonata\MediaBundle\Model\GalleryInterface');
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $gManager = $this->createMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $galleryHasMedia = $this->createMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
+        $gallery = $this->createMock('Sonata\MediaBundle\Model\GalleryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
 
         $gallery->expects($this->once())->method('getGalleryHasMedias')->will($this->returnValue(array($galleryHasMedia)));
 
         $gManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
 
-        $mediaManager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $mediaManager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
 
         $gController = new GalleryController($gManager, $mediaManager, $formFactory, 'test');
 
@@ -96,19 +97,19 @@ class GalleryControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetGalleryMediaAction()
     {
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
 
-        $galleryHasMedia = $this->getMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
+        $galleryHasMedia = $this->createMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
         $galleryHasMedia->expects($this->once())->method('getMedia')->will($this->returnValue($media));
 
-        $gallery = $this->getMock('Sonata\MediaBundle\Model\GalleryInterface');
+        $gallery = $this->createMock('Sonata\MediaBundle\Model\GalleryInterface');
         $gallery->expects($this->once())->method('getGalleryHasMedias')->will($this->returnValue(array($galleryHasMedia)));
 
-        $gManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $gManager = $this->createMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
         $gManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
 
-        $mediaManager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $mediaManager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
 
         $gController = new GalleryController($gManager, $mediaManager, $formFactory, 'test');
 
@@ -117,21 +118,21 @@ class GalleryControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPostGalleryMediaGalleryhasmediaAction()
     {
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
 
-        $media2 = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media2 = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $media2->expects($this->any())->method('getId')->will($this->returnValue(1));
 
-        $galleryHasMedia = $this->getMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
+        $galleryHasMedia = $this->createMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
         $galleryHasMedia->expects($this->once())->method('getMedia')->will($this->returnValue($media2));
 
-        $gallery = $this->getMock('Sonata\MediaBundle\Model\GalleryInterface');
+        $gallery = $this->createMock('Sonata\MediaBundle\Model\GalleryInterface');
         $gallery->expects($this->once())->method('getGalleryHasMedias')->will($this->returnValue(array($galleryHasMedia)));
 
-        $galleryManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $galleryManager = $this->createMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
         $galleryManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
 
-        $mediaManager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $mediaManager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
         $mediaManager->expects($this->once())->method('findOneBy')->will($this->returnValue($media));
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
@@ -139,7 +140,7 @@ class GalleryControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($galleryHasMedia));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, 'Sonata\MediaBundle\Tests\Controller\Api\GalleryTest');
@@ -151,22 +152,22 @@ class GalleryControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPostGalleryMediaGalleryhasmediaInvalidAction()
     {
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $media->expects($this->any())->method('getId')->will($this->returnValue(1));
 
-        $galleryHasMedia = $this->getMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
+        $galleryHasMedia = $this->createMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
         $galleryHasMedia->expects($this->once())->method('getMedia')->will($this->returnValue($media));
 
-        $gallery = $this->getMock('Sonata\MediaBundle\Model\GalleryInterface');
+        $gallery = $this->createMock('Sonata\MediaBundle\Model\GalleryInterface');
         $gallery->expects($this->once())->method('getGalleryHasMedias')->will($this->returnValue(array($galleryHasMedia)));
 
-        $galleryManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $galleryManager = $this->createMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
         $galleryManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
 
-        $mediaManager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $mediaManager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
         $mediaManager->expects($this->once())->method('findOneBy')->will($this->returnValue($media));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
 
         $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, 'Sonata\MediaBundle\Tests\Controller\Api\GalleryTest');
         $view = $galleryController->postGalleryMediaGalleryhasmediaAction(1, 1, new Request());
@@ -177,19 +178,19 @@ class GalleryControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPutGalleryMediaGalleryhasmediaAction()
     {
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $media->expects($this->any())->method('getId')->will($this->returnValue(1));
 
-        $galleryHasMedia = $this->getMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
+        $galleryHasMedia = $this->createMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
         $galleryHasMedia->expects($this->once())->method('getMedia')->will($this->returnValue($media));
 
-        $gallery = $this->getMock('Sonata\MediaBundle\Model\GalleryInterface');
+        $gallery = $this->createMock('Sonata\MediaBundle\Model\GalleryInterface');
         $gallery->expects($this->once())->method('getGalleryHasMedias')->will($this->returnValue(array($galleryHasMedia)));
 
-        $galleryManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $galleryManager = $this->createMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
         $galleryManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
 
-        $mediaManager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $mediaManager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
         $mediaManager->expects($this->once())->method('findOneBy')->will($this->returnValue($media));
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
@@ -197,7 +198,7 @@ class GalleryControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($galleryHasMedia));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, 'Sonata\MediaBundle\Tests\Controller\Api\GalleryTest');
@@ -209,26 +210,26 @@ class GalleryControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPutGalleryMediaGalleryhasmediaInvalidAction()
     {
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $media->expects($this->any())->method('getId')->will($this->returnValue(1));
 
-        $galleryHasMedia = $this->getMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
+        $galleryHasMedia = $this->createMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
         $galleryHasMedia->expects($this->once())->method('getMedia')->will($this->returnValue($media));
 
-        $gallery = $this->getMock('Sonata\MediaBundle\Model\GalleryInterface');
+        $gallery = $this->createMock('Sonata\MediaBundle\Model\GalleryInterface');
         $gallery->expects($this->once())->method('getGalleryHasMedias')->will($this->returnValue(array($galleryHasMedia)));
 
-        $galleryManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $galleryManager = $this->createMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
         $galleryManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
 
-        $mediaManager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $mediaManager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
         $mediaManager->expects($this->once())->method('findOneBy')->will($this->returnValue($media));
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, 'Sonata\MediaBundle\Tests\Controller\Api\GalleryTest');
@@ -239,22 +240,22 @@ class GalleryControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteGalleryMediaGalleryhasmediaAction()
     {
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $media->expects($this->any())->method('getId')->will($this->returnValue(1));
 
-        $galleryHasMedia = $this->getMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
+        $galleryHasMedia = $this->createMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
         $galleryHasMedia->expects($this->once())->method('getMedia')->will($this->returnValue($media));
 
-        $gallery = $this->getMock('Sonata\MediaBundle\Model\GalleryInterface');
+        $gallery = $this->createMock('Sonata\MediaBundle\Model\GalleryInterface');
         $gallery->expects($this->any())->method('getGalleryHasMedias')->will($this->returnValue(new ArrayCollection(array($galleryHasMedia))));
 
-        $galleryManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $galleryManager = $this->createMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
         $galleryManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
 
-        $mediaManager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $mediaManager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
         $mediaManager->expects($this->once())->method('findOneBy')->will($this->returnValue($media));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
 
         $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, 'Sonata\MediaBundle\Tests\Controller\Api\GalleryTest');
         $view = $galleryController->deleteGalleryMediaGalleryhasmediaAction(1, 1);
@@ -264,24 +265,24 @@ class GalleryControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteGalleryMediaGalleryhasmediaInvalidAction()
     {
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
 
-        $media2 = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media2 = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $media2->expects($this->any())->method('getId')->will($this->returnValue(2));
 
-        $galleryHasMedia = $this->getMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
+        $galleryHasMedia = $this->createMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
         $galleryHasMedia->expects($this->once())->method('getMedia')->will($this->returnValue($media2));
 
-        $gallery = $this->getMock('Sonata\MediaBundle\Model\GalleryInterface');
+        $gallery = $this->createMock('Sonata\MediaBundle\Model\GalleryInterface');
         $gallery->expects($this->any())->method('getGalleryHasMedias')->will($this->returnValue(new ArrayCollection(array($galleryHasMedia))));
 
-        $galleryManager = $this->getMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $galleryManager = $this->createMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
         $galleryManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
 
-        $mediaManager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $mediaManager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
         $mediaManager->expects($this->once())->method('findOneBy')->will($this->returnValue($media));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
 
         $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, 'Sonata\MediaBundle\Tests\Controller\Api\GalleryTest');
         $view = $galleryController->deleteGalleryMediaGalleryhasmediaAction(1, 1);

--- a/Tests/Controller/Api/MediaControllerTest.php
+++ b/Tests/Controller/Api/MediaControllerTest.php
@@ -12,17 +12,18 @@
 namespace Sonata\MediaBundle\Tests\Controller\Api;
 
 use Sonata\MediaBundle\Controller\Api\MediaController;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-class MediaControllerTest extends \PHPUnit_Framework_TestCase
+class MediaControllerTest extends PHPUnit_Framework_TestCase
 {
     public function testGetMediaAction()
     {
-        $mManager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $mManager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
 
         $mManager->expects($this->once())->method('getPager')->will($this->returnValue(array($media)));
 
@@ -39,9 +40,9 @@ class MediaControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetMediumAction()
     {
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
 
-        $manager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $manager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
         $manager->expects($this->once())->method('findOneBy')->will($this->returnValue($media));
 
         $controller = $this->createMediaController($manager);
@@ -60,12 +61,12 @@ class MediaControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetMediumFormatsAction()
     {
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
 
-        $manager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $manager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
         $manager->expects($this->once())->method('findOneBy')->will($this->returnValue($media));
 
-        $provider = $this->getMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
         $provider->expects($this->exactly(2))->method('getHelperProperties')->will($this->returnValue(array('foo' => 'bar')));
 
         $pool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
@@ -93,14 +94,14 @@ class MediaControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetMediumBinariesAction()
     {
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
 
         $binaryResponse = $this->getMockBuilder('Symfony\Component\HttpFoundation\BinaryFileResponse')->disableOriginalConstructor()->getMock();
 
-        $manager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $manager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
         $manager->expects($this->once())->method('findOneBy')->will($this->returnValue($media));
 
-        $provider = $this->getMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
         $provider->expects($this->once())->method('getDownloadResponse')->will($this->returnValue($binaryResponse));
 
         $pool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
@@ -113,9 +114,9 @@ class MediaControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteMediumAction()
     {
-        $manager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $manager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
         $manager->expects($this->once())->method('delete');
-        $manager->expects($this->once())->method('findOneBy')->will($this->returnValue($this->getMock('Sonata\MediaBundle\Model\MediaInterface')));
+        $manager->expects($this->once())->method('findOneBy')->will($this->returnValue($this->createMock('Sonata\MediaBundle\Model\MediaInterface')));
 
         $controller = $this->createMediaController($manager);
 
@@ -126,12 +127,12 @@ class MediaControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPutMediumAction()
     {
-        $medium = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $medium = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
 
-        $manager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $manager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
         $manager->expects($this->once())->method('findOneBy')->will($this->returnValue($medium));
 
-        $provider = $this->getMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
         $provider->expects($this->once())->method('getName');
 
         $pool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
@@ -142,7 +143,7 @@ class MediaControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($medium));
 
-        $factory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $factory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         $factory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $controller = $this->createMediaController($manager, $pool, $factory);
@@ -152,12 +153,12 @@ class MediaControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPutMediumInvalidFormAction()
     {
-        $medium = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $medium = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
 
-        $manager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $manager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
         $manager->expects($this->once())->method('findOneBy')->will($this->returnValue($medium));
 
-        $provider = $this->getMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
         $provider->expects($this->once())->method('getName');
 
         $pool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
@@ -167,7 +168,7 @@ class MediaControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $factory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $factory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         $factory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $controller = $this->createMediaController($manager, $pool, $factory);
@@ -177,13 +178,13 @@ class MediaControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPostProviderMediumAction()
     {
-        $medium = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $medium = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $medium->expects($this->once())->method('setProviderName');
 
-        $manager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $manager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
         $manager->expects($this->once())->method('create')->will($this->returnValue($medium));
 
-        $provider = $this->getMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
         $provider->expects($this->once())->method('getName');
 
         $pool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
@@ -194,7 +195,7 @@ class MediaControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($medium));
 
-        $factory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $factory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         $factory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $controller = $this->createMediaController($manager, $pool, $factory);
@@ -207,10 +208,10 @@ class MediaControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function testPostProviderActionNotFound()
     {
-        $medium = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $medium = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $medium->expects($this->once())->method('setProviderName');
 
-        $manager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $manager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
         $manager->expects($this->once())->method('create')->will($this->returnValue($medium));
 
         $pool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
@@ -222,10 +223,10 @@ class MediaControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPutMediumBinaryContentAction()
     {
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $media->expects($this->once())->method('setBinaryContent');
 
-        $manager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $manager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
         $manager->expects($this->once())->method('findOneBy')->will($this->returnValue($media));
 
         $pool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
@@ -238,13 +239,13 @@ class MediaControllerTest extends \PHPUnit_Framework_TestCase
     protected function createMediaController($manager = null, $pool = null, $factory = null)
     {
         if (null === $manager) {
-            $manager = $this->getMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+            $manager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
         }
         if (null === $pool) {
             $pool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
         }
         if (null === $factory) {
-            $factory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+            $factory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         }
 
         return new MediaController($manager, $pool, $factory);

--- a/Tests/Document/MediaManagerTest.php
+++ b/Tests/Document/MediaManagerTest.php
@@ -12,12 +12,13 @@
 namespace Sonata\MediaBundle\Tests\Document;
 
 use Sonata\MediaBundle\Document\MediaManager;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 /**
  * @group document
  * @group mongo
  */
-class MediaManagerTest extends \PHPUnit_Framework_TestCase
+class MediaManagerTest extends PHPUnit_Framework_TestCase
 {
     /** @var MediaManager */
     private $manager;
@@ -71,7 +72,7 @@ class MediaManagerTest extends \PHPUnit_Framework_TestCase
     {
         $dm = $this->getMockBuilder('Doctrine\ODM\MongoDB\DocumentManager')->disableOriginalConstructor()->getMock();
 
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($dm));
 
         return $registry;

--- a/Tests/Entity/GalleryManagerTest.php
+++ b/Tests/Entity/GalleryManagerTest.php
@@ -13,11 +13,12 @@ namespace Sonata\MediaBundle\Test\Entity;
 
 use Sonata\CoreBundle\Test\EntityManagerMockFactory;
 use Sonata\MediaBundle\Entity\GalleryManager;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 /**
  * @author Benoit de Jacobet <benoit.de-jacobet@ekino.com>
  */
-class GalleryManagerTest extends \PHPUnit_Framework_TestCase
+class GalleryManagerTest extends PHPUnit_Framework_TestCase
 {
     public function testGetPager()
     {
@@ -105,7 +106,7 @@ class GalleryManagerTest extends \PHPUnit_Framework_TestCase
             'enabled',
         ));
 
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
         return new GalleryManager('Sonata\MediaBundle\Entity\BaseGallery', $registry);

--- a/Tests/Entity/MediaManagerTest.php
+++ b/Tests/Entity/MediaManagerTest.php
@@ -13,11 +13,12 @@ namespace Sonata\MediaBundle\Test\Entity;
 
 use Sonata\CoreBundle\Test\EntityManagerMockFactory;
 use Sonata\MediaBundle\Entity\MediaManager;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 /**
  * @author Benoit de Jacobet <benoit.de-jacobet@ekino.com>
  */
-class MediaManagerTest extends \PHPUnit_Framework_TestCase
+class MediaManagerTest extends PHPUnit_Framework_TestCase
 {
     public function testGetPager()
     {
@@ -101,7 +102,7 @@ class MediaManagerTest extends \PHPUnit_Framework_TestCase
             'enabled',
         ));
 
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
         return new MediaManager('Sonata\MediaBundle\Entity\BaseMedia', $registry);

--- a/Tests/Filesystem/ReplicateTest.php
+++ b/Tests/Filesystem/ReplicateTest.php
@@ -12,13 +12,14 @@
 namespace Sonata\MediaBundle\Tests\Filesystem;
 
 use Sonata\MediaBundle\Filesystem\Replicate;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class ReplicateTest extends \PHPUnit_Framework_TestCase
+class ReplicateTest extends PHPUnit_Framework_TestCase
 {
     public function testReplicate()
     {
-        $master = $this->getMock('Gaufrette\Adapter');
-        $slave = $this->getMock('Gaufrette\Adapter');
+        $master = $this->createMock('Gaufrette\Adapter');
+        $slave = $this->createMock('Gaufrette\Adapter');
         $replicate = new Replicate($master, $slave);
 
         $master->expects($this->once())->method('mtime')->will($this->returnValue('master'));

--- a/Tests/Form/DataTransformer/ProviderDataTransformerTest.php
+++ b/Tests/Form/DataTransformer/ProviderDataTransformerTest.php
@@ -14,9 +14,10 @@ namespace Sonata\MediaBundle\Tests\Form\DataTransformer;
 use Sonata\MediaBundle\Form\DataTransformer\ProviderDataTransformer;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Provider\Pool;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
-class ProviderDataTransformerTest extends \PHPUnit_Framework_TestCase
+class ProviderDataTransformerTest extends PHPUnit_Framework_TestCase
 {
     public function testReverseTransformFakeValue()
     {
@@ -33,7 +34,7 @@ class ProviderDataTransformerTest extends \PHPUnit_Framework_TestCase
     {
         $pool = new Pool('default');
 
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $media->expects($this->exactly(3))->method('getProviderName')->will($this->returnValue('unknown'));
         $media->expects($this->any())->method('getId')->will($this->returnValue(1));
         $media->expects($this->any())->method('getBinaryContent')->will($this->returnValue('xcs'));
@@ -46,13 +47,13 @@ class ProviderDataTransformerTest extends \PHPUnit_Framework_TestCase
 
     public function testReverseTransformValidProvider()
     {
-        $provider = $this->getMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
         $provider->expects($this->once())->method('transform');
 
         $pool = new Pool('default');
         $pool->addProvider('default', $provider);
 
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $media->expects($this->exactly(3))->method('getProviderName')->will($this->returnValue('default'));
         $media->expects($this->any())->method('getId')->will($this->returnValue(1));
         $media->expects($this->any())->method('getBinaryContent')->will($this->returnValue('xcs'));
@@ -65,12 +66,12 @@ class ProviderDataTransformerTest extends \PHPUnit_Framework_TestCase
 
     public function testReverseTransformWithNewMediaAndNoBinaryContent()
     {
-        $provider = $this->getMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
 
         $pool = new Pool('default');
         $pool->addProvider('default', $provider);
 
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $media->expects($this->any())->method('getId')->will($this->returnValue(null));
         $media->expects($this->any())->method('getBinaryContent')->will($this->returnValue(null));
         $media->expects($this->any())->method('getProviderName')->will($this->returnValue('default'));
@@ -86,12 +87,12 @@ class ProviderDataTransformerTest extends \PHPUnit_Framework_TestCase
 
     public function testReverseTransformWithMediaAndNoBinaryContent()
     {
-        $provider = $this->getMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
 
         $pool = new Pool('default');
         $pool->addProvider('default', $provider);
 
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $media->expects($this->any())->method('getId')->will($this->returnValue(1));
         $media->expects($this->any())->method('getBinaryContent')->will($this->returnValue(null));
 
@@ -101,11 +102,11 @@ class ProviderDataTransformerTest extends \PHPUnit_Framework_TestCase
 
     public function testReverseTransformWithMediaAndUploadFileInstance()
     {
-        $provider = $this->getMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
         $pool = new Pool('default');
         $pool->addProvider('default', $provider);
 
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $media->expects($this->exactly(3))->method('getProviderName')->will($this->returnValue('default'));
         $media->expects($this->any())->method('getId')->will($this->returnValue(1));
         $media->expects($this->any())->method('getBinaryContent')->will($this->returnValue(new UploadedFile(__FILE__, 'ProviderDataTransformerTest')));

--- a/Tests/Form/Type/AbstractTypeTest.php
+++ b/Tests/Form/Type/AbstractTypeTest.php
@@ -38,7 +38,9 @@ abstract class AbstractTypeTest extends TypeTestCase
 
     protected function setUp()
     {
-        $provider = $this->getMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->getMockBuilder('Sonata\MediaBundle\Provider\MediaProviderInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $this->mediaPool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
         $this->mediaPool->expects($this->any())->method('getProvider')->willReturn($provider);

--- a/Tests/Form/Type/ApiMediaTypeTest.php
+++ b/Tests/Form/Type/ApiMediaTypeTest.php
@@ -21,7 +21,7 @@ class ApiMediaTypeTest extends AbstractTypeTest
     public function testBuildForm()
     {
         parent::testBuildForm();
-        $provider = $this->getMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->getMockBuilder('Sonata\MediaBundle\Provider\MediaProviderInterface')->getMock();
 
         $mediaPool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
         $mediaPool->expects($this->once())->method('getProvider')->will($this->returnValue($provider));

--- a/Tests/Helpers/PHPUnit_Framework_TestCase.php
+++ b/Tests/Helpers/PHPUnit_Framework_TestCase.php
@@ -39,4 +39,16 @@ class PHPUnit_Framework_TestCase extends \PHPUnit_Framework_TestCase
 
         return parent::setExpectedException($exception, $message, $code);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createMock($originalClassName)
+    {
+        if (is_callable('parent::createMock')) {
+            return parent::createMock($originalClassName);
+        }
+
+        return parent::getMock($originalClassName);
+    }
 }

--- a/Tests/Listener/ORM/MediaEventSubscriberTest.php
+++ b/Tests/Listener/ORM/MediaEventSubscriberTest.php
@@ -15,12 +15,13 @@ use Doctrine\ORM\Events;
 use Sonata\MediaBundle\Listener\ORM\MediaEventSubscriber;
 use Sonata\MediaBundle\Model\Media;
 use Sonata\MediaBundle\Provider\Pool;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @author Mathieu Lemoine <mlemoine@mlemoine.name>
  */
-class MediaEventSubscriberTest extends \PHPUnit_Framework_TestCase
+class MediaEventSubscriberTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @see https://github.com/sonata-project/SonataClassificationBundle/issues/60
@@ -28,19 +29,23 @@ class MediaEventSubscriberTest extends \PHPUnit_Framework_TestCase
      */
     public function testRefetchCategoriesAfterClear()
     {
-        $provider = $this->getMock('Sonata\\MediaBundle\\Provider\\MediaProviderInterface');
+        $provider = $this->createMock('Sonata\\MediaBundle\\Provider\\MediaProviderInterface');
 
-        $pool = $this->getMock('Sonata\\MediaBundle\\Provider\\Pool', array(), array('default'));
+        $pool = $this->getMockBuilder('Sonata\\MediaBundle\\Provider\\Pool')
+            ->setMethods(array('getProvider'))
+            ->setConstructorArgs(array('default'))
+            ->getMock();
 
         $pool->method('getProvider')->will($this->returnValueMap(array(array('provider', $provider))));
 
-        $category = $this->getMock('Sonata\\ClassificationBundle\\Model\\CategoryInterface');
+        $category = $this->createMock('Sonata\\ClassificationBundle\\Model\\CategoryInterface');
 
-        $catManager = $this->getMockBuilder('Sonata\\ClassificationBundle\\Entity\\CategoryManager', array('getRootCategories'))
-                           ->disableOriginalConstructor()
-                           ->getMock();
+        $catManager = $this->getMockBuilder('Sonata\\ClassificationBundle\\Entity\\CategoryManager')
+            ->setMethods(array('getRootCategories'))
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
+        $container = $this->createMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
 
         $container->method('get')->will($this->returnValueMap(array(
             array('sonata.media.pool', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $pool),
@@ -48,30 +53,37 @@ class MediaEventSubscriberTest extends \PHPUnit_Framework_TestCase
         )));
 
         $catManager->expects($this->exactly(2))
-                   ->method('getRootCategories')
-                   ->willReturn(array('context' => $category))
-                       ;
+            ->method('getRootCategories')
+            ->willReturn(array('context' => $category));
 
         $subscriber = new MediaEventSubscriber($container);
 
         $this->assertContains(Events::onClear, $subscriber->getSubscribedEvents());
 
-        $media1 = $this->getMock('Sonata\\MediaBundle\\Model\\Media', array('getId', 'getCategory', 'getProvider', 'getContext'));
+        $media1 = $this->getMockBuilder('Sonata\\MediaBundle\\Model\\Media')
+            ->setMethods(array('getId', 'getCategory', 'getProvider', 'getContext'))
+            ->getMock();
         $media1->method('getProvider')->willReturn('provider');
         $media1->method('getContext')->willReturn('context');
 
-        $args1 = $this->getMock('Doctrine\\Common\\EventArgs', array('getEntity'));
+        $args1 = $this->getMockBuilder('Doctrine\\Common\\EventArgs')
+            ->setMethods(array('getEntity'))
+            ->getMock();
         $args1->method('getEntity')->willReturn($media1);
 
         $subscriber->prePersist($args1);
 
         $subscriber->onClear();
 
-        $media2 = $this->getMock('Sonata\\MediaBundle\\Model\\Media', array('getId', 'getCategory', 'getProvider', 'getContext'));
+        $media2 = $this->getMockBuilder('Sonata\\MediaBundle\\Model\\Media')
+            ->setMethods(array('getId', 'getCategory', 'getProvider', 'getContext'))
+            ->getMock();
         $media2->method('getProvider')->willReturn('provider');
         $media2->method('getContext')->willReturn('context');
 
-        $args2 = $this->getMock('Doctrine\\Common\\EventArgs', array('getEntity'));
+        $args2 = $this->getMockBuilder('Doctrine\\Common\\EventArgs')
+            ->setMethods(array('getEntity'))
+            ->getMock();
         $args2->method('getEntity')->willReturn($media2);
 
         $subscriber->prePersist($args2);

--- a/Tests/Metadata/AmazonMetadataBuilderTest.php
+++ b/Tests/Metadata/AmazonMetadataBuilderTest.php
@@ -13,8 +13,9 @@ namespace Sonata\MediaBundle\Tests\Metadata;
 
 use Aws\S3\Enum\Storage;
 use Sonata\MediaBundle\Metadata\AmazonMetadataBuilder;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class AmazonMetadataBuilderTest extends \PHPUnit_Framework_TestCase
+class AmazonMetadataBuilderTest extends PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
@@ -25,7 +26,7 @@ class AmazonMetadataBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testAmazon()
     {
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $filename = '/test/folder/testfile.png';
 
         foreach ($this->provider() as $provider) {

--- a/Tests/Metadata/NoopMetadataBuilderTest.php
+++ b/Tests/Metadata/NoopMetadataBuilderTest.php
@@ -12,12 +12,13 @@
 namespace Sonata\MediaBundle\Tests\Metadata;
 
 use Sonata\MediaBundle\Metadata\NoopMetadataBuilder;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class NoopMetadataBuilderTest extends \PHPUnit_Framework_TestCase
+class NoopMetadataBuilderTest extends PHPUnit_Framework_TestCase
 {
     public function testNoop()
     {
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $filename = '/test/folder/testfile.png';
 
         $noopmetadatabuilder = new NoopMetadataBuilder();

--- a/Tests/Metadata/ProxyMetadataBuilderTest.php
+++ b/Tests/Metadata/ProxyMetadataBuilderTest.php
@@ -16,8 +16,9 @@ use Gaufrette\Adapter\AmazonS3;
 use Sonata\MediaBundle\Filesystem\Local;
 use Sonata\MediaBundle\Filesystem\Replicate;
 use Sonata\MediaBundle\Metadata\ProxyMetadataBuilder;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class ProxyMetadataBuilderTest extends \PHPUnit_Framework_TestCase
+class ProxyMetadataBuilderTest extends PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
@@ -33,7 +34,7 @@ class ProxyMetadataBuilderTest extends \PHPUnit_Framework_TestCase
             ->method('get')
             ->will($this->returnValue(array('key' => 'amazon')));
 
-        $noop = $this->getMock('Sonata\MediaBundle\Metadata\NoopMetadataBuilder');
+        $noop = $this->createMock('Sonata\MediaBundle\Metadata\NoopMetadataBuilder');
         $noop->expects($this->never())
             ->method('get')
             ->will($this->returnValue(array('key' => 'noop')));
@@ -45,10 +46,10 @@ class ProxyMetadataBuilderTest extends \PHPUnit_Framework_TestCase
         $filesystem = $this->getMockBuilder('Gaufrette\Filesystem')->disableOriginalConstructor()->getMock();
         $filesystem->expects($this->any())->method('getAdapter')->will($this->returnValue($adapter));
 
-        $provider = $this->getMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
         $provider->expects($this->any())->method('getFilesystem')->will($this->returnValue($filesystem));
 
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $media->expects($this->any())
             ->method('getProviderName')
             ->will($this->returnValue('sonata.media.provider.image'));
@@ -73,7 +74,7 @@ class ProxyMetadataBuilderTest extends \PHPUnit_Framework_TestCase
             ->method('get')
             ->will($this->returnValue(array('key' => 'amazon')));
 
-        $noop = $this->getMock('Sonata\MediaBundle\Metadata\NoopMetadataBuilder');
+        $noop = $this->createMock('Sonata\MediaBundle\Metadata\NoopMetadataBuilder');
         $noop->expects($this->once())
             ->method('get')
             ->will($this->returnValue(array('key' => 'noop')));
@@ -84,10 +85,10 @@ class ProxyMetadataBuilderTest extends \PHPUnit_Framework_TestCase
         $filesystem = $this->getMockBuilder('Gaufrette\Filesystem')->disableOriginalConstructor()->getMock();
         $filesystem->expects($this->any())->method('getAdapter')->will($this->returnValue($adapter));
 
-        $provider = $this->getMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
         $provider->expects($this->any())->method('getFilesystem')->will($this->returnValue($filesystem));
 
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $media->expects($this->any())
             ->method('getProviderName')
             ->will($this->returnValue('sonata.media.provider.image'));
@@ -112,7 +113,7 @@ class ProxyMetadataBuilderTest extends \PHPUnit_Framework_TestCase
             ->method('get')
             ->will($this->returnValue(array('key' => 'amazon')));
 
-        $noop = $this->getMock('Sonata\MediaBundle\Metadata\NoopMetadataBuilder');
+        $noop = $this->createMock('Sonata\MediaBundle\Metadata\NoopMetadataBuilder');
         $noop->expects($this->never())
             ->method('get')
             ->will($this->returnValue(array('key' => 'noop')));
@@ -123,10 +124,10 @@ class ProxyMetadataBuilderTest extends \PHPUnit_Framework_TestCase
         $filesystem = $this->getMockBuilder('Gaufrette\Filesystem')->disableOriginalConstructor()->getMock();
         $filesystem->expects($this->any())->method('getAdapter')->will($this->returnValue($adapter));
 
-        $provider = $this->getMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
         $provider->expects($this->any())->method('getFilesystem')->will($this->returnValue($filesystem));
 
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $media->expects($this->any())
             ->method('getProviderName')
             ->will($this->returnValue('wrongprovider'));
@@ -151,7 +152,7 @@ class ProxyMetadataBuilderTest extends \PHPUnit_Framework_TestCase
             ->method('get')
             ->will($this->returnValue(array('key' => 'amazon')));
 
-        $noop = $this->getMock('Sonata\MediaBundle\Metadata\NoopMetadataBuilder');
+        $noop = $this->createMock('Sonata\MediaBundle\Metadata\NoopMetadataBuilder');
         $noop->expects($this->never())
             ->method('get')
             ->will($this->returnValue(array('key' => 'noop')));
@@ -165,10 +166,10 @@ class ProxyMetadataBuilderTest extends \PHPUnit_Framework_TestCase
         $filesystem = $this->getMockBuilder('Gaufrette\Filesystem')->disableOriginalConstructor()->getMock();
         $filesystem->expects($this->any())->method('getAdapter')->will($this->returnValue($adapter));
 
-        $provider = $this->getMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
         $provider->expects($this->any())->method('getFilesystem')->will($this->returnValue($filesystem));
 
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $media->expects($this->any())
             ->method('getProviderName')
             ->will($this->returnValue('sonata.media.provider.image'));
@@ -193,7 +194,7 @@ class ProxyMetadataBuilderTest extends \PHPUnit_Framework_TestCase
             ->method('get')
             ->will($this->returnValue(array('key' => 'amazon')));
 
-        $noop = $this->getMock('Sonata\MediaBundle\Metadata\NoopMetadataBuilder');
+        $noop = $this->createMock('Sonata\MediaBundle\Metadata\NoopMetadataBuilder');
         $noop->expects($this->once())
             ->method('get')
             ->will($this->returnValue(array('key' => 'noop')));
@@ -206,10 +207,10 @@ class ProxyMetadataBuilderTest extends \PHPUnit_Framework_TestCase
         $filesystem = $this->getMockBuilder('Gaufrette\Filesystem')->disableOriginalConstructor()->getMock();
         $filesystem->expects($this->any())->method('getAdapter')->will($this->returnValue($adapter));
 
-        $provider = $this->getMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
         $provider->expects($this->any())->method('getFilesystem')->will($this->returnValue($filesystem));
 
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $media->expects($this->any())
             ->method('getProviderName')
             ->will($this->returnValue('sonata.media.provider.image'));
@@ -236,7 +237,7 @@ class ProxyMetadataBuilderTest extends \PHPUnit_Framework_TestCase
      */
     protected function getContainerMock(array $services)
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container
             ->expects($this->any())
             ->method('get')

--- a/Tests/PHPCR/MediaManagerTest.php
+++ b/Tests/PHPCR/MediaManagerTest.php
@@ -12,12 +12,13 @@
 namespace Sonata\MediaBundle\Tests\PHPCR;
 
 use Sonata\MediaBundle\PHPCR\MediaManager;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 /**
  * @group document
  * @group PHPCR
  */
-class MediaManagerTest extends \PHPUnit_Framework_TestCase
+class MediaManagerTest extends PHPUnit_Framework_TestCase
 {
     /** @var MediaManager */
     private $manager;
@@ -71,7 +72,7 @@ class MediaManagerTest extends \PHPUnit_Framework_TestCase
     {
         $dm = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')->disableOriginalConstructor()->getMock();
 
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($dm));
 
         return $registry;

--- a/Tests/Provider/AbstractProviderTest.php
+++ b/Tests/Provider/AbstractProviderTest.php
@@ -13,13 +13,14 @@ namespace Sonata\MediaBundle\Tests\Provider;
 
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormTypeInterface;
 
 /**
  * @author Virgile Vivier <virgilevivier@gmail.com>
  */
-abstract class AbstractProviderTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractProviderTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var FormBuilder

--- a/Tests/Provider/BaseProviderTest.php
+++ b/Tests/Provider/BaseProviderTest.php
@@ -21,10 +21,15 @@ class BaseProviderTest extends AbstractProviderTest
 {
     public function getProvider()
     {
-        $adapter = $this->getMock('Gaufrette\Adapter');
+        $adapter = $this->createMock('Gaufrette\Adapter');
 
-        $filesystem = $this->getMock('Gaufrette\Filesystem', array('get'), array($adapter));
-        $file = $this->getMock('Gaufrette\File', array(), array('foo', $filesystem));
+        $filesystem = $this->getMockBuilder('Gaufrette\Filesystem')
+            ->setMethods(array('get'))
+            ->setConstructorArgs(array($adapter))
+            ->getMock();
+        $file = $this->getMockBuilder('Gaufrette\File')
+            ->setConstructorArgs(array('foo', $filesystem))
+            ->getMock();
 
         $filesystem->expects($this->any())
             ->method('get')
@@ -34,9 +39,9 @@ class BaseProviderTest extends AbstractProviderTest
 
         $generator = new \Sonata\MediaBundle\Generator\DefaultGenerator();
 
-        $thumbnail = $this->getMock('Sonata\MediaBundle\Thumbnail\ThumbnailInterface');
+        $thumbnail = $this->createMock('Sonata\MediaBundle\Thumbnail\ThumbnailInterface');
 
-        $metadata = $this->getMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
+        $metadata = $this->createMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
 
         $provider = new TestProvider('test', $filesystem, $cdn, $generator, $thumbnail, $metadata);
 

--- a/Tests/Provider/DailyMotionProviderTest.php
+++ b/Tests/Provider/DailyMotionProviderTest.php
@@ -26,14 +26,19 @@ class DailyMotionProviderTest extends AbstractProviderTest
             $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
         }
 
-        $resizer = $this->getMock('Sonata\MediaBundle\Resizer\ResizerInterface');
+        $resizer = $this->createMock('Sonata\MediaBundle\Resizer\ResizerInterface');
         $resizer->expects($this->any())->method('resize')->will($this->returnValue(true));
         $resizer->expects($this->any())->method('getBox')->will($this->returnValue(new Box(100, 100)));
 
-        $adapter = $this->getMock('Gaufrette\Adapter');
+        $adapter = $this->createMock('Gaufrette\Adapter');
 
-        $filesystem = $this->getMock('Gaufrette\Filesystem', array('get'), array($adapter));
-        $file = $this->getMock('Gaufrette\File', array(), array('foo', $filesystem));
+        $filesystem = $this->getMockBuilder('Gaufrette\Filesystem')
+            ->setMethods(array('get'))
+            ->setConstructorArgs(array($adapter))
+            ->getMock();
+        $file = $this->getMockBuilder('Gaufrette\File')
+            ->setConstructorArgs(array('foo', $filesystem))
+            ->getMock();
         $filesystem->expects($this->any())->method('get')->will($this->returnValue($file));
 
         $cdn = new \Sonata\MediaBundle\CDN\Server('/uploads/media');
@@ -42,7 +47,7 @@ class DailyMotionProviderTest extends AbstractProviderTest
 
         $thumbnail = new FormatThumbnail('jpg');
 
-        $metadata = $this->getMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
+        $metadata = $this->createMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
 
         $provider = new DailyMotionProvider('file', $filesystem, $cdn, $generator, $thumbnail, $browser, $metadata);
         $provider->setResizer($resizer);
@@ -71,7 +76,7 @@ class DailyMotionProviderTest extends AbstractProviderTest
 
     public function testThumbnail()
     {
-        $response = $this->getMock('Buzz\Message\AbstractMessage');
+        $response = $this->createMock('Buzz\Message\AbstractMessage');
         $response->expects($this->once())->method('getContent')->will($this->returnValue('content'));
 
         $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
@@ -154,12 +159,15 @@ class DailyMotionProviderTest extends AbstractProviderTest
 
         $provider = $this->getProvider();
 
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->any())
             ->method('trans')
             ->will($this->returnValue('message'));
 
-        $formMapper = $this->getMock('Sonata\AdminBundle\Form\FormMapper', array('add', 'getAdmin'), array(), '', false);
+        $formMapper = $this->getMockBuilder('Sonata\AdminBundle\Form\FormMapper')
+            ->setMethods(array('add', 'getAdmin'))
+            ->disableOriginalConstructor()
+            ->getMock();
         $formMapper->expects($this->exactly(8))
             ->method('add')
             ->will($this->returnValue(null));

--- a/Tests/Provider/FileProviderTest.php
+++ b/Tests/Provider/FileProviderTest.php
@@ -21,14 +21,19 @@ class FileProviderTest extends AbstractProviderTest
 {
     public function getProvider()
     {
-        $resizer = $this->getMock('Sonata\MediaBundle\Resizer\ResizerInterface');
+        $resizer = $this->createMock('Sonata\MediaBundle\Resizer\ResizerInterface');
         $resizer->expects($this->any())->method('resize')->will($this->returnValue(true));
 
         $adapter = $this->getMockBuilder('Sonata\MediaBundle\Filesystem\Local')->disableOriginalConstructor()->getMock();
         $adapter->expects($this->any())->method('getDirectory')->will($this->returnValue(realpath(__DIR__).'/../fixtures'));
 
-        $filesystem = $this->getMock('Gaufrette\Filesystem', array('get'), array($adapter));
-        $file = $this->getMock('Gaufrette\File', array(), array('foo', $filesystem));
+        $filesystem = $this->getMockBuilder('Gaufrette\Filesystem')
+            ->setMethods(array('get'))
+            ->setConstructorArgs(array($adapter))
+            ->getMock();
+        $file = $this->getMockBuilder('Gaufrette\File')
+            ->setConstructorArgs(array('foo', $filesystem))
+            ->getMock();
         $filesystem->expects($this->any())->method('get')->will($this->returnValue($file));
 
         $cdn = new \Sonata\MediaBundle\CDN\Server('/uploads/media');
@@ -37,7 +42,7 @@ class FileProviderTest extends AbstractProviderTest
 
         $thumbnail = new FormatThumbnail('jpg');
 
-        $metadata = $this->getMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
+        $metadata = $this->createMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
 
         $provider = new FileProvider('file', $filesystem, $cdn, $generator, $thumbnail, array('txt'), array('foo/bar'), $metadata);
         $provider->setResizer($resizer);
@@ -88,12 +93,15 @@ class FileProviderTest extends AbstractProviderTest
 
         $provider = $this->getProvider();
 
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->any())
             ->method('trans')
             ->will($this->returnValue('message'));
 
-        $formMapper = $this->getMock('Sonata\AdminBundle\Form\FormMapper', array('add', 'getAdmin'), array(), '', false);
+        $formMapper = $this->getMockBuilder('Sonata\AdminBundle\Form\FormMapper')
+            ->setMethods(array('add', 'getAdmin'))
+            ->disableOriginalConstructor()
+            ->getMock();
         $formMapper->expects($this->exactly(8))
             ->method('add')
             ->will($this->returnValue(null));
@@ -232,7 +240,7 @@ class FileProviderTest extends AbstractProviderTest
      */
     public function testBinaryContentWithRealPath()
     {
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
 
         $media->expects($this->any())
             ->method('getProviderReference')
@@ -277,7 +285,7 @@ class FileProviderTest extends AbstractProviderTest
      */
     public function testBinaryContentStreamWrapped()
     {
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
 
         $media->expects($this->any())
             ->method('getProviderReference')

--- a/Tests/Provider/ImageProviderTest.php
+++ b/Tests/Provider/ImageProviderTest.php
@@ -20,14 +20,19 @@ class ImageProviderTest extends AbstractProviderTest
 {
     public function getProvider($allowedExtensions = array(), $allowedMimeTypes = array())
     {
-        $resizer = $this->getMock('Sonata\MediaBundle\Resizer\ResizerInterface');
+        $resizer = $this->createMock('Sonata\MediaBundle\Resizer\ResizerInterface');
         $resizer->expects($this->any())->method('resize')->will($this->returnValue(true));
         $resizer->expects($this->any())->method('getBox')->will($this->returnValue(new Box(100, 100)));
 
-        $adapter = $this->getMock('Gaufrette\Adapter');
+        $adapter = $this->createMock('Gaufrette\Adapter');
 
-        $filesystem = $this->getMock('Gaufrette\Filesystem', array('get'), array($adapter));
-        $file = $this->getMock('Gaufrette\File', array(), array('foo', $filesystem));
+        $filesystem = $this->getMockBuilder('Gaufrette\Filesystem')
+            ->setMethods(array('get'))
+            ->setConstructorArgs(array($adapter))
+            ->getMock();
+        $file = $this->getMockBuilder('Gaufrette\File')
+            ->setConstructorArgs(array('foo', $filesystem))
+            ->getMock();
         $filesystem->expects($this->any())->method('get')->will($this->returnValue($file));
 
         $cdn = new \Sonata\MediaBundle\CDN\Server('/uploads/media');
@@ -36,17 +41,17 @@ class ImageProviderTest extends AbstractProviderTest
 
         $thumbnail = new FormatThumbnail('jpg');
 
-        $size = $this->getMock('Imagine\Image\BoxInterface');
+        $size = $this->createMock('Imagine\Image\BoxInterface');
         $size->expects($this->any())->method('getWidth')->will($this->returnValue(100));
         $size->expects($this->any())->method('getHeight')->will($this->returnValue(100));
 
-        $image = $this->getMock('Imagine\Image\ImageInterface');
+        $image = $this->createMock('Imagine\Image\ImageInterface');
         $image->expects($this->any())->method('getSize')->will($this->returnValue($size));
 
-        $adapter = $this->getMock('Imagine\Image\ImagineInterface');
+        $adapter = $this->createMock('Imagine\Image\ImagineInterface');
         $adapter->expects($this->any())->method('open')->will($this->returnValue($image));
 
-        $metadata = $this->getMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
+        $metadata = $this->createMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
 
         $provider = new ImageProvider('file', $filesystem, $cdn, $generator, $thumbnail, $allowedExtensions, $allowedMimeTypes, $adapter, $metadata);
         $provider->setResizer($resizer);

--- a/Tests/Provider/PoolTest.php
+++ b/Tests/Provider/PoolTest.php
@@ -12,12 +12,13 @@
 namespace Sonata\MediaBundle\Tests\Provider;
 
 use Sonata\MediaBundle\Provider\FileProvider;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Sonata\MediaBundle\Thumbnail\FormatThumbnail;
 
 /**
  * @author Javier Spagnoletti <phansys@gmail.com>
  */
-class PoolTest extends \PHPUnit_Framework_TestCase
+class PoolTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @expectedException        \InvalidArgumentException
@@ -81,7 +82,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
         $cdn = new \Sonata\MediaBundle\CDN\Server('/uploads/media');
         $generator = new \Sonata\MediaBundle\Generator\DefaultGenerator();
         $thumbnail = new FormatThumbnail('jpg');
-        $metadata = $this->getMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
+        $metadata = $this->createMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
 
         return new FileProvider($name, $filesystem, $cdn, $generator, $thumbnail, array(), array(), $metadata);
     }

--- a/Tests/Provider/VimeoProviderTest.php
+++ b/Tests/Provider/VimeoProviderTest.php
@@ -26,14 +26,19 @@ class VimeoProviderTest extends AbstractProviderTest
             $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
         }
 
-        $resizer = $this->getMock('Sonata\MediaBundle\Resizer\ResizerInterface');
+        $resizer = $this->createMock('Sonata\MediaBundle\Resizer\ResizerInterface');
         $resizer->expects($this->any())->method('resize')->will($this->returnValue(true));
         $resizer->expects($this->any())->method('getBox')->will($this->returnValue(new Box(100, 100)));
 
-        $adapter = $this->getMock('Gaufrette\Adapter');
+        $adapter = $this->createMock('Gaufrette\Adapter');
 
-        $filesystem = $this->getMock('Gaufrette\Filesystem', array('get'), array($adapter));
-        $file = $this->getMock('Gaufrette\File', array(), array('foo', $filesystem));
+        $filesystem = $this->getMockBuilder('Gaufrette\Filesystem')
+            ->setMethods(array('get'))
+            ->setConstructorArgs(array($adapter))
+            ->getMock();
+        $file = $this->getMockBuilder('Gaufrette\File')
+            ->setConstructorArgs(array('foo', $filesystem))
+            ->getMock();
         $filesystem->expects($this->any())->method('get')->will($this->returnValue($file));
 
         $cdn = new \Sonata\MediaBundle\CDN\Server('/uploads/media');
@@ -42,7 +47,7 @@ class VimeoProviderTest extends AbstractProviderTest
 
         $thumbnail = new FormatThumbnail('jpg');
 
-        $metadata = $this->getMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
+        $metadata = $this->createMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
 
         $provider = new VimeoProvider('file', $filesystem, $cdn, $generator, $thumbnail, $browser, $metadata);
         $provider->setResizer($resizer);
@@ -70,7 +75,7 @@ class VimeoProviderTest extends AbstractProviderTest
 
     public function testThumbnail()
     {
-        $response = $this->getMock('Buzz\Message\AbstractMessage');
+        $response = $this->createMock('Buzz\Message\AbstractMessage');
         $response->expects($this->once())->method('getContent')->will($this->returnValue('content'));
 
         $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
@@ -170,12 +175,15 @@ class VimeoProviderTest extends AbstractProviderTest
 
         $provider = $this->getProvider();
 
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->any())
             ->method('trans')
             ->will($this->returnValue('message'));
 
-        $formMapper = $this->getMock('Sonata\AdminBundle\Form\FormMapper', array('add', 'getAdmin'), array(), '', false);
+        $formMapper = $this->getMockBuilder('Sonata\AdminBundle\Form\FormMapper')
+            ->setMethods(array('add', 'getAdmin'))
+            ->disableOriginalConstructor()
+            ->getMock();
         $formMapper->expects($this->exactly(8))
             ->method('add')
             ->will($this->returnValue(null));

--- a/Tests/Provider/YouTubeProviderTest.php
+++ b/Tests/Provider/YouTubeProviderTest.php
@@ -26,14 +26,19 @@ class YouTubeProviderTest extends AbstractProviderTest
             $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
         }
 
-        $resizer = $this->getMock('Sonata\MediaBundle\Resizer\ResizerInterface');
+        $resizer = $this->createMock('Sonata\MediaBundle\Resizer\ResizerInterface');
         $resizer->expects($this->any())->method('resize')->will($this->returnValue(true));
         $resizer->expects($this->any())->method('getBox')->will($this->returnValue(new Box(100, 100)));
 
-        $adapter = $this->getMock('Gaufrette\Adapter');
+        $adapter = $this->createMock('Gaufrette\Adapter');
 
-        $filesystem = $this->getMock('Gaufrette\Filesystem', array('get'), array($adapter));
-        $file = $this->getMock('Gaufrette\File', array(), array('foo', $filesystem));
+        $filesystem = $this->getMockBuilder('Gaufrette\Filesystem')
+            ->setMethods(array('get'))
+            ->setConstructorArgs(array($adapter))
+            ->getMock();
+        $file = $this->getMockBuilder('Gaufrette\File')
+            ->setConstructorArgs(array('foo', $filesystem))
+            ->getMock();
         $filesystem->expects($this->any())->method('get')->will($this->returnValue($file));
 
         $cdn = new \Sonata\MediaBundle\CDN\Server('/uploads/media');
@@ -42,7 +47,7 @@ class YouTubeProviderTest extends AbstractProviderTest
 
         $thumbnail = new FormatThumbnail('jpg');
 
-        $metadata = $this->getMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
+        $metadata = $this->createMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
 
         $provider = new YouTubeProvider('file', $filesystem, $cdn, $generator, $thumbnail, $browser, $metadata);
         $provider->setResizer($resizer);
@@ -71,7 +76,7 @@ class YouTubeProviderTest extends AbstractProviderTest
 
     public function testThumbnail()
     {
-        $response = $this->getMock('Buzz\Message\AbstractMessage');
+        $response = $this->createMock('Buzz\Message\AbstractMessage');
         $response->expects($this->once())->method('getContent')->will($this->returnValue('content'));
 
         $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
@@ -173,12 +178,15 @@ class YouTubeProviderTest extends AbstractProviderTest
 
         $provider = $this->getProvider();
 
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->any())
             ->method('trans')
             ->will($this->returnValue('message'));
 
-        $formMapper = $this->getMock('Sonata\AdminBundle\Form\FormMapper', array('add', 'getAdmin'), array(), '', false);
+        $formMapper = $this->getMockBuilder('Sonata\AdminBundle\Form\FormMapper')
+            ->setMethods(array('add', 'getAdmin'))
+            ->disableOriginalConstructor()
+            ->getMock();
         $formMapper->expects($this->exactly(8))
             ->method('add')
             ->will($this->returnValue(null));

--- a/Tests/Resizer/SimpleResizerTest.php
+++ b/Tests/Resizer/SimpleResizerTest.php
@@ -16,17 +16,18 @@ use Gaufrette\File;
 use Gaufrette\Filesystem;
 use Imagine\Image\Box;
 use Sonata\MediaBundle\Resizer\SimpleResizer;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class SimpleResizerTest extends \PHPUnit_Framework_TestCase
+class SimpleResizerTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @expectedException \RuntimeException
      */
     public function testResizeWithNoWidth()
     {
-        $adapter = $this->getMock('Imagine\Image\ImagineInterface');
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
-        $metadata = $this->getMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
+        $adapter = $this->createMock('Imagine\Image\ImagineInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $metadata = $this->createMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
         $file = $this->getMockBuilder('Gaufrette\File')->disableOriginalConstructor()->getMock();
 
         $resizer = new SimpleResizer($adapter, 'foo', $metadata);
@@ -35,14 +36,14 @@ class SimpleResizerTest extends \PHPUnit_Framework_TestCase
 
     public function testResize()
     {
-        $image = $this->getMock('Imagine\Image\ImageInterface');
+        $image = $this->createMock('Imagine\Image\ImageInterface');
         $image->expects($this->once())->method('thumbnail')->will($this->returnValue($image));
         $image->expects($this->once())->method('get')->will($this->returnValue(file_get_contents(__DIR__.'/../fixtures/logo.png')));
 
-        $adapter = $this->getMock('Imagine\Image\ImagineInterface');
+        $adapter = $this->createMock('Imagine\Image\ImagineInterface');
         $adapter->expects($this->any())->method('load')->will($this->returnValue($image));
 
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $media->expects($this->exactly(2))->method('getBox')->will($this->returnValue(new Box(535, 132)));
 
         $filesystem = new Filesystem(new InMemory());
@@ -51,7 +52,7 @@ class SimpleResizerTest extends \PHPUnit_Framework_TestCase
 
         $out = $filesystem->get('out', true);
 
-        $metadata = $this->getMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
+        $metadata = $this->createMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
         $metadata->expects($this->once())->method('get')->will($this->returnValue(array()));
 
         $resizer = new SimpleResizer($adapter, 'outbound', $metadata);
@@ -63,12 +64,12 @@ class SimpleResizerTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetBox($mode, $settings, Box $mediaSize, Box $result)
     {
-        $adapter = $this->getMock('Imagine\Image\ImagineInterface');
+        $adapter = $this->createMock('Imagine\Image\ImagineInterface');
 
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $media->expects($this->exactly(2))->method('getBox')->will($this->returnValue($mediaSize));
 
-        $metadata = $this->getMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
+        $metadata = $this->createMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
 
         $resizer = new SimpleResizer($adapter, $mode, $metadata);
 

--- a/Tests/Resizer/SquareResizerTest.php
+++ b/Tests/Resizer/SquareResizerTest.php
@@ -16,18 +16,19 @@ use Gaufrette\File;
 use Gaufrette\Filesystem;
 use Imagine\Image\Box;
 use Sonata\MediaBundle\Resizer\SquareResizer;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class SquareResizerTest extends \PHPUnit_Framework_TestCase
+class SquareResizerTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @expectedException \RuntimeException
      */
     public function testResizeWithNoWidth()
     {
-        $adapter = $this->getMock('Imagine\Image\ImagineInterface');
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $adapter = $this->createMock('Imagine\Image\ImagineInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $file = $this->getMockBuilder('Gaufrette\File')->disableOriginalConstructor()->getMock();
-        $metadata = $this->getMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
+        $metadata = $this->createMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
 
         $resizer = new SquareResizer($adapter, 'foo', $metadata);
         $resizer->resize($media, $file, $file, 'bar', array());
@@ -36,14 +37,14 @@ class SquareResizerTest extends \PHPUnit_Framework_TestCase
 //    public function testResize()
 //    {
 //
-//        $image = $this->getMock('Imagine\Image\ImageInterface');
+//        $image = $this->createMock('Imagine\Image\ImageInterface');
 //        $image->expects($this->once())->method('thumbnail')->will($this->returnValue($image));
 //        $image->expects($this->once())->method('get')->will($this->returnValue(file_get_contents(__DIR__.'/../fixtures/logo.png')));
 //
-//        $adapter = $this->getMock('Imagine\Image\ImagineInterface');
+//        $adapter = $this->createMock('Imagine\Image\ImagineInterface');
 //        $adapter->expects($this->any())->method('load')->will($this->returnValue($image));
 //
-//        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+//        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
 //        $media->expects($this->once())->method('getBox')->will($this->returnValue(new Box(535, 132)));
 //
 //        $filesystem = new Filesystem(new InMemory);
@@ -61,12 +62,12 @@ class SquareResizerTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetBox($settings, Box $mediaSize, Box $expected)
     {
-        $adapter = $this->getMock('Imagine\Image\ImagineInterface');
+        $adapter = $this->createMock('Imagine\Image\ImagineInterface');
 
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $media->expects($this->once())->method('getBox')->will($this->returnValue($mediaSize));
 
-        $metadata = $this->getMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
+        $metadata = $this->createMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
 
         $resizer = new SquareResizer($adapter, 'foo', $metadata);
 

--- a/Tests/Security/ForbiddenDownloadStrategyTest.php
+++ b/Tests/Security/ForbiddenDownloadStrategyTest.php
@@ -12,14 +12,15 @@
 namespace Sonata\MediaBundle\Tests\Security;
 
 use Sonata\MediaBundle\Security\ForbiddenDownloadStrategy;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class ForbiddenDownloadStrategyTest extends \PHPUnit_Framework_TestCase
+class ForbiddenDownloadStrategyTest extends PHPUnit_Framework_TestCase
 {
     public function testIsGranted()
     {
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
-        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
 
         $strategy = new ForbiddenDownloadStrategy($translator);
         $this->assertFalse($strategy->isGranted($media, $request));

--- a/Tests/Security/PublicDownloadStrategyTest.php
+++ b/Tests/Security/PublicDownloadStrategyTest.php
@@ -12,14 +12,15 @@
 namespace Sonata\MediaBundle\Tests\Security;
 
 use Sonata\MediaBundle\Security\PublicDownloadStrategy;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class PublicDownloadStrategyTest extends \PHPUnit_Framework_TestCase
+class PublicDownloadStrategyTest extends PHPUnit_Framework_TestCase
 {
     public function testIsGranted()
     {
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
-        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
 
         $strategy = new PublicDownloadStrategy($translator);
         $this->assertTrue($strategy->isGranted($media, $request));

--- a/Tests/Security/RolesDownloadStrategyTest.php
+++ b/Tests/Security/RolesDownloadStrategyTest.php
@@ -12,20 +12,21 @@
 namespace Sonata\MediaBundle\Tests\Security;
 
 use Sonata\MediaBundle\Security\RolesDownloadStrategy;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class RolesDownloadStrategyTest extends \PHPUnit_Framework_TestCase
+class RolesDownloadStrategyTest extends PHPUnit_Framework_TestCase
 {
     public function testIsGrantedTrue()
     {
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
-        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
 
         // Prefer the Symfony 2.6+ API if available
         if (interface_exists('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')) {
-            $security = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+            $security = $this->createMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
         } else {
-            $security = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+            $security = $this->createMock('Symfony\Component\Security\Core\SecurityContextInterface');
         }
 
         $security->expects($this->any())
@@ -40,15 +41,15 @@ class RolesDownloadStrategyTest extends \PHPUnit_Framework_TestCase
 
     public function testIsGrantedFalse()
     {
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
-        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
 
         // Prefer the Symfony 2.6+ API if available
         if (interface_exists('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')) {
-            $security = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+            $security = $this->createMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
         } else {
-            $security = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+            $security = $this->createMock('Symfony\Component\Security\Core\SecurityContextInterface');
         }
 
         $security->expects($this->any())

--- a/Tests/Security/SessionDownloadStrategyTest.php
+++ b/Tests/Security/SessionDownloadStrategyTest.php
@@ -12,18 +12,19 @@
 namespace Sonata\MediaBundle\Tests\Security;
 
 use Sonata\MediaBundle\Security\SessionDownloadStrategy;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 /**
  * @author Ahmet Akbana <ahmetakbana@gmail.com>
  */
-final class SessionDownloadStrategyTest extends \PHPUnit_Framework_TestCase
+final class SessionDownloadStrategyTest extends PHPUnit_Framework_TestCase
 {
     public function testIsGrantedFalseWithGreaterSessionTime()
     {
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
-        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
-        $session = $this->getMock('Symfony\Component\HttpFoundation\Session\Session');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
+        $session = $this->createMock('Symfony\Component\HttpFoundation\Session\Session');
 
         $session->expects($this->any())
             ->method('get')
@@ -35,10 +36,10 @@ final class SessionDownloadStrategyTest extends \PHPUnit_Framework_TestCase
 
     public function testIsGrantedTrue()
     {
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
-        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
-        $session = $this->getMock('Symfony\Component\HttpFoundation\Session\Session');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
+        $session = $this->createMock('Symfony\Component\HttpFoundation\Session\Session');
 
         $session->expects($this->any())
             ->method('get')
@@ -54,12 +55,12 @@ final class SessionDownloadStrategyTest extends \PHPUnit_Framework_TestCase
      */
     public function testIsGrantedTrueWithContainer()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
 
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
-        $request = $this->getMock('Symfony\Component\HttpFoundation\Request');
-        $session = $this->getMock('Symfony\Component\HttpFoundation\Session\Session');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
+        $session = $this->createMock('Symfony\Component\HttpFoundation\Session\Session');
 
         $session->expects($this->any())
             ->method('get')
@@ -79,7 +80,7 @@ final class SessionDownloadStrategyTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidArgumentException()
     {
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
 
         new SessionDownloadStrategy($translator, 'foo', 1);
     }

--- a/Tests/Thumbnail/ConsumerThumbnailTest.php
+++ b/Tests/Thumbnail/ConsumerThumbnailTest.php
@@ -11,18 +11,19 @@
 
 namespace Sonata\MediaBundle\Tests\Thumbnail;
 
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Sonata\MediaBundle\Thumbnail\ConsumerThumbnail;
 
-class ConsumerThumbnailTest extends \PHPUnit_Framework_TestCase
+class ConsumerThumbnailTest extends PHPUnit_Framework_TestCase
 {
     public function testGenerateDispatchesEvents()
     {
-        $thumbnail = $this->getMock('Sonata\MediaBundle\Thumbnail\ThumbnailInterface');
-        $backend = $this->getMock('Sonata\NotificationBundle\Backend\BackendInterface');
-        $provider = $this->getMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $thumbnail = $this->createMock('Sonata\MediaBundle\Thumbnail\ThumbnailInterface');
+        $backend = $this->createMock('Sonata\NotificationBundle\Backend\BackendInterface');
+        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
 
-        $dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $dispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $dispatcher->expects($this->at(0))
             ->method('addListener')
             ->with($this->equalTo('kernel.finish_request'), $this->anything());

--- a/Tests/Thumbnail/FormatThumbnailTest.php
+++ b/Tests/Thumbnail/FormatThumbnailTest.php
@@ -14,9 +14,10 @@ namespace Sonata\MediaBundle\Tests\Security;
 use Gaufrette\Adapter\InMemory;
 use Gaufrette\File;
 use Gaufrette\Filesystem;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Sonata\MediaBundle\Thumbnail\FormatThumbnail;
 
-class FormatThumbnailTest extends \PHPUnit_Framework_TestCase
+class FormatThumbnailTest extends PHPUnit_Framework_TestCase
 {
     public function testGenerate()
     {
@@ -31,10 +32,10 @@ class FormatThumbnailTest extends \PHPUnit_Framework_TestCase
            'anothercontext_large' => array('height' => 500, 'width' => 500, 'quality' => 100),
         );
 
-        $resizer = $this->getMock('Sonata\MediaBundle\Resizer\ResizerInterface');
+        $resizer = $this->createMock('Sonata\MediaBundle\Resizer\ResizerInterface');
         $resizer->expects($this->exactly(2))->method('resize')->will($this->returnValue(true));
 
-        $provider = $this->getMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
         $provider->expects($this->once())->method('requireThumbnails')->will($this->returnValue(true));
         $provider->expects($this->once())->method('getReferenceFile')->will($this->returnValue($referenceFile));
         $provider->expects($this->once())->method('getFormats')->will($this->returnValue($formats));
@@ -42,7 +43,7 @@ class FormatThumbnailTest extends \PHPUnit_Framework_TestCase
         $provider->expects($this->exactly(2))->method('generatePrivateUrl')->will($this->returnValue('/my/private/path'));
         $provider->expects($this->exactly(2))->method('getFilesystem')->will($this->returnValue($filesystem));
 
-        $media = $this->getMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $media->expects($this->exactly(6))->method('getContext')->will($this->returnValue('mycontext'));
         $media->expects($this->exactly(2))->method('getExtension')->will($this->returnValue('png'));
 

--- a/Tests/Twig/Extension/MediaExtensionTest.php
+++ b/Tests/Twig/Extension/MediaExtensionTest.php
@@ -10,12 +10,13 @@
  */
 
 use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Sonata\MediaBundle\Twig\Extension\MediaExtension;
 
 /**
  * @author Geza Buza <bghome@gmail.com>
  */
-class MediaExtensionTest extends \PHPUnit_Framework_TestCase
+class MediaExtensionTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var Sonata\MediaBundle\Provider\MediaProviderInterface
@@ -84,13 +85,13 @@ class MediaExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function getMediaManager()
     {
-        return $this->getMock('Sonata\CoreBundle\Model\ManagerInterface');
+        return $this->createMock('Sonata\CoreBundle\Model\ManagerInterface');
     }
 
     public function getProvider()
     {
         if (is_null($this->provider)) {
-            $this->provider = $this->getMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+            $this->provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
             $this->provider->method('getFormatName')->will($this->returnArgument(1));
         }
 
@@ -100,7 +101,7 @@ class MediaExtensionTest extends \PHPUnit_Framework_TestCase
     public function getTemplate()
     {
         if (is_null($this->template)) {
-            $this->template = $this->getMock('Twig_TemplateInterface');
+            $this->template = $this->createMock('Twig_TemplateInterface');
         }
 
         return $this->template;
@@ -121,7 +122,7 @@ class MediaExtensionTest extends \PHPUnit_Framework_TestCase
     public function getMedia()
     {
         if (is_null($this->media)) {
-            $this->media = $this->getMock('Sonata\MediaBundle\Model\Media');
+            $this->media = $this->createMock('Sonata\MediaBundle\Model\Media');
             $this->media->method('getProviderStatus')->willReturn(MediaInterface::STATUS_OK);
         }
 

--- a/Tests/Validator/FormatValidatorTest.php
+++ b/Tests/Validator/FormatValidatorTest.php
@@ -12,17 +12,18 @@
 namespace Sonata\MediaBundle\Tests\Validator;
 
 use Sonata\MediaBundle\Provider\Pool;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Sonata\MediaBundle\Validator\Constraints\ValidMediaFormat;
 use Sonata\MediaBundle\Validator\FormatValidator;
 
-class FormatValidatorTest extends \PHPUnit_Framework_TestCase
+class FormatValidatorTest extends PHPUnit_Framework_TestCase
 {
     public function testValidate()
     {
         $pool = new Pool('defaultContext');
         $pool->addContext('test', array(), array('format1' => array()));
 
-        $gallery = $this->getMock('Sonata\MediaBundle\Model\GalleryInterface');
+        $gallery = $this->createMock('Sonata\MediaBundle\Model\GalleryInterface');
         $gallery->expects($this->once())->method('getDefaultFormat')->will($this->returnValue('format1'));
         $gallery->expects($this->once())->method('getContext')->will($this->returnValue('test'));
 
@@ -33,7 +34,9 @@ class FormatValidatorTest extends \PHPUnit_Framework_TestCase
             $contextClass = 'Symfony\Component\Validator\ExecutionContext';
         }
 
-        $context = $this->getMock($contextClass, array(), array(), '', false);
+        $context = $this->getMockBuilder($contextClass)
+            ->disableOriginalConstructor()
+            ->getMock();
         $context->expects($this->never())->method('addViolation');
 
         $validator = new FormatValidator($pool);
@@ -47,7 +50,7 @@ class FormatValidatorTest extends \PHPUnit_Framework_TestCase
         $pool = new Pool('defaultContext');
         $pool->addContext('test');
 
-        $gallery = $this->getMock('Sonata\MediaBundle\Model\GalleryInterface');
+        $gallery = $this->createMock('Sonata\MediaBundle\Model\GalleryInterface');
         $gallery->expects($this->once())->method('getDefaultFormat')->will($this->returnValue('format1'));
         $gallery->expects($this->once())->method('getContext')->will($this->returnValue('test'));
 
@@ -58,7 +61,9 @@ class FormatValidatorTest extends \PHPUnit_Framework_TestCase
             $contextClass = 'Symfony\Component\Validator\ExecutionContext';
         }
 
-        $context = $this->getMock($contextClass, array(), array(), '', false);
+        $context = $this->getMockBuilder($contextClass)
+            ->disableOriginalConstructor()
+            ->getMock();
         $context->expects($this->once())->method('addViolation');
 
         $validator = new FormatValidator($pool);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this only affects tests.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- getMock calls from tests
```

## Subject

<!-- Describe your Pull Request content here -->
getMock is deprecated, replaced with createMock or getMockBuilder with a fallback for older PHPUnit versions.