### PR TITLE
Replace missing providers column by providerName on clean command

### DIFF
--- a/Command/CleanMediaCommand.php
+++ b/Command/CleanMediaCommand.php
@@ -25,9 +25,9 @@ use Symfony\Component\Finder\Finder;
 class CleanMediaCommand extends ContainerAwareCommand
 {
     /**
-     * @var MediaProviderInterface[]|false
+     * @var MediaProviderInterface[]|null
      */
-    private $providers = false;
+    private $providers;
 
     /**
      * {@inheritdoc}
@@ -45,7 +45,7 @@ class CleanMediaCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $dryRun = (bool) $input->getOption('dry-run');
-        $verbose = (bool) $input->getOption('verbose');
+        $verbose = $output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE;
 
         $pool = $this->getContainer()->get('sonata.media.pool');
         $finder = Finder::create();
@@ -121,14 +121,14 @@ class CleanMediaCommand extends ContainerAwareCommand
 
         if (count($fileParts) > 1 && $fileParts[0] == 'thumb') {
             return $mediaManager->findOneBy(array(
-                    'id' => $fileParts[1],
-                    'context' => $context,
-                )) != null;
+                'id' => $fileParts[1],
+                'context' => $context,
+            )) != null;
         }
 
         return count($mediaManager->findBy(array(
-                'providerReference' => $filename,
-                'providers' => $this->getProviders(),
-            ))) > 0;
+            'providerReference' => $filename,
+            'providerName' => $this->getProviders(),
+        ))) > 0;
     }
 }

--- a/Tests/Command/CleanMediaCommandTest.php
+++ b/Tests/Command/CleanMediaCommandTest.php
@@ -17,6 +17,7 @@ use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Filesystem\Tests\FilesystemTestCase;
@@ -173,7 +174,7 @@ class CleanMediaCommandTest extends TestCase
             ->with($this->equalTo(array('id' => 1, 'context' => 'foo')))
             ->will($this->returnValue(array($media)));
         $this->mediaManager->expects($this->once())->method('findBy')
-            ->with($this->equalTo(array('providerReference' => 'qwertz.ext', 'providers' => array('fooprovider'))))
+            ->with($this->equalTo(array('providerReference' => 'qwertz.ext', 'providerName' => array('fooprovider'))))
             ->will($this->returnValue(array($media)));
 
         $output = $this->tester->execute(array('command' => $this->command->getName()));
@@ -207,10 +208,13 @@ class CleanMediaCommandTest extends TestCase
             ->with($this->equalTo(array('id' => 1, 'context' => 'foo')))
             ->will($this->returnValue(array($media)));
         $this->mediaManager->expects($this->once())->method('findBy')
-            ->with($this->equalTo(array('providerReference' => 'qwertz.ext', 'providers' => array('fooprovider'))))
+            ->with($this->equalTo(array('providerReference' => 'qwertz.ext', 'providerName' => array('fooprovider'))))
             ->will($this->returnValue(array($media)));
 
-        $output = $this->tester->execute(array('command' => $this->command->getName(), '--verbose' => true));
+        $output = $this->tester->execute(
+            array('command' => $this->command->getName()),
+            array('verbosity' => OutputInterface::VERBOSITY_VERBOSE)
+        );
 
         $this->assertOutputFoundInContext(
             '/Context: foo\s+(.+)\s+done!/ms',
@@ -245,7 +249,7 @@ class CleanMediaCommandTest extends TestCase
             ->with($this->equalTo(array('id' => 1, 'context' => 'foo')))
             ->will($this->returnValue(array()));
         $this->mediaManager->expects($this->once())->method('findBy')
-            ->with($this->equalTo(array('providerReference' => 'qwertz.ext', 'providers' => array('fooprovider'))))
+            ->with($this->equalTo(array('providerReference' => 'qwertz.ext', 'providerName' => array('fooprovider'))))
             ->will($this->returnValue(array()));
 
         $output = $this->tester->execute(array('command' => $this->command->getName(), '--dry-run' => true));
@@ -283,7 +287,7 @@ class CleanMediaCommandTest extends TestCase
             ->with($this->equalTo(array('id' => 1, 'context' => 'foo')))
             ->will($this->returnValue(array()));
         $this->mediaManager->expects($this->once())->method('findBy')
-            ->with($this->equalTo(array('providerReference' => 'qwertz.ext', 'providers' => array('fooprovider'))))
+            ->with($this->equalTo(array('providerReference' => 'qwertz.ext', 'providerName' => array('fooprovider'))))
             ->will($this->returnValue(array()));
 
         $output = $this->tester->execute(array('command' => $this->command->getName()));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1228 #954 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Replace missing `providers` column by `providerName` on clean command
```

## Subject

<!-- Describe your Pull Request content here -->
Clean media command was not working because it was trying to access to a `providers` database column that does not exists. I Replaced it with `providerName`.