### PR TITLE
Remove old Symfony 2.3 code

### DIFF
--- a/Admin/BaseMediaAdmin.php
+++ b/Admin/BaseMediaAdmin.php
@@ -107,16 +107,8 @@ abstract class BaseMediaAdmin extends AbstractAdmin
         if ($this->hasRequest()) {
             if ($this->getRequest()->isMethod('POST')) {
                 $uniqid = $this->getUniqid();
-
-                if (method_exists('Symfony\Component\HttpFoundation\JsonResponse', 'transformJsonError')) {
-                    // NEXT_MAJOR remove this block when dropping sf < 2.8 compatibility
-                    $media->setProviderName(
-                        $this->getRequest()->get(sprintf('%s[providerName]', $uniqid), null, true)
-                    );
-                } else {
-                    $providerParams = $this->getRequest()->get($uniqid);
-                    $media->setProviderName($providerParams['providerName']);
-                }
+                $providerParams = $this->getRequest()->get($uniqid);
+                $media->setProviderName($providerParams['providerName']);
             } else {
                 $media->setProviderName($this->getRequest()->get('provider'));
             }
@@ -183,12 +175,7 @@ abstract class BaseMediaAdmin extends AbstractAdmin
             return;
         }
 
-        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
-        $hiddenType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
-            : 'hidden';
-
-        $formMapper->add('providerName', $hiddenType);
+        $formMapper->add('providerName', 'Symfony\Component\Form\Extension\Core\Type\HiddenType');
 
         $formMapper->getFormBuilder()->addModelTransformer(new ProviderDataTransformer($this->pool, $this->getClass()), true);
 
@@ -201,12 +188,7 @@ abstract class BaseMediaAdmin extends AbstractAdmin
         }
 
         if (null !== $this->categoryManager) {
-            // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
-            $modelListType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Sonata\AdminBundle\Form\Type\ModelListType'
-                : 'sonata_type_model_list';
-
-            $formMapper->add('category', $modelListType, array(), array(
+            $formMapper->add('category', 'Sonata\AdminBundle\Form\Type\ModelListType', array(), array(
                 'link_parameters' => array(
                     'context' => $media->getContext(),
                     'hide_context' => true,

--- a/Admin/GalleryAdmin.php
+++ b/Admin/GalleryAdmin.php
@@ -116,27 +116,21 @@ class GalleryAdmin extends AbstractAdmin
             $contexts[$contextItem] = $contextItem;
         }
 
-        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
-        $choiceType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-            : 'choice';
-
-        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
-        $collectionType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\CoreBundle\Form\Type\CollectionType'
-            : 'sonata_type_collection';
-
         $formMapper
             ->with('Options')
-                ->add('context', $choiceType, array('choices' => $contexts))
+                ->add('context', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
+                    'choices' => $contexts,
+                ))
                 ->add('enabled', null, array('required' => false))
                 ->add('name')
                 ->ifTrue($formats)
-                    ->add('defaultFormat', $choiceType, array('choices' => $formats))
+                    ->add('defaultFormat', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
+                        'choices' => $formats,
+                    ))
                 ->ifEnd()
             ->end()
             ->with('Gallery')
-                ->add('galleryItems', $collectionType, array(), array(
+                ->add('galleryItems', 'Sonata\CoreBundle\Form\Type\CollectionType', array(), array(
                     'edit' => 'inline',
                     'inline' => 'table',
                     'sortable' => 'position',

--- a/Admin/GalleryItemAdmin.php
+++ b/Admin/GalleryItemAdmin.php
@@ -36,22 +36,12 @@ class GalleryItemAdmin extends AbstractAdmin
             }
         }
 
-        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
-        $modelListType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\AdminBundle\Form\Type\ModelListType'
-            : 'sonata_type_model_list';
-
-        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
-        $hiddenType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
-            : 'hidden';
-
         $formMapper
-            ->add('media', $modelListType, array('required' => false), array(
+            ->add('media', 'Sonata\AdminBundle\Form\Type\ModelListType', array('required' => false), array(
                 'link_parameters' => $link_parameters,
             ))
             ->add('enabled', null, array('required' => false))
-            ->add('position', $hiddenType)
+            ->add('position', 'Symfony\Component\Form\Extension\Core\Type\HiddenType')
         ;
     }
 

--- a/Admin/ORM/MediaAdmin.php
+++ b/Admin/ORM/MediaAdmin.php
@@ -29,18 +29,13 @@ class MediaAdmin extends Admin
             $options['choices'][$name] = $name;
         }
 
-        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
-        $choiceType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-            : 'choice';
-
         $datagridMapper
             ->add('name')
             ->add('providerReference')
             ->add('enabled')
             ->add('context', null, array(
                 'show_filter' => $this->getPersistentParameter('hide_context') !== true,
-            ), $choiceType, $options);
+            ), 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', $options);
 
         if (null !== $this->categoryManager) {
             $datagridMapper->add('category', null, array('show_filter' => false));
@@ -59,19 +54,14 @@ class MediaAdmin extends Admin
             $providers[$name] = $name;
         }
 
-        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
-        $ormChoiceType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\DoctrineORMAdminBundle\Filter\ChoiceFilter'
-            : 'doctrine_orm_choice';
-
-        $datagridMapper->add('providerName', $ormChoiceType, array(
+        $datagridMapper->add('providerName', 'Sonata\DoctrineORMAdminBundle\Filter\ChoiceFilter', array(
             'field_options' => array(
                 'choices' => $providers,
                 'required' => false,
                 'multiple' => false,
                 'expanded' => false,
             ),
-            'field_type' => $choiceType,
+            'field_type' => 'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
         ));
     }
 }

--- a/Block/FeatureMediaBlockService.php
+++ b/Block/FeatureMediaBlockService.php
@@ -45,30 +45,17 @@ class FeatureMediaBlockService extends MediaBlockService
     {
         $formatChoices = $this->getFormatChoices($block->getSetting('mediaId'));
 
-        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $immutableArrayType = 'Sonata\CoreBundle\Form\Type\ImmutableArrayType';
-            $textType = 'Symfony\Component\Form\Extension\Core\Type\TextType';
-            $textareaType = 'Symfony\Component\Form\Extension\Core\Type\TextareaType';
-            $choiceType = 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
-        } else {
-            $immutableArrayType = 'sonata_type_immutable_array';
-            $textType = 'text';
-            $textareaType = 'textarea';
-            $choiceType = 'choice';
-        }
-
-        $formMapper->add('settings', $immutableArrayType, array(
+        $formMapper->add('settings', 'Sonata\CoreBundle\Form\Type\ImmutableArrayType', array(
             'keys' => array(
-                array('title', $textType, array(
+                array('title', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
                     'required' => false,
                     'label' => 'form.label_title',
                 )),
-                array('content', $textareaType, array(
+                array('content', 'Symfony\Component\Form\Extension\Core\Type\TextareaType', array(
                     'required' => false,
                     'label' => 'form.label_content',
                 )),
-                array('orientation', $choiceType, array(
+                array('orientation', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                     'required' => false,
                     'choices' => array(
                         'left' => 'form.label_orientation_left',
@@ -77,7 +64,7 @@ class FeatureMediaBlockService extends MediaBlockService
                     'label' => 'form.label_orientation',
                 )),
                 array($this->getMediaBuilder($formMapper), null, array()),
-                array('format', $choiceType, array(
+                array('format', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                     'required' => count($formatChoices) > 0,
                     'choices' => $formatChoices,
                     'label' => 'form.label_format',

--- a/Block/GalleryBlockService.php
+++ b/Block/GalleryBlockService.php
@@ -125,51 +125,34 @@ class GalleryBlockService extends AbstractBlockService
         $fieldDescription->setOption('edit', 'list');
         $fieldDescription->setAssociationMapping(array('fieldName' => 'gallery', 'type' => ClassMetadataInfo::MANY_TO_ONE));
 
-        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $modelListType = 'Sonata\AdminBundle\Form\Type\ModelListType';
-            $immutableArrayType = 'Sonata\CoreBundle\Form\Type\ImmutableArrayType';
-            $textType = 'Symfony\Component\Form\Extension\Core\Type\TextType';
-            $choiceType = 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
-            $numberType = 'Symfony\Component\Form\Extension\Core\Type\NumberType';
-            $checkboxType = 'Symfony\Component\Form\Extension\Core\Type\CheckboxType';
-        } else {
-            $modelListType = 'sonata_type_model_list';
-            $immutableArrayType = 'sonata_type_immutable_array';
-            $textType = 'text';
-            $choiceType = 'choice';
-            $numberType = 'number';
-            $checkboxType = 'checkbox';
-        }
-
-        $builder = $formMapper->create('galleryId', $modelListType, array(
+        $builder = $formMapper->create('galleryId', 'Sonata\AdminBundle\Form\Type\ModelListType', array(
             'sonata_field_description' => $fieldDescription,
             'class' => $this->getGalleryAdmin()->getClass(),
             'model_manager' => $this->getGalleryAdmin()->getModelManager(),
             'label' => 'form.label_gallery',
         ));
 
-        $formMapper->add('settings', $immutableArrayType, array(
+        $formMapper->add('settings', 'Sonata\CoreBundle\Form\Type\ImmutableArrayType', array(
             'keys' => array(
-                array('title', $textType, array(
+                array('title', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
                     'required' => false,
                     'label' => 'form.label_title',
                 )),
-                array('context', $choiceType, array(
+                array('context', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                     'required' => true,
                     'choices' => $contextChoices,
                     'label' => 'form.label_context',
                 )),
-                array('format', $choiceType, array(
+                array('format', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                     'required' => count($formatChoices) > 0,
                     'choices' => $formatChoices,
                     'label' => 'form.label_format',
                 )),
                 array($builder, null, array()),
-                array('pauseTime', $numberType, array(
+                array('pauseTime', 'Symfony\Component\Form\Extension\Core\Type\NumberType', array(
                     'label' => 'form.label_pause_time',
                 )),
-                array('startPaused', $checkboxType, array(
+                array('startPaused', 'Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(
                     'required' => false,
                     'label' => 'form.label_start_paused',
                 )),

--- a/Block/GalleryListBlockService.php
+++ b/Block/GalleryListBlockService.php
@@ -59,42 +59,29 @@ class GalleryListBlockService extends AbstractBlockService
             $contextChoices[$name] = $name;
         }
 
-        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $immutableArrayType = 'Sonata\CoreBundle\Form\Type\ImmutableArrayType';
-            $textType = 'Symfony\Component\Form\Extension\Core\Type\TextType';
-            $integerType = 'Symfony\Component\Form\Extension\Core\Type\IntegerType';
-            $choiceType = 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
-        } else {
-            $immutableArrayType = 'sonata_type_immutable_array';
-            $textType = 'text';
-            $integerType = 'integer';
-            $choiceType = 'choice';
-        }
-
-        $formMapper->add('settings', $immutableArrayType, array(
+        $formMapper->add('settings', 'Sonata\CoreBundle\Form\Type\ImmutableArrayType', array(
             'keys' => array(
-                array('title', $textType, array(
+                array('title', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
                     'label' => 'form.label_title',
                     'required' => false,
                 )),
-                array('number', $integerType, array(
+                array('number', 'Symfony\Component\Form\Extension\Core\Type\IntegerType', array(
                     'label' => 'form.label_number',
                     'required' => true,
                 )),
-                array('context', $choiceType, array(
+                array('context', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                     'required' => true,
                     'label' => 'form.label_context',
                     'choices' => $contextChoices,
                 )),
-                array('mode', $choiceType, array(
+                array('mode', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                     'label' => 'form.label_mode',
                     'choices' => array(
                         'public' => 'form.label_mode_public',
                         'admin' => 'form.label_mode_admin',
                     ),
                 )),
-                array('order', $choiceType,  array(
+                array('order', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType',  array(
                     'label' => 'form.label_order',
                     'choices' => array(
                         'name' => 'form.label_order_name',
@@ -102,7 +89,7 @@ class GalleryListBlockService extends AbstractBlockService
                         'updatedAt' => 'form.label_order_updated_at',
                     ),
                 )),
-                array('sort', $choiceType, array(
+                array('sort', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                     'label' => 'form.label_sort',
                     'choices' => array(
                         'desc' => 'form.label_sort_desc',

--- a/Block/MediaBlockService.php
+++ b/Block/MediaBlockService.php
@@ -102,25 +102,14 @@ class MediaBlockService extends AbstractBlockService
 
         $formatChoices = $this->getFormatChoices($block->getSetting('mediaId'));
 
-        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $immutableArrayType = 'Sonata\CoreBundle\Form\Type\ImmutableArrayType';
-            $textType = 'Symfony\Component\Form\Extension\Core\Type\TextType';
-            $choiceType = 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
-        } else {
-            $immutableArrayType = 'sonata_type_immutable_array';
-            $textType = 'text';
-            $choiceType = 'choice';
-        }
-
-        $formMapper->add('settings', $immutableArrayType, array(
+        $formMapper->add('settings', 'Sonata\CoreBundle\Form\Type\ImmutableArrayType', array(
             'keys' => array(
-                array('title', $textType, array(
+                array('title', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
                     'required' => false,
                     'label' => 'form.label_title',
                 )),
                 array($this->getMediaBuilder($formMapper), null, array()),
-                array('format', $choiceType, array(
+                array('format', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array(
                     'required' => count($formatChoices) > 0,
                     'choices' => $formatChoices,
                     'label' => 'form.label_format',
@@ -233,12 +222,7 @@ class MediaBlockService extends AbstractBlockService
             'type' => ClassMetadataInfo::MANY_TO_ONE,
         ));
 
-        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
-        $modelListType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\AdminBundle\Form\Type\ModelListType'
-            : 'sonata_type_model_list';
-
-        return $formMapper->create('mediaId', $modelListType, array(
+        return $formMapper->create('mediaId', 'Sonata\AdminBundle\Form\Type\ModelListType', array(
             'sonata_field_description' => $fieldDescription,
             'class' => $this->getMediaAdmin()->getClass(),
             'model_manager' => $this->getMediaAdmin()->getModelManager(),

--- a/Controller/MediaController.php
+++ b/Controller/MediaController.php
@@ -15,6 +15,7 @@ use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -44,12 +45,13 @@ class MediaController extends Controller
     /**
      * @throws NotFoundHttpException
      *
-     * @param string $id
-     * @param string $format
+     * @param Request $request
+     * @param string  $id
+     * @param string  $format
      *
      * @return Response
      */
-    public function downloadAction($id, $format = 'reference')
+    public function downloadAction(Request $request, $id, $format = 'reference')
     {
         $media = $this->getMedia($id);
 
@@ -57,14 +59,14 @@ class MediaController extends Controller
             throw new NotFoundHttpException(sprintf('unable to find the media with the id : %s', $id));
         }
 
-        if (!$this->get('sonata.media.pool')->getDownloadSecurity($media)->isGranted($media, $this->getCurrentRequest())) {
+        if (!$this->get('sonata.media.pool')->getDownloadSecurity($media)->isGranted($media, $request)) {
             throw new AccessDeniedException();
         }
 
         $response = $this->getProvider($media)->getDownloadResponse($media, $format, $this->get('sonata.media.pool')->getDownloadMode($media));
 
         if ($response instanceof BinaryFileResponse) {
-            $response->prepare($this->getCurrentRequest());
+            $response->prepare($request);
         }
 
         return $response;
@@ -73,12 +75,13 @@ class MediaController extends Controller
     /**
      * @throws NotFoundHttpException
      *
-     * @param string $id
-     * @param string $format
+     * @param Request $request
+     * @param string  $id
+     * @param string  $format
      *
      * @return Response
      */
-    public function viewAction($id, $format = 'reference')
+    public function viewAction(Request $request, $id, $format = 'reference')
     {
         $media = $this->getMedia($id);
 
@@ -86,7 +89,7 @@ class MediaController extends Controller
             throw new NotFoundHttpException(sprintf('unable to find the media with the id : %s', $id));
         }
 
-        if (!$this->get('sonata.media.pool')->getDownloadSecurity($media)->isGranted($media, $this->getCurrentRequest())) {
+        if (!$this->get('sonata.media.pool')->getDownloadSecurity($media)->isGranted($media, $request)) {
             throw new AccessDeniedException();
         }
 
@@ -102,18 +105,19 @@ class MediaController extends Controller
      * optionally saves the image and
      * outputs it to the browser at the same time.
      *
-     * @param string $path
-     * @param string $filter
+     * @param Request $request
+     * @param string  $path
+     * @param string  $filter
      *
      * @return Response
      */
-    public function liipImagineFilterAction($path, $filter)
+    public function liipImagineFilterAction(Request $request, $path, $filter)
     {
         if (!preg_match('@([^/]*)/(.*)/([0-9]*)_([a-z_A-Z]*).jpg@', $path, $matches)) {
             throw new NotFoundHttpException();
         }
 
-        $targetPath = $this->get('liip_imagine.cache.manager')->resolve($this->getCurrentRequest(), $path, $filter);
+        $targetPath = $this->get('liip_imagine.cache.manager')->resolve($request, $path, $filter);
 
         if ($targetPath instanceof Response) {
             return $targetPath;
@@ -134,27 +138,12 @@ class MediaController extends Controller
 
         $image = $this->get('liip_imagine')->open($tmpFile);
 
-        $response = $this->get('liip_imagine.filter.manager')->get($this->getCurrentRequest(), $filter, $image, $path);
+        $response = $this->get('liip_imagine.filter.manager')->get($request, $filter, $image, $path);
 
         if ($targetPath) {
             $response = $this->get('liip_imagine.cache.manager')->store($response, $targetPath, $filter);
         }
 
         return $response;
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method when bumping Symfony requirement to 2.8+.
-     * Inject the Symfony\Component\HttpFoundation\Request into the actions instead.
-     *
-     * @return Request
-     */
-    private function getCurrentRequest()
-    {
-        if ($this->has('request_stack')) {
-            return $this->get('request_stack')->getCurrentRequest();
-        }
-
-        return $this->get('request');
     }
 }

--- a/DependencyInjection/SonataMediaExtension.php
+++ b/DependencyInjection/SonataMediaExtension.php
@@ -42,25 +42,6 @@ class SonataMediaExtension extends Extension
         $loader->load('extra.xml');
         $loader->load('form.xml');
         $loader->load('gaufrette.xml');
-
-        // NEXT_MAJOR: Remove Following lines
-        $amazonS3Definition = $container->getDefinition('sonata.media.adapter.service.s3');
-        if (method_exists($amazonS3Definition, 'setFactory')) {
-            $amazonS3Definition->setFactory(array('Aws\S3\S3Client', 'factory'));
-        } else {
-            $amazonS3Definition->setFactoryClass('Aws\S3\S3Client');
-            $amazonS3Definition->setFactoryMethod('factory');
-        }
-
-        // NEXT_MAJOR: Remove Following lines
-        $openCloudDefinition = $container->getDefinition('sonata.media.adapter.filesystem.opencloud.objectstore');
-        if (method_exists($openCloudDefinition, 'setFactory')) {
-            $openCloudDefinition->setFactory(array(new Reference('sonata.media.adapter.filesystem.opencloud.connection'), 'ObjectStore'));
-        } else {
-            $openCloudDefinition->setFactoryService('sonata.media.adapter.filesystem.opencloud.connection');
-            $openCloudDefinition->setFactoryMethod('ObjectStore');
-        }
-
         $loader->load('validators.xml');
         $loader->load('serializer.xml');
 

--- a/Model/Media.php
+++ b/Model/Media.php
@@ -12,9 +12,7 @@
 namespace Sonata\MediaBundle\Model;
 
 use Imagine\Image\Box;
-use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 abstract class Media implements MediaInterface
 {
@@ -609,21 +607,6 @@ abstract class Media implements MediaInterface
     public function getPreviousProviderReference()
     {
         return $this->previousProviderReference;
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method when bumping Symfony requirement to 2.8+.
-     *
-     * @param ClassMetadata $metadata
-     */
-    public static function loadValidatorMetadata(ClassMetadata $metadata)
-    {
-        if (class_exists('Symfony\Component\Validator\Constraints\Expression')) {
-            $method = 'isStatusErroneous';
-        } else {
-            $method = array('methods' => array('isStatusErroneous'));
-        }
-        $metadata->addConstraint(new Assert\Callback($method));
     }
 
     /**

--- a/Resources/config/gaufrette.xml
+++ b/Resources/config/gaufrette.xml
@@ -10,9 +10,7 @@
         <service id="sonata.media.adapter.filesystem.local" class="Sonata\MediaBundle\Filesystem\Local"/>
         <service id="sonata.media.adapter.filesystem.ftp" class="Gaufrette\Adapter\Ftp"/>
         <service id="sonata.media.adapter.service.s3" class="Aws\S3\S3Client">
-            <!-- NEXT_MAJOR: Uncomment Following line
             <factory class="Aws\S3\S3Client" method="factory"/>
-            -->
             <argument type="collection"/>
         </service>
         <service id="sonata.media.adapter.filesystem.s3" class="Gaufrette\Adapter\AwsS3">
@@ -39,9 +37,7 @@
             <argument/>
         </service>
         <service id="sonata.media.adapter.filesystem.opencloud.objectstore" class="OpenCloud\ObjectSource\Service">
-            <!-- NEXT_MAJOR: Uncomment Following line
             <factory service="sonata.media.adapter.filesystem.opencloud.connection" method="ObjectStore"/>
-            -->
             <argument/>
             <argument/>
         </service>

--- a/Resources/config/validation.xml
+++ b/Resources/config/validation.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping         http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
     <class name="Sonata\MediaBundle\Model\Media">
-        <!-- NEXT_MAJOR: Uncomment Following line
         <constraint name="Callback">isStatusErroneous</constraint>
-        -->
         <constraint name="Sonata\CoreBundle\Validator\Constraints\InlineConstraint">
             <option name="service">sonata.media.pool</option>
             <option name="method">validate</option>

--- a/Tests/Admin/BaseMediaAdminTest.php
+++ b/Tests/Admin/BaseMediaAdminTest.php
@@ -97,12 +97,7 @@ class BaseMediaAdminTest extends \PHPUnit_Framework_TestCase
 
     private function configureGetProviderName($media)
     {
-        // NEXT_MAJOR remove this block when dropping sf < 2.8 compatibility
-        if (method_exists('Symfony\Component\HttpFoundation\JsonResponse', 'transformJsonError')) {
-            $this->request->get('uniqid[providerName]', null, true)->willReturn('providerName');
-        } else {
-            $this->request->get('uniqid')->willReturn(array('providerName' => 'providerName'));
-        }
+        $this->request->get('uniqid')->willReturn(array('providerName' => 'providerName'));
         $media->setProviderName('providerName')->shouldBeCalled();
     }
 }

--- a/Tests/Controller/GalleryAdminControllerTest.php
+++ b/Tests/Controller/GalleryAdminControllerTest.php
@@ -83,38 +83,22 @@ class GalleryAdminControllerTest extends \PHPUnit_Framework_TestCase
 
     private function configureGetCurrentRequest($request)
     {
-        // NEXT_MAJOR: Remove this trick when bumping Symfony requirement to 2.8+.
-        if (class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            $requestStack = $this->prophesize('Symfony\Component\HttpFoundation\RequestStack');
+        $requestStack = $this->prophesize('Symfony\Component\HttpFoundation\RequestStack');
 
-            $this->container->has('request_stack')->willReturn(true);
-            $this->container->get('request_stack')->willReturn($requestStack->reveal());
-            $requestStack->getCurrentRequest()->willReturn($request);
-        } else {
-            $this->container->has('request_stack')->willReturn(false);
-            $this->container->get('request')->willReturn($request);
-        }
+        $this->container->has('request_stack')->willReturn(true);
+        $this->container->get('request_stack')->willReturn($requestStack->reveal());
+        $requestStack->getCurrentRequest()->willReturn($request);
     }
 
     private function configureSetCsrfToken($intention)
     {
-        // NEXT_MAJOR: Remove this trick when bumping Symfony requirement to 2.8+.
-        if (interface_exists('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface')) {
-            $tokenManager = $this->prophesize('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface');
-            $token = $this->prophesize('Symfony\Component\Security\Csrf\CsrfToken');
+        $tokenManager = $this->prophesize('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface');
+        $token = $this->prophesize('Symfony\Component\Security\Csrf\CsrfToken');
 
-            $tokenManager->getToken($intention)->willReturn($token->reveal());
-            $token->getValue()->willReturn('token');
-            $this->container->has('security.csrf.token_manager')->willReturn(true);
-            $this->container->get('security.csrf.token_manager')->willReturn($tokenManager->reveal());
-        } else {
-            $csrfProvider = $this->prophesize('Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface');
-
-            $csrfProvider->generateCsrfToken($intention)->shouldBeCalled('token');
-            $this->container->has('security.csrf.token_manager')->willReturn(false);
-            $this->container->has('form.csrf_provider')->willReturn(true);
-            $this->container->get('form.csrf_provider')->willReturn($csrfProvider->reveal());
-        }
+        $tokenManager->getToken($intention)->willReturn($token->reveal());
+        $token->getValue()->willReturn('token');
+        $this->container->has('security.csrf.token_manager')->willReturn(true);
+        $this->container->get('security.csrf.token_manager')->willReturn($tokenManager->reveal());
     }
 
     private function configureSetFormTheme($formView, $formTheme)

--- a/Tests/Controller/MediaAdminControllerTest.php
+++ b/Tests/Controller/MediaAdminControllerTest.php
@@ -158,17 +158,11 @@ class MediaAdminControllerTest extends \PHPUnit_Framework_TestCase
 
     private function configureGetCurrentRequest($request)
     {
-        // NEXT_MAJOR: Remove this trick when bumping Symfony requirement to 2.8+.
-        if (class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            $requestStack = $this->prophesize('Symfony\Component\HttpFoundation\RequestStack');
+        $requestStack = $this->prophesize('Symfony\Component\HttpFoundation\RequestStack');
 
-            $this->container->has('request_stack')->willReturn(true);
-            $this->container->get('request_stack')->willReturn($requestStack->reveal());
-            $requestStack->getCurrentRequest()->willReturn($request);
-        } else {
-            $this->container->has('request_stack')->willReturn(false);
-            $this->container->get('request')->willReturn($request);
-        }
+        $this->container->has('request_stack')->willReturn(true);
+        $this->container->get('request_stack')->willReturn($requestStack->reveal());
+        $requestStack->getCurrentRequest()->willReturn($request);
     }
 
     private function configureSetFormTheme($formView, $formTheme)
@@ -194,23 +188,13 @@ class MediaAdminControllerTest extends \PHPUnit_Framework_TestCase
 
     private function configureSetCsrfToken($intention)
     {
-        // NEXT_MAJOR: Remove this trick when bumping Symfony requirement to 2.8+.
-        if (interface_exists('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface')) {
-            $tokenManager = $this->prophesize('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface');
-            $token = $this->prophesize('Symfony\Component\Security\Csrf\CsrfToken');
+        $tokenManager = $this->prophesize('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface');
+        $token = $this->prophesize('Symfony\Component\Security\Csrf\CsrfToken');
 
-            $tokenManager->getToken($intention)->willReturn($token->reveal());
-            $token->getValue()->willReturn('token');
-            $this->container->has('security.csrf.token_manager')->willReturn(true);
-            $this->container->get('security.csrf.token_manager')->willReturn($tokenManager->reveal());
-        } else {
-            $csrfProvider = $this->prophesize('Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface');
-
-            $csrfProvider->generateCsrfToken($intention)->shouldBeCalled('token');
-            $this->container->has('security.csrf.token_manager')->willReturn(false);
-            $this->container->has('form.csrf_provider')->willReturn(true);
-            $this->container->get('form.csrf_provider')->willReturn($csrfProvider->reveal());
-        }
+        $tokenManager->getToken($intention)->willReturn($token->reveal());
+        $token->getValue()->willReturn('token');
+        $this->container->has('security.csrf.token_manager')->willReturn(true);
+        $this->container->get('security.csrf.token_manager')->willReturn($tokenManager->reveal());
     }
 
     private function configureRender($template, $data, $rendered)

--- a/Tests/Form/Type/AbstractTypeTest.php
+++ b/Tests/Form/Type/AbstractTypeTest.php
@@ -54,20 +54,7 @@ abstract class AbstractTypeTest extends TypeTestCase
             ->method('add')
             ->will($this->returnCallback(function ($name, $type = null) use ($that) {
                 if (null !== $type) {
-                    $isFQCN = class_exists($type);
-                    if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                        // 2.8
-                        @trigger_error(
-                            sprintf(
-                                'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                                .' Use the fully-qualified type class name instead.',
-                                $type
-                            ),
-                            E_USER_DEPRECATED)
-                        ;
-                    }
-
-                    $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                    $that->assertTrue(class_exists($type), sprintf('Unable to ensure %s is a FQCN', $type));
                 }
             }));
 
@@ -89,20 +76,7 @@ abstract class AbstractTypeTest extends TypeTestCase
     {
         $parentRef = $this->formType->getParent();
 
-        $isFQCN = class_exists($parentRef);
-        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-            // 2.8
-            @trigger_error(
-                sprintf(
-                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                    .' Use the fully-qualified type class name instead.',
-                    $parentRef
-                ),
-                E_USER_DEPRECATED)
-            ;
-        }
-
-        $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
+        $this->assertTrue(class_exists($parentRef), sprintf('Unable to ensure %s is a FQCN', $parentRef));
     }
 
     /**

--- a/Tests/Provider/AbstractProviderTest.php
+++ b/Tests/Provider/AbstractProviderTest.php
@@ -53,20 +53,7 @@ abstract class AbstractProviderTest extends PHPUnit_Framework_TestCase
             ->method('add')
             ->will($this->returnCallback(function ($name, $type = null) use ($that) {
                 if (null !== $type) {
-                    $isFQCN = class_exists($type);
-                    if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                        // 2.8
-                        @trigger_error(
-                            sprintf(
-                                'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                                .' Use the fully-qualified type class name instead.',
-                                $type
-                            ),
-                            E_USER_DEPRECATED)
-                        ;
-                    }
-
-                    $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                    $that->assertTrue(class_exists($type), sprintf('Unable to ensure %s is a FQCN', $type));
                 }
             }));
 
@@ -76,20 +63,7 @@ abstract class AbstractProviderTest extends PHPUnit_Framework_TestCase
             ->method('add')
             ->will($this->returnCallback(function ($name, $type = null) use ($that) {
                 if (null !== $type) {
-                    $isFQCN = class_exists($type);
-                    if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                        // 2.8
-                        @trigger_error(
-                            sprintf(
-                                'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                                .' Use the fully-qualified type class name instead.',
-                                $type
-                            ),
-                            E_USER_DEPRECATED)
-                        ;
-                    }
-
-                    $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
+                    $that->assertTrue(class_exists($type), sprintf('Unable to ensure %s is a FQCN', $type));
                 }
             }));
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -9,20 +9,27 @@ Please read [3.x](https://github.com/sonata-project/SonataMediaBundle/tree/3.x) 
 
 See also the [diff code](https://github.com/sonata-project/SonataMediaBundle/compare/3.x...4.0.0).
 
+## Controllers
+
+`MediaController` actions were changed to introduce `Request $request` as first parameter.
+You must update those signatures if you want to still extend this class:
+`downloadAction`, `listAction` and `liipImagineFilterAction`
+
 ## Blocks
 
-The property `wrap` in `GalleryBlockService` was removed. You must create a custom block, if you still want to use ist.
+The property `wrap` in `GalleryBlockService` was removed. You must create a custom block, if you still want to use it.
 
 ## Models
+
 If you have implemented a custom model, you must adapt the signature of the following new methods:
  * `GalleryHasMediaInterface::getId`
  * `GalleryInterface::getId`
- 
+
 ## Renamed GalleryHasMedia to GalleryItem
 
 All Actions, Controllers, Interfaces and anything related to this is renamed accordingly.
 
 ## Removed classification dependency
 
-The category feature is now optional and can be disabled in the configuration. 
+The category feature is now optional and can be disabled in the configuration.
 If you need this feature you have to require `sonata-project/classifcation-bundle` via composer.


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is removing compatibility with Symfony 2.3.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1057 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Changed `MediaController::downloadAction` signature to include Request as first parameter
- Changed `MediaController::viewAction` signature to include Request as first parameter
- Changed `MediaController::liipImagineFilterAction` signature to include Request as first parameter
```


## Subject

<!-- Describe your Pull Request content here -->
I am removing unused lines of codes, used for symfony 2.3 compatibility on 3.x branch.
Also changing some controllers signatures to accept `$request`as a parameter.