### PR TITLE
Move to https on Youtube urls

### DIFF
--- a/Provider/YouTubeProvider.php
+++ b/Provider/YouTubeProvider.php
@@ -202,7 +202,7 @@ class YouTubeProvider extends BaseVideoProvider
      */
     public function updateMetadata(MediaInterface $media, $force = false)
     {
-        $url = sprintf('http://www.youtube.com/oembed?url=%s&format=json', $this->getReferenceUrl($media));
+        $url = sprintf('https://www.youtube.com/oembed?url=%s&format=json', $this->getReferenceUrl($media));
 
         try {
             $metadata = $this->getMetadata($media, $url);
@@ -242,7 +242,7 @@ class YouTubeProvider extends BaseVideoProvider
      */
     public function getReferenceUrl(MediaInterface $media)
     {
-        return sprintf('http://www.youtube.com/watch?v=%s', $media->getProviderReference());
+        return sprintf('https://www.youtube.com/watch?v=%s', $media->getProviderReference());
     }
 
     /**

--- a/Tests/Provider/YouTubeProviderTest.php
+++ b/Tests/Provider/YouTubeProviderTest.php
@@ -215,6 +215,6 @@ class YouTubeProviderTest extends AbstractProviderTest
     {
         $media = new Media();
         $media->setProviderReference('123456');
-        $this->assertEquals('http://www.youtube.com/watch?v=123456', $this->getProvider()->getReferenceUrl($media));
+        $this->assertEquals('https://www.youtube.com/watch?v=123456', $this->getProvider()->getReferenceUrl($media));
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Change Youtube urls to use https
```

## Subject

<!-- Describe your Pull Request content here -->
Youtube urls for fetching metadata and referenceUrl were using http. It is preferable to just use https.

Not sure if patch or pedantic