### PR TITLE
Fixed namespace on test classes

### DIFF
--- a/Tests/Block/FeatureMediaBlockServiceTest.php
+++ b/Tests/Block/FeatureMediaBlockServiceTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sonata\MediaBundle\Tests\Block\Service;
+namespace Sonata\MediaBundle\Tests\Block;
 
 use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
 use Sonata\MediaBundle\Block\FeatureMediaBlockService;

--- a/Tests/Block/GalleryBlockServiceTest.php
+++ b/Tests/Block/GalleryBlockServiceTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sonata\MediaBundle\Tests\Block\Service;
+namespace Sonata\MediaBundle\Tests\Block;
 
 use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
 use Sonata\MediaBundle\Block\GalleryBlockService;

--- a/Tests/Block/GalleryListBlockServiceTest.php
+++ b/Tests/Block/GalleryListBlockServiceTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sonata\MediaBundle\Tests\Block\Service;
+namespace Sonata\MediaBundle\Tests\Block;
 
 use Sonata\BlockBundle\Block\BlockContext;
 use Sonata\BlockBundle\Model\Block;

--- a/Tests/Block/MediaBlockServiceTest.php
+++ b/Tests/Block/MediaBlockServiceTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sonata\MediaBundle\Tests\Block\Service;
+namespace Sonata\MediaBundle\Tests\Block;
 
 use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
 use Sonata\MediaBundle\Block\MediaBlockService;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this only changes test.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

<!-- Describe your Pull Request content here -->
This is pedantic. I found that Block Test were on a incorrect namespace. This PR just fixes that