### PR TITLE
Bring back twig 1.x compatibility

### DIFF
--- a/Twig/Extension/FormatterMediaExtension.php
+++ b/Twig/Extension/FormatterMediaExtension.php
@@ -109,4 +109,14 @@ class FormatterMediaExtension extends BaseProxyExtension
     {
         return $this->getTwigExtension()->path($media, $format);
     }
+
+    /**
+     * NEXT_MAJOR: Remove this method when bumping requirements to twig 2.
+     *
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'sonata_formatter_media';
+    }
 }


### PR DESCRIPTION


<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is restoring twig 1.x compatibility.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1215 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Compatibility with twig 1.x
```

## Subject

<!-- Describe your Pull Request content here -->
Revert some of the changes from PR (#1184)
getName is needed on twig 1.x removed on twig 2