### PR TITLE
Fixing typo made in #1193

### DIFF
--- a/Block/GalleryBlockService.php
+++ b/Block/GalleryBlockService.php
@@ -15,7 +15,7 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
-use Sonata\BlockBundle\Block\Service\AbstractBlockService;
+use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\CoreBundle\Model\ManagerInterface;
 use Sonata\CoreBundle\Model\Metadata;
@@ -30,7 +30,7 @@ use Symfony\Component\Templating\EngineInterface;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class GalleryBlockService extends AbstractBlockService
+class GalleryBlockService extends AbstractAdminBlockService
 {
     /**
      * @var ManagerInterface

--- a/Block/GalleryListBlockService.php
+++ b/Block/GalleryListBlockService.php
@@ -13,7 +13,7 @@ namespace Sonata\MediaBundle\Block;
 
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
-use Sonata\BlockBundle\Block\Service\AbstractBlockService;
+use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\CoreBundle\Model\Metadata;
 use Sonata\MediaBundle\Model\GalleryManagerInterface;
@@ -22,7 +22,7 @@ use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class GalleryListBlockService extends AbstractBlockService
+class GalleryListBlockService extends AbstractAdminBlockService
 {
     /**
      * @var GalleryManagerInterface

--- a/Block/MediaBlockService.php
+++ b/Block/MediaBlockService.php
@@ -14,7 +14,7 @@ namespace Sonata\MediaBundle\Block;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
-use Sonata\BlockBundle\Block\Service\AbstractBlockService;
+use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\CoreBundle\Model\ManagerInterface;
 use Sonata\CoreBundle\Model\Metadata;
@@ -30,7 +30,7 @@ use Symfony\Component\Templating\EngineInterface;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class MediaBlockService extends AbstractBlockService
+class MediaBlockService extends AbstractAdminBlockService
 {
     /**
      * @var BaseMediaAdmin


### PR DESCRIPTION
I am targetting this branch, because it is BC compatible and it is a fix for typo error made [https://github.com/sonata-project/SonataMediaBundle/pull/1193](https://github.com/sonata-project/SonataMediaBundle/pull/1193).

Closes: N/A

## Changelog

- Fixed issue when using SonataMediaBundle blocks in conjunction with SonataPageBundle and page composer (Sonata sandbox)

## Subject

Same issue as in: [https://github.com/sonata-project/SonataFormatterBundle/pull/235](https://github.com/sonata-project/SonataFormatterBundle/pull/235) -> it is not possible to use Media Bundle blocks because of wrong inheritance.
