### PR TITLE
Fix providerName access from request object

### DIFF
--- a/Admin/BaseMediaAdmin.php
+++ b/Admin/BaseMediaAdmin.php
@@ -114,8 +114,9 @@ abstract class BaseMediaAdmin extends AbstractAdmin
                         $this->getRequest()->get(sprintf('%s[providerName]', $uniqid), null, true)
                     );
                 } else {
+                    $provider = $this->getRequest()->get($uniqid);
                     $media->setProviderName(
-                        $this->getRequest()->get($uniqid)['providerName']
+                        $provider['providerName']
                     );
                 }
             } else {

--- a/Admin/BaseMediaAdmin.php
+++ b/Admin/BaseMediaAdmin.php
@@ -115,7 +115,7 @@ abstract class BaseMediaAdmin extends AbstractAdmin
                     );
                 } else {
                     $media->setProviderName(
-                        $this->getRequest()->get($uniqid['providerName'])
+                        $this->getRequest()->get($uniqid)['providerName']
                     );
                 }
             } else {

--- a/Admin/BaseMediaAdmin.php
+++ b/Admin/BaseMediaAdmin.php
@@ -114,10 +114,8 @@ abstract class BaseMediaAdmin extends AbstractAdmin
                         $this->getRequest()->get(sprintf('%s[providerName]', $uniqid), null, true)
                     );
                 } else {
-                    $provider = $this->getRequest()->get($uniqid);
-                    $media->setProviderName(
-                        $provider['providerName']
-                    );
+                    $providerParams = $this->getRequest()->get($uniqid);
+                    $media->setProviderName($providerParams['providerName']);
                 }
             } else {
                 $media->setProviderName($this->getRequest()->get('provider'));

--- a/Tests/Admin/BaseMediaAdminTest.php
+++ b/Tests/Admin/BaseMediaAdminTest.php
@@ -17,16 +17,27 @@ class TestMediaAdmin extends BaseMediaAdmin
 {
 }
 
+class EntityWithGetId
+{
+    public function getId()
+    {
+    }
+}
+
 class BaseMediaAdminTest extends \PHPUnit_Framework_TestCase
 {
     private $pool;
     private $categoryManager;
+    private $request;
+    private $modelManager;
     private $mediaAdmin;
 
     protected function setUp()
     {
         $this->pool = $this->prophesize('Sonata\MediaBundle\Provider\Pool');
         $this->categoryManager = $this->prophesize('Sonata\ClassificationBundle\Entity\CategoryManager');
+        $this->request = $this->prophesize('Symfony\Component\HttpFoundation\Request');
+        $this->modelManager = $this->prophesize('Sonata\AdminBundle\Model\ModelManagerInterface');
 
         $this->mediaAdmin = new TestMediaAdmin(
             null,
@@ -35,10 +46,55 @@ class BaseMediaAdminTest extends \PHPUnit_Framework_TestCase
             $this->pool->reveal(),
             $this->categoryManager->reveal()
         );
+        $this->mediaAdmin->setRequest($this->request->reveal());
+        $this->mediaAdmin->setModelManager($this->modelManager->reveal());
+        $this->mediaAdmin->setUniqid('uniqid');
     }
 
-    public function testItIsInstantiable()
+    public function testGetNewInstance()
     {
-        $this->assertNotNull($this->mediaAdmin);
+        $media = $this->prophesize('Sonata\MediaBundle\Model\Media');
+        $category = $this->prophesize();
+        $category->willExtend('Sonata\MediaBundle\Tests\Admin\EntityWithGetId');
+        $category->willImplement('Sonata\ClassificationBundle\Model\CategoryInterface');
+        $context = $this->prophesize();
+        $context->willExtend('Sonata\MediaBundle\Tests\Admin\EntityWithGetId');
+        $context->willImplement('Sonata\ClassificationBundle\Model\ContextInterface');
+
+        $this->configureGetPersistentParameters();
+        $this->configureGetProviderName($media);
+        $this->modelManager->getModelInstance('Sonata\MediaBundle\Entity\BaseMedia')->willReturn($media->reveal());
+        $this->categoryManager->find(1)->willReturn($category->reveal());
+        $this->request->isMethod('POST')->willReturn(true);
+        $category->getContext()->willReturn($context->reveal());
+        $media->setContext('context')->shouldBeCalled();
+
+        $this->assertSame($media->reveal(), $this->mediaAdmin->getNewInstance());
+    }
+
+    private function configureGetPersistentParameters()
+    {
+        $category = $this->prophesize();
+        $category->willExtend('Sonata\MediaBundle\Tests\Admin\EntityWithGetId');
+        $category->willImplement('Sonata\ClassificationBundle\Model\CategoryInterface');
+
+        $this->categoryManager->getRootCategory('context')->willReturn($category->reveal());
+        $this->request->get('filter')->willReturn(array());
+        $this->request->get('provider')->willReturn('provider');
+        $this->request->get('category')->willReturn(1);
+        $this->request->get('hide_context')->willReturn(true);
+        $this->request->get('context', null)->willReturn('context');
+        $category->getId()->willReturn(1);
+    }
+
+    private function configureGetProviderName($media)
+    {
+        // NEXT_MAJOR remove this block when dropping sf < 2.8 compatibility
+        if (method_exists('Symfony\Component\HttpFoundation\JsonResponse', 'transformJsonError')) {
+            $this->request->get('uniqid[providerName]')->willReturn('providerName');
+        } else {
+            $this->request->get('uniqid')->willReturn(array('providerName' => 'providerName'));
+        }
+        $media->setProviderName('providerName')->shouldBeCalled();
     }
 }


### PR DESCRIPTION
BaseMediaAdmin incorrectly retrieved providerName from request

I am targeting this branch, because the bug was recently introduced in it in this PR #1191

Closes #1197

## Changelog

```markdown
### Fixed
- Incorrect access to providerName parameter in request in `Admin/BaseMediaAdmin.php`
```

## Subject

This fixes a recently introduced bug where the providerName was incorrectly being read from the request object.
