### PR TITLE
Fixing typo made in #1218

### DIFF
--- a/DependencyInjection/Compiler/AddProviderCompilerPass.php
+++ b/DependencyInjection/Compiler/AddProviderCompilerPass.php
@@ -131,6 +131,6 @@ class AddProviderCompilerPass implements CompilerPassInterface
         $config = $container->getExtensionConfig('sonata_media');
         $processor = new Processor();
 
-        return $processor->processConfiguration(new Configuration(), $configs);
+        return $processor->processConfiguration(new Configuration(), $config);
     }
 }


### PR DESCRIPTION
I am targetting this branch, because this is typo error fix.

Closes #1218 for good.

## Subject

File: DependencyInjection/Compiler/AddProviderCompilerPass.php, method getExtensionConfig() had typo error in working with $config(s) variable.
