### PR TITLE
Fixed category filter on Media List and Test MediaAdminController

### DIFF
--- a/Resources/views/MediaAdmin/list.html.twig
+++ b/Resources/views/MediaAdmin/list.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% extends 'SonataAdminBundle:CRUD:base_list.html.twig' %}
 
 {% import _self as tree %}
-{% macro navigate_child(collection, admin, root, current_category, depth) %}
+{% macro navigate_child(collection, admin, root, current_category_id, depth) %}
     {% if root and collection|length == 0 %}
         <div>
             <p class="bg-warning">{{ 'warning_no_category'|trans({}, admin.translationdomain) }}</p>
@@ -21,13 +21,13 @@ file that was distributed with this source code.
     <ul{% if root %} class="sonata-tree sonata-tree--small js-treeview sonata-tree--toggleable"{% endif %}>
         {% for element in collection %}
             <li>
-                <div class="sonata-tree__item{% if element.id == current_category.id %} is-active{% endif %}"{% if depth < 2 %} data-treeview-toggled{% endif %}>
+                <div class="sonata-tree__item{% if element.id == current_category_id %} is-active{% endif %}"{% if depth < 2 %} data-treeview-toggled{% endif %}>
                     {% if element.parent or root %}<i class="fa fa-caret-right" data-treeview-toggler></i>{% endif %}
                     <a class="sonata-tree__item__edit" href="{{ url(app.request.attributes.get('_route'), app.request.query.all|merge({category: element.id})) }}">{{ element.name }}</a>
                 </div>
 
                 {% if element.children|length %}
-                    {{ _self.navigate_child(element.children, admin, false, current_category, depth + 1) }}
+                    {{ _self.navigate_child(element.children, admin, false, current_category_id, depth + 1) }}
                 {% endif %}
             </li>
         {% endfor %}

--- a/Tests/Controller/MediaAdminControllerTest.php
+++ b/Tests/Controller/MediaAdminControllerTest.php
@@ -1,0 +1,212 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\Controller;
+
+use Prophecy\Argument;
+use Sonata\MediaBundle\Controller\MediaAdminController;
+
+class EntityWithGetId
+{
+    public function getId()
+    {
+    }
+}
+
+class MediaAdminControllerTest extends \PHPUnit_Framework_TestCase
+{
+    protected $controller;
+
+    protected function setUp()
+    {
+        $this->container = $this->prophesize('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->admin = $this->prophesize('Sonata\MediaBundle\Admin\BaseMediaAdmin');
+        $this->request = $this->prophesize('Symfony\Component\HttpFoundation\Request');
+
+        $this->configureCRUDController();
+
+        $this->controller = new MediaAdminController();
+        $this->controller->setContainer($this->container->reveal());
+    }
+
+    public function testCreateActionToSelectProvider()
+    {
+        $pool = $this->prophesize('Sonata\MediaBundle\Provider\Pool');
+
+        $this->configureRender(
+            'SonataMediaBundle:MediaAdmin:select_provider.html.twig',
+            Argument::type('array'),
+            'renderResponse'
+        );
+        $pool->getProvidersByContext('context')->willReturn(array('provider'));
+        $pool->getDefaultContext()->willReturn('default_context');
+        $this->admin->checkAccess('create')->shouldBeCalled();
+        $this->container->get('sonata.media.pool')->willReturn($pool->reveal());
+        $this->request->get('provider')->willReturn(false);
+        $this->request->isMethod('get')->willReturn(true);
+        $this->request->get('context', 'default_context')->willReturn('context');
+
+        $response = $this->controller->createAction($this->request->reveal());
+
+        $this->assertSame('renderResponse', $response);
+    }
+
+    public function testCreateAction()
+    {
+        $this->configureCreateAction('Sonata\MediaBundle\Tests\Entity\Media');
+        $this->configureRender('template', Argument::type('array'), 'renderResponse');
+        $this->admin->checkAccess('create')->shouldBeCalled();
+        $this->request->get('provider')->willReturn(true);
+        $this->request->isMethod('get')->willReturn(true);
+
+        $response = $this->controller->createAction($this->request->reveal());
+
+        $this->assertSame('renderResponse', $response);
+    }
+
+    public function testListAction()
+    {
+        $datagrid = $this->prophesize('Sonata\AdminBundle\Datagrid\DatagridInterface');
+        $pool = $this->prophesize('Sonata\MediaBundle\Provider\Pool');
+        $categoryManager = $this->prophesize('Sonata\ClassificationBundle\Entity\CategoryManager');
+        $category = $this->prophesize();
+        $category->willExtend('Sonata\MediaBundle\Tests\Controller\EntityWithGetId');
+        $category->willImplement('Sonata\ClassificationBundle\Model\CategoryInterface');
+        $form = $this->prophesize('Symfony\Component\Form\Form');
+        $formView = $this->prophesize('Symfony\Component\Form\FormView');
+
+        $this->configureSetFormTheme($formView->reveal(), 'filterTheme');
+        $this->configureSetCsrfToken('sonata.batch');
+        $this->configureRender('templateList', Argument::type('array'), 'renderResponse');
+        $datagrid->setValue('context', null, 'another_context')->shouldBeCalled();
+        $datagrid->setValue('category', null, 1)->shouldBeCalled();
+        $datagrid->getForm()->willReturn($form->reveal());
+        $pool->getDefaultContext()->willReturn('context');
+        $categoryManager->getRootCategory('another_context')->willReturn($category->reveal());
+        $categoryManager->findOneBy(array(
+            'id' => 2,
+            'context' => 'another_context',
+        ))->willReturn($category->reveal());
+        $category->getId()->willReturn(1);
+        $form->createView()->willReturn($formView->reveal());
+        $this->container->get('sonata.media.pool')->willReturn($pool->reveal());
+        $this->container->get('sonata.classification.manager.category')->willReturn($categoryManager->reveal());
+        $this->admin->checkAccess('list')->shouldBeCalled();
+        $this->admin->setListMode('mosaic')->shouldBeCalled();
+        $this->admin->getDatagrid()->willReturn($datagrid->reveal());
+        $this->admin->getPersistentParameter('context', 'context')->willReturn('another_context');
+        $this->admin->getFilterTheme()->willReturn('filterTheme');
+        $this->admin->getTemplate('list')->willReturn('templateList');
+        $this->request->get('_list_mode', 'mosaic')->willReturn('mosaic');
+        $this->request->get('filter')->willReturn(array());
+        $this->request->get('category')->willReturn(2);
+
+        $response = $this->controller->listAction($this->request->reveal());
+
+        $this->assertSame('renderResponse', $response);
+    }
+
+    private function configureCRUDController()
+    {
+        $pool = $this->prophesize('Sonata\AdminBundle\Admin\Pool');
+        $breadcrumbsBuilder = $this->prophesize('Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface');
+
+        $this->configureGetCurrentRequest($this->request->reveal());
+        $pool->getAdminByAdminCode('admin_code')->willReturn($this->admin->reveal());
+        $this->request->isXmlHttpRequest()->willReturn(false);
+        $this->request->get('_xml_http_request')->willReturn(false);
+        $this->request->get('_sonata_admin')->willReturn('admin_code');
+        $this->request->get('uniqid')->shouldBeCalled();
+        $this->container->has('templating')->willReturn(true);
+        $this->container->get('sonata.admin.pool')->willReturn($pool->reveal());
+        $this->container->get('sonata.admin.breadcrumbs_builder')->willReturn($breadcrumbsBuilder->reveal());
+        $this->admin->getTemplate('layout')->willReturn('layout.html.twig');
+        $this->admin->isChild()->willReturn(false);
+        $this->admin->setRequest($this->request->reveal())->shouldBeCalled();
+    }
+
+    private function configureCreateAction($class)
+    {
+        $object = $this->prophesize('Sonata\MediaBundle\Tests\Entity\Media');
+        $form = $this->prophesize('Symfony\Component\Form\Form');
+        $formView = $this->prophesize('Symfony\Component\Form\FormView');
+
+        $this->configureSetFormTheme($formView->reveal(), 'formTheme');
+        $this->admin->hasActiveSubClass()->willReturn(false);
+        $this->admin->getClass()->willReturn($class);
+        $this->admin->getNewInstance()->willReturn($object->reveal());
+        $this->admin->setSubject($object->reveal())->shouldBeCalled();
+        $this->admin->getForm()->willReturn($form->reveal());
+        $this->admin->getFormTheme()->willReturn('formTheme');
+        $this->admin->getTemplate('edit')->willReturn('template');
+        $form->createView()->willReturn($formView->reveal());
+        $form->setData($object->reveal())->shouldBeCalled();
+        $form->handleRequest($this->request->reveal())->shouldBeCalled();
+        $form->isSubmitted()->willReturn(false);
+    }
+
+    private function configureGetCurrentRequest($request)
+    {
+        // NEXT_MAJOR: Remove this trick when bumping Symfony requirement to 2.8+.
+        if (class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
+            $requestStack = $this->prophesize('Symfony\Component\HttpFoundation\RequestStack');
+
+            $this->container->has('request_stack')->willReturn(true);
+            $this->container->get('request_stack')->willReturn($requestStack->reveal());
+            $requestStack->getCurrentRequest()->willReturn($request);
+        } else {
+            $this->container->has('request_stack')->willReturn(false);
+            $this->container->get('request')->willReturn($request);
+        }
+    }
+
+    private function configureSetFormTheme($formView, $formTheme)
+    {
+        $twig = $this->prophesize('\Twig_Environment');
+        $twigRenderer = $this->prophesize('Symfony\Bridge\Twig\Form\TwigRenderer');
+
+        $twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')->willReturn($twigRenderer->reveal());
+        $twigRenderer->setTheme($formView, $formTheme)->shouldBeCalled();
+        $this->container->get('twig')->willReturn($twig->reveal());
+    }
+
+    private function configureSetCsrfToken($intention)
+    {
+        if (interface_exists('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface')) {
+            $tokenManager = $this->prophesize('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface');
+            $token = $this->prophesize('Symfony\Component\Security\Csrf\CsrfToken');
+
+            $tokenManager->getToken($intention)->willReturn($token->reveal());
+            $token->getValue()->willReturn('token');
+            $this->container->has('security.csrf.token_manager')->willReturn(true);
+            $this->container->get('security.csrf.token_manager')->willReturn($tokenManager->reveal());
+        } else {
+            $csrfProvider = $this->prophesize('Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface');
+
+            $csrfProvider->generateCsrfToken($intention)->shouldBeCalled('token');
+            $this->container->has('security.csrf.token_manager')->willReturn(false);
+            $this->container->has('form.csrf_provider')->willReturn(true);
+            $this->container->get('form.csrf_provider')->willReturn($csrfProvider->reveal());
+        }
+    }
+
+    private function configureRender($template, $data, $rendered)
+    {
+        $templating = $this->prophesize('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
+        $pool = $this->prophesize('Sonata\MediaBundle\Provider\Pool');
+
+        $this->admin->getPersistentParameters()->willReturn(array('param' => 'param'));
+        $this->container->has('templating')->willReturn(true);
+        $this->container->get('templating')->willReturn($templating->reveal());
+        $this->container->get('sonata.media.pool')->willReturn($pool->reveal());
+        $templating->renderResponse($template, $data, null)->willReturn($rendered);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "jackalope/jackalope-doctrine-dbal": "^1.1",
         "nelmio/api-doc-bundle": "^2.11",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
-        "sonata-project/admin-bundle": "^3.1",
+        "sonata-project/admin-bundle": "^3.11",
         "sonata-project/block-bundle": "^3.2",
         "sonata-project/datagrid-bundle": "^2.2.1",
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1156 #1130 #1054 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added test on `MediaAdminController`
### Fixed
- Media List is now filterable by Category again
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests

## Subject

<!-- Describe your Pull Request content here -->
Same fix as other PR's but with tests.

Not sure about all the mocks I have created. But it will be needed in order to fully test MediaAdminController.

I have done a little bit of refactor on MediaAdminController based on content in CRUDController (changed isGranted by checkAccess, removing some parameters,...)