### PR TITLE
Fixed Mimetype lookup for current GuzzleHttp

### DIFF
--- a/Metadata/AmazonMetadataBuilder.php
+++ b/Metadata/AmazonMetadataBuilder.php
@@ -11,7 +11,6 @@
 
 namespace Sonata\MediaBundle\Metadata;
 
-use Guzzle\Http\Mimetypes;
 use Sonata\MediaBundle\Model\MediaInterface;
 
 class AmazonMetadataBuilder implements MetadataBuilderInterface
@@ -115,7 +114,7 @@ class AmazonMetadataBuilder implements MetadataBuilderInterface
     protected function getContentType($filename)
     {
         $extension = pathinfo($filename, PATHINFO_EXTENSION);
-        $contentType = Mimetypes::getInstance()->fromExtension($extension);
+        $contentType = \GuzzleHttp\Psr7\mimetype_from_extension($extension);
 
         return array('contentType' => $contentType);
     }

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     ],
     "require": {
         "php": "^5.3 || ^7.0",
+        "guzzlehttp/guzzle": "^6.1",
         "imagine/imagine": "^0.6",
         "jms/serializer-bundle": "^0.13 || ^1.0",
         "knplabs/gaufrette": "^0.1.6 || ^0.2 || ^0.3",


### PR DESCRIPTION
Thanks @jonaguera

I am targeting this branch, because, the Guzzle dependency being used is outdated and no longer maintained. The mimetype lookup fix was provided by @jonaguera and uses the current GuzzleHttp library. 

Closes #1160

## Changelog


```markdown
### Changed
- use `GuzzleHttp\Psr7\mimetype_from_extension` to get the Content-Type
```

## To do
- [ ] Update the tests

## Subject

I can not upload to Amazon S3
