### PR TITLE
Calling a macro without being imported is an error on twig 2.0

### DIFF
--- a/Resources/views/MediaAdmin/list.html.twig
+++ b/Resources/views/MediaAdmin/list.html.twig
@@ -12,7 +12,10 @@ file that was distributed with this source code.
 {% extends 'SonataAdminBundle:CRUD:base_list.html.twig' %}
 
 {% import _self as tree %}
+
 {% macro navigate_child(collection, admin, root, current_category_id, depth) %}
+    {% import _self as tree %}
+
     {% if root and collection|length == 0 %}
         <div>
             <p class="bg-warning">{{ 'warning_no_category'|trans({}, admin.translationdomain) }}</p>
@@ -27,7 +30,7 @@ file that was distributed with this source code.
                 </div>
 
                 {% if element.children|length %}
-                    {{ _self.navigate_child(element.children, admin, false, current_category_id, depth + 1) }}
+                    {{ tree.navigate_child(element.children, admin, false, current_category_id, depth + 1) }}
                 {% endif %}
             </li>
         {% endfor %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because is a bug fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Calling a macro without importing it is an error on twig 2.0
```

## Subject

<!-- Describe your Pull Request content here -->
On Twig 2.0 is mandatory to import every macro you are going to use. When calling a macro inside another macro you also need to import it.