### PR TITLE
LiipImagineThumbnail thumbnail path resolve

### DIFF
--- a/Controller/MediaController.php
+++ b/Controller/MediaController.php
@@ -98,6 +98,8 @@ class MediaController extends Controller
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * This action applies a given filter to a given image,
      * optionally saves the image and
      * outputs it to the browser at the same time.
@@ -106,9 +108,16 @@ class MediaController extends Controller
      * @param string $filter
      *
      * @return Response
+     *
+     * @deprecated since 3.x, to be removed in 4.0.
      */
     public function liipImagineFilterAction($path, $filter)
     {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since 3.x, to be removed in 4.0.',
+            E_USER_DEPRECATED
+        );
+
         if (!preg_match('@([^/]*)/(.*)/([0-9]*)_([a-z_A-Z]*).jpg@', $path, $matches)) {
             throw new NotFoundHttpException();
         }

--- a/Provider/ImageProvider.php
+++ b/Provider/ImageProvider.php
@@ -160,6 +160,11 @@ class ImageProvider extends FileProvider
             $path = $this->thumbnail->generatePublicUrl($this, $media, $format);
         }
 
+        // if path is url, do not action
+        if (null !== parse_url($path, PHP_URL_SCHEME)) {
+            return $path;
+        }
+
         return $this->getCdn()->getPath($path, $media->getCdnIsFlushable());
     }
 

--- a/Resources/config/provider.xml
+++ b/Resources/config/provider.xml
@@ -19,7 +19,7 @@
             <argument type="string">%sonata.media.thumbnail.format.default%</argument>
         </service>
         <service id="sonata.media.thumbnail.liip_imagine" class="%sonata.media.thumbnail.liip_imagine%">
-            <argument type="service" id="router"/>
+            <argument type="service" id="liip_imagine.cache.manager" />
         </service>
         <service id="sonata.media.provider.image" class="%sonata.media.provider.image.class%">
             <tag name="sonata.media.provider"/>

--- a/Resources/doc/reference/extra.rst
+++ b/Resources/doc/reference/extra.rst
@@ -73,14 +73,12 @@ have a set named default_small.
         filter_sets:
             default_small:
                 quality: 75
-                controller_action: 'SonataMediaBundle:Media:liipImagineFilter'
                 filters:
                     thumbnail: { size: [100, 70], mode: outbound }
 
 
             default_big:
                 quality: 75
-                controller_action: 'SonataMediaBundle:Media:liipImagineFilter'
                 filters:
                     thumbnail: { size: [500, 70], mode: outbound }
 
@@ -94,6 +92,8 @@ You also need to alter the ``sonata_media`` configuration to use the ``sonata.me
             # ...
             image:
                 thumbnail:  sonata.media.thumbnail.liip_imagine
+                allowed_extensions: ['jpg', 'png', 'gif', 'jpeg'] # Optional
+                allowed_mime_types: ['image/pjpeg','image/jpeg','image/png','image/x-png', 'image/gif'] # Optional
             vimeo:
                 thumbnail:  sonata.media.thumbnail.liip_imagine
             youtube:

--- a/Tests/Security/LiipImagineThumbnailTest.php
+++ b/Tests/Security/LiipImagineThumbnailTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\Security;
+
+use Gaufrette\Adapter\InMemory;
+use Gaufrette\File;
+use Gaufrette\Filesystem;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
+use Sonata\MediaBundle\Thumbnail\LiipImagineThumbnail;
+
+class LiipImagineThumbnailTest extends PHPUnit_Framework_TestCase
+{
+    public function testGenerate()
+    {
+        $cacheManager = $this->createMock('Liip\ImagineBundle\Imagine\Cache\CacheMenager');
+        $thumbnail = new LiipImagineThumbnail($cacheManager);
+
+        $filesystem = new Filesystem(new InMemory(array('myfile' => 'content')));
+        $referenceFile = new File('myfile', $filesystem);
+
+        $formats = array(
+          'admin' => array('height' => 50, 'width' => 50, 'quality' => 100),
+          'mycontext_medium' => array('height' => 500, 'width' => 500, 'quality' => 100),
+          'anothercontext_large' => array('height' => 500, 'width' => 500, 'quality' => 100),
+        );
+
+        $resizer = $this->createMock('Sonata\MediaBundle\Resizer\ResizerInterface');
+        $resizer->expects($this->any())->method('resize')->will($this->returnValue(true));
+
+        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider->expects($this->any())->method('requireThumbnails')->will($this->returnValue(true));
+        $provider->expects($this->any())->method('getReferenceFile')->will($this->returnValue($referenceFile));
+        $provider->expects($this->any())->method('getFormats')->will($this->returnValue($formats));
+        $provider->expects($this->any())->method('getResizer')->will($this->returnValue($resizer));
+        $provider->expects($this->any())->method('generatePrivateUrl')->will($this->returnValue('/my/private/path'));
+        $provider->expects($this->any())->method('generatePublicUrl')->will($this->returnValue('/my/public/path'));
+        $provider->expects($this->any())->method('getFilesystem')->will($this->returnValue($filesystem));
+
+        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media->expects($this->any())->method('getContext')->will($this->returnValue('mycontext'));
+        $media->expects($this->any())->method('getExtension')->will($this->returnValue('png'));
+
+        $thumbnail->generate($provider, $media);
+    }
+}

--- a/Thumbnail/LiipImagineThumbnail.php
+++ b/Thumbnail/LiipImagineThumbnail.php
@@ -11,23 +11,23 @@
 
 namespace Sonata\MediaBundle\Thumbnail;
 
+use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
-use Symfony\Component\Routing\RouterInterface;
 
 class LiipImagineThumbnail implements ThumbnailInterface
 {
     /**
-     * @var RouterInterface
+     * @var CacheManager
      */
-    protected $router;
+    private $cacheManager;
 
     /**
-     * @param RouterInterface $router
+     * @param CacheManager $cacheManager
      */
-    public function __construct(RouterInterface $router)
+    public function __construct(CacheManager $cacheManager)
     {
-        $this->router = $router;
+        $this->cacheManager = $cacheManager;
     }
 
     /**
@@ -35,16 +35,15 @@ class LiipImagineThumbnail implements ThumbnailInterface
      */
     public function generatePublicUrl(MediaProviderInterface $provider, MediaInterface $media, $format)
     {
-        if (MediaProviderInterface::FORMAT_REFERENCE === $format) {
-            $path = $provider->getReferenceImage($media);
-        } else {
-            $path = $this->router->generate(
-                sprintf('_imagine_%s', $format),
-                array('path' => sprintf('%s/%s_%s.jpg', $provider->generatePath($media), $media->getId(), $format))
-            );
+        $path = $provider->getReferenceImage($media);
+
+        if (MediaProviderInterface::FORMAT_ADMIN === $format || MediaProviderInterface::FORMAT_REFERENCE === $format) {
+            return $path;
         }
 
-        return $provider->getCdnPath($path, $media->getCdnIsFlushable());
+        $path = $provider->getCdnPath($path, $media->getCdnIsFlushable());
+
+        return $this->cacheManager->getBrowserPath($path, $format);
     }
 
     /**

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -9,6 +9,11 @@ UPGRADE FROM 3.4 to 3.5
 Sonata\MediaBundle\DependencyInjection\Compiler\AddProviderCompilerPass::fixSettings($container)
 is deprecated. Please avoid using this method, use ``getExtensionConfig($container)`` instead.
 
+Sonata\MediaBundle\Controller\Controller\MediaController::liipImagineFilterAction($path, $filter)
+is deprecated. Please avoid using this method.
+If you define controller_action in liip_imagine configs please remove it.
+
+
 UPGRADE FROM 3.2 to 3.3
 =======================
 

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "symfony/phpunit-bridge": "^2.7 || ^3.0"
     },
     "suggest": {
-        "liip/imagine-bundle": "^0.9",
+        "liip/imagine-bundle": "If you want on-the-fly thumbnail generation or image filtering (scale, crop, watermark...)",
         "rackspace/php-opencloud": "^1.6",
         "sonata-project/classification-bundle": "If you want to categorize your media items.",
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",


### PR DESCRIPTION
I am targeting this branch, because, The LiipImagine dependency being used is outdated and no longer maintained. Actually i fixed relative image paths


## Changelog

```markdown
### Fixed
- LiipImagine generatePublicUrl updated to work with latest version of that bundle
- Relative path when path it is already an url
```