### PR TITLE
Fix deleting a media if included in a gallery

### DIFF
--- a/DependencyInjection/SonataMediaExtension.php
+++ b/DependencyInjection/SonataMediaExtension.php
@@ -243,6 +243,7 @@ class SonataMediaExtension extends Extension
                 array(
                     'name' => 'gallery_id',
                     'referencedColumnName' => 'id',
+                    'onDelete' => 'CASCADE',
                 ),
             ),
             'orphanRemoval' => false,
@@ -260,6 +261,7 @@ class SonataMediaExtension extends Extension
                 array(
                     'name' => 'media_id',
                     'referencedColumnName' => 'id',
+                    'onDelete' => 'CASCADE',
                 ),
             ),
             'orphanRemoval' => false,

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,11 @@
 UPGRADE 3.x
 ===========
 
+### Doctrine schema update for GalleryHasMedia
+Doctrine ORM join columns from GalleryHasMedia entity towards both Gallery and Media entities has been changed. Now
+they include the `onDelete="CASCADE"` option: this allows to delete a media if included in a gallery (and vice-versa).
+You should upgrade your database in a safe way after upgrading your vendors.
+
 UPGRADE FROM 3.4 to 3.5
 =======================
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1240

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `'onDelete' => 'CASCADE'` for mapping from GalleryHasMedia to Media and Gallery
