### PR TITLE
Add conflict with SonataFormatterBundle <3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "sonata-project/block-bundle": "^3.2",
         "sonata-project/datagrid-bundle": "^2.2.1",
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
-        "sonata-project/formatter-bundle": "^3.0",
+        "sonata-project/formatter-bundle": "^3.2",
         "sonata-project/seo-bundle": "^2.1",
         "symfony/phpunit-bridge": "^2.7 || ^3.0"
     },
@@ -71,6 +71,7 @@
         "jms/serializer": "<0.13",
         "sonata-project/block-bundle": "<3.1.1 || >=4.0",
         "sonata-project/classification-bundle": "<3.0 || >= 5.0",
+        "sonata-project/formatter-bundle": "<3.2",
         "sonata-project/seo-bundle": "<2.1 || >=3.0"
     },
     "autoload": {


### PR DESCRIPTION


<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC and fixes a bug.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1215 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Optional dependency to SonataFormatterBundle is now on `^3.2`
```

## Subject

SonataFormatterBundle 3.1.0 has a twig extension that implements
`\Twig_ExtensionInterface`. This is changed on 3.2.0 to extend `\Twig_Extension`.
This change allows us to support both twig 1.x and 2.x
<!-- Describe your Pull Request content here -->
