### PR TITLE
Changed how we retrieve configuration on AddProviderCompilerPass

### DIFF
--- a/DependencyInjection/Compiler/AddProviderCompilerPass.php
+++ b/DependencyInjection/Compiler/AddProviderCompilerPass.php
@@ -11,6 +11,8 @@
 
 namespace Sonata\MediaBundle\DependencyInjection\Compiler;
 
+use Sonata\MediaBundle\DependencyInjection\Configuration;
+use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -25,11 +27,11 @@ class AddProviderCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $settings = $this->fixSettings($container);
+        $config = $this->getExtensionConfig($container);
 
         // define configuration per provider
-        $this->applyFormats($container, $settings);
-        $this->attachArguments($container, $settings);
+        $this->applyFormats($container, $config);
+        $this->attachArguments($container, $config);
         $this->attachProviders($container);
 
         $format = $container->getParameter('sonata.media.admin_format');
@@ -40,31 +42,20 @@ class AddProviderCompilerPass implements CompilerPassInterface
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @param ContainerBuilder $container
      *
      * @return array
      */
     public function fixSettings(ContainerBuilder $container)
     {
-        $pool = $container->getDefinition('sonata.media.pool');
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since 3.x, to be removed in 4.0.',
+            E_USER_DEPRECATED
+        );
 
-        // not very clean but don't know how to do that for now
-        $settings = false;
-        $methods = $pool->getMethodCalls();
-        foreach ($methods as $pos => $calls) {
-            if ($calls[0] == '__hack__') {
-                $settings = $calls[1];
-                break;
-            }
-        }
-
-        if ($settings) {
-            unset($methods[$pos]);
-        }
-
-        $pool->setMethodCalls($methods);
-
-        return $settings;
+        return $this->getExtensionConfig($container);
     }
 
     /**
@@ -128,5 +119,18 @@ class AddProviderCompilerPass implements CompilerPassInterface
                 }
             }
         }
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     *
+     * @return array
+     */
+    private function getExtensionConfig(ContainerBuilder $container)
+    {
+        $config = $container->getExtensionConfig('sonata_media');
+        $processor = new Processor();
+
+        return $processor->processConfiguration(new Configuration(), $configs);
     }
 }

--- a/DependencyInjection/SonataMediaExtension.php
+++ b/DependencyInjection/SonataMediaExtension.php
@@ -119,10 +119,6 @@ class SonataMediaExtension extends Extension
         $pool = $container->getDefinition('sonata.media.pool');
         $pool->replaceArgument(0, $config['default_context']);
 
-        // this shameless hack is done in order to have one clean configuration
-        // for adding formats ....
-        $pool->addMethodCall('__hack__', $config);
-
         $strategies = array();
 
         foreach ($config['contexts'] as $name => $settings) {

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -41,13 +41,18 @@ __construct($id, ThumbnailInterface $thumbnail, BackendInterface $backend, Event
 When creating a custom video provider, you have to implement the ``getReferenceUrl`` method to establish
 the media url.
 
+### Deprecations
+
+Sonata\MediaBundle\DependencyInjection\Compiler\AddProviderCompilerPass::fixSettings($container)
+is deprecated. Please avoid using this method, use ``getExtensionConfig($container)`` instead.
+
 UPGRADE FROM 3.0 to 3.1
 =======================
 
 ### Tests
 
-All files under the ``Tests`` directory are now correctly handled as internal test classes. 
-You can't extend them anymore, because they are only loaded when running internal tests. 
+All files under the ``Tests`` directory are now correctly handled as internal test classes.
+You can't extend them anymore, because they are only loaded when running internal tests.
 More information can be found in the [composer docs](https://getcomposer.org/doc/04-schema.md#autoload-dev).
 
 ### Deprecated


### PR DESCRIPTION

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Removed an ugly hack to retrieve configuration on `AddProviderCompilerPass`
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the tests

## Subject

<!-- Describe your Pull Request content here -->
we were previously using an ugly hack that was relying on changing a definition
on the Extension class and then recovering it (and removing it after all) on the
compiler pass.
