### PR TITLE
Remove deprecations from non FQCNs on form types

### DIFF
--- a/Admin/ORM/MediaAdmin.php
+++ b/Admin/ORM/MediaAdmin.php
@@ -29,13 +29,18 @@ class MediaAdmin extends Admin
             $options['choices'][$name] = $name;
         }
 
+        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
+        $choiceType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
+            : 'choice';
+
         $datagridMapper
             ->add('name')
             ->add('providerReference')
             ->add('enabled')
             ->add('context', null, array(
                 'show_filter' => $this->getPersistentParameter('hide_context') !== true,
-            ), 'choice', $options)
+            ), $choiceType, $options)
             ->add('category', null, array(
                 'show_filter' => false,
             ))
@@ -63,7 +68,7 @@ class MediaAdmin extends Admin
                 'multiple' => false,
                 'expanded' => false,
             ),
-            'field_type' => 'choice',
+            'field_type' => $choiceType,
         ));
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

<!-- Describe your Pull Request content here -->
This PR tries to avoid deprecation warnings on Symfony2.8 with non FQCNs. 

I didn't spot it because it does not produce an error on Symfony3. There is some magic on Sonata that resolves this `'choice'`to its FQCN but only on SF3... since I don't like magic, I just replaced it with the correct value.