### PR TITLE
Pool#validate requires ErrorElement from AdminBundle

### DIFF
--- a/Resources/config/validation.xml
+++ b/Resources/config/validation.xml
@@ -10,7 +10,7 @@
                 <value>isStatusErroneous</value>
             </option>
         </constraint>
-        <constraint name="Sonata\CoreBundle\Validator\Constraints\InlineConstraint" >
+        <constraint name="Sonata\AdminBundle\Validator\Constraints\InlineConstraint" >
             <option name="service">sonata.media.pool</option>
             <option name="method">validate</option>
         </constraint>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because the issue appears in 2.3.4 version.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

### Fixed

- Fixed TypeError in `Pool#validate`

## Subject

Fix TypeError in `Pool#validate` by changing `validation.xml`
