### PR TITLE
Fixed double padding on media list

### DIFF
--- a/Resources/views/MediaAdmin/list.html.twig
+++ b/Resources/views/MediaAdmin/list.html.twig
@@ -42,9 +42,9 @@ file that was distributed with this source code.
         <div class="col-xs-6 col-md-3">
             {{ tree.navigate_child([root_category], admin, true, datagrid.values['category']['value'], 1) }}
         </div>
-    <div class="col-xs-12 col-md-9">
-        {{ parent() }}
-    </div>
+        <div class="col-xs-12 col-md-9 no-padding">
+            {{ parent() }}
+        </div>
     {% else %}
         {{ parent() }}
     {% endif %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this only changes a little thing on the media list.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

<!-- Describe your Pull Request content here -->
There is a double padding on media list, because we are using col-* class two times.
I just removed the first's one padding.

BEFORE:
![captura de pantalla 2017-03-05 a las 21 46 58](https://cloud.githubusercontent.com/assets/1137485/23591344/f6d06e64-01ee-11e7-8497-d1880b33fe20.png)

AFTER:
![captura de pantalla 2017-03-05 a las 21 47 34](https://cloud.githubusercontent.com/assets/1137485/23591346/ffc39f78-01ee-11e7-951e-5c5d2cf60481.png)
