### PR TITLE
Fixed wrong FQCN's and added missing end() on GalleryAdmin

### DIFF
--- a/Admin/GalleryAdmin.php
+++ b/Admin/GalleryAdmin.php
@@ -137,6 +137,7 @@ class GalleryAdmin extends AbstractAdmin
                 ->ifTrue($formats)
                     ->add('defaultFormat', $choiceType, array('choices' => $formats))
                 ->ifEnd()
+            ->end()
             ->with('Gallery')
                 ->add('galleryHasMedias', $collectionType, array(), array(
                     'edit' => 'inline',

--- a/Admin/GalleryAdmin.php
+++ b/Admin/GalleryAdmin.php
@@ -118,20 +118,17 @@ class GalleryAdmin extends AbstractAdmin
 
         // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
         $choiceType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\AdminBundle\Form\Type\ChoiceType'
+            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
             : 'choice';
 
         // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
         $collectionType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\AdminBundle\Form\Type\CollectionType'
+            ? 'Sonata\CoreBundle\Form\Type\CollectionType'
             : 'sonata_type_collection';
 
         $formMapper
             ->with('Options')
-                ->add('context', $choiceType, array(
-                    'choices' => $contexts,
-                    'translation_domain' => 'SonataMediaBundle',
-                ))
+                ->add('context', $choiceType, array('choices' => $contexts))
                 ->add('enabled', null, array('required' => false))
                 ->add('name')
                 ->ifTrue($formats)

--- a/Block/MediaBlockService.php
+++ b/Block/MediaBlockService.php
@@ -233,7 +233,12 @@ class MediaBlockService extends AbstractBlockService
             'type' => ClassMetadataInfo::MANY_TO_ONE,
         ));
 
-        return $formMapper->create('mediaId', 'sonata_type_model_list', array(
+        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
+        $modelListType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Sonata\AdminBundle\Form\Type\ModelListType'
+            : 'sonata_type_model_list';
+
+        return $formMapper->create('mediaId', $modelListType, array(
             'sonata_field_description' => $fieldDescription,
             'class' => $this->getMediaAdmin()->getClass(),
             'model_manager' => $this->getMediaAdmin()->getModelManager(),


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

<!-- Describe your Pull Request content here -->
There was one missing change for the FQCN's on MediaBlockService.

I did a mistake on the GalleryAdmin: 'choice' is a Symfony type, not Sonata, and 'sonata_type_collection' is on CoreBundle. There is one CollectionType on AdminBundle but does not produce same behavior as before using 'sonta_type_collection'.

And from the PR: https://github.com/sonata-project/SonataMediaBundle/pull/1150, we removed a necessary end() call.