### PR TITLE
Fix #1107: Catch exception preventing correct handling of upload errors

### DIFF
--- a/Form/DataTransformer/ServiceProviderDataTransformer.php
+++ b/Form/DataTransformer/ServiceProviderDataTransformer.php
@@ -11,11 +11,14 @@
 
 namespace Sonata\MediaBundle\Form\DataTransformer;
 
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Symfony\Component\Form\DataTransformerInterface;
 
-class ServiceProviderDataTransformer implements DataTransformerInterface
+class ServiceProviderDataTransformer implements DataTransformerInterface, LoggerAwareInterface
 {
     /**
      * @var MediaProviderInterface
@@ -23,11 +26,30 @@ class ServiceProviderDataTransformer implements DataTransformerInterface
     protected $provider;
 
     /**
+     * NEXT_MAJOR: When switching to PHP 5.4+, replace by LoggerAwareTrait.
+     *
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @param MediaProviderInterface $provider
      */
     public function __construct(MediaProviderInterface $provider)
     {
         $this->provider = $provider;
+
+        $this->logger = new NullLogger();
+    }
+
+    /**
+     * NEXT_MAJOR: When switching to PHP 5.4+, replace by LoggerAwareTrait.
+     *
+     * @param LoggerInterface $logger
+     */
+    public function setLogger(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
     }
 
     /**
@@ -47,7 +69,17 @@ class ServiceProviderDataTransformer implements DataTransformerInterface
             return $media;
         }
 
-        $this->provider->transform($media);
+        try {
+            $this->provider->transform($media);
+        } catch (\Exception $e) { // NEXT_MAJOR: When switching to PHP 7+, change this to \Throwable
+            // #1107 We must never throw an exception here.
+            // An exception here would prevent us to provide meaningful errors through the Form
+            // Error message taken from Monolog\ErrorHandler
+            $this->logger->error(
+                sprintf('Caught Exception %s: "%s" at %s line %s', get_class($e), $e->getMessage(), $e->getFile(), $e->getLine()),
+                array('exception' => $e)
+            );
+        }
 
         return $media;
     }

--- a/Form/Type/ApiMediaType.php
+++ b/Form/Type/ApiMediaType.php
@@ -11,6 +11,9 @@
 
 namespace Sonata\MediaBundle\Form\Type;
 
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Sonata\MediaBundle\Form\DataTransformer\ProviderDataTransformer;
 use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Component\Form\AbstractType;
@@ -21,7 +24,7 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-class ApiMediaType extends AbstractType
+class ApiMediaType extends AbstractType implements LoggerAwareInterface
 {
     /**
      * @var Pool
@@ -34,6 +37,13 @@ class ApiMediaType extends AbstractType
     protected $class;
 
     /**
+     * NEXT_MAJOR: When switching to PHP 5.4+, replace by LoggerAwareTrait.
+     *
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @param Pool   $mediaPool
      * @param string $class
      */
@@ -41,6 +51,17 @@ class ApiMediaType extends AbstractType
     {
         $this->mediaPool = $mediaPool;
         $this->class = $class;
+        $this->logger = new NullLogger();
+    }
+
+    /**
+     * NEXT_MAJOR: When switching to PHP 5.4+, replace by LoggerAwareTrait.
+     *
+     * @param LoggerInterface $logger
+     */
+    public function setLogger(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
     }
 
     /**
@@ -48,9 +69,12 @@ class ApiMediaType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->addModelTransformer(new ProviderDataTransformer($this->mediaPool, $this->class, array(
+        $dataTransformer = new ProviderDataTransformer($this->mediaPool, $this->class, array(
             'empty_on_new' => false,
-        )), true);
+        ));
+        $dataTransformer->setLogger($this->logger);
+
+        $builder->addModelTransformer($dataTransformer, true);
 
         $provider = $this->mediaPool->getProvider($options['provider_name']);
         $provider->buildMediaType($builder);

--- a/Resources/config/api_form_doctrine_mongodb.xml
+++ b/Resources/config/api_form_doctrine_mongodb.xml
@@ -13,6 +13,10 @@
             <tag name="form.type" alias="sonata_media_api_form_media"/>
             <argument type="service" id="sonata.media.pool"/>
             <argument>%sonata.media.admin.media.entity%</argument>
+            <call method="setLogger">
+                <argument type="service" id="logger" on-invalid="ignore"/>
+                <!-- NEXT_MAJOR: make symfony/monolog-bundle a require dependency and remove on-invalid here -->
+            </call>
         </service>
         <service id="sonata.media.api.form.type.gallery" class="Sonata\MediaBundle\Form\Type\ApiGalleryType">
             <tag name="form.type" alias="sonata_media_api_form_gallery"/>

--- a/Resources/config/api_form_doctrine_orm.xml
+++ b/Resources/config/api_form_doctrine_orm.xml
@@ -13,6 +13,10 @@
             <tag name="form.type" alias="sonata_media_api_form_media"/>
             <argument type="service" id="sonata.media.pool"/>
             <argument>%sonata.media.admin.media.entity%</argument>
+            <call method="setLogger">
+                <argument type="service" id="logger" on-invalid="ignore"/>
+                <!-- NEXT_MAJOR: make symfony/monolog-bundle a require dependency and remove on-invalid here -->
+            </call>
         </service>
         <service id="sonata.media.api.form.type.gallery" class="Sonata\MediaBundle\Form\Type\ApiGalleryType">
             <tag name="form.type" alias="sonata_media_api_form_gallery"/>

--- a/Resources/config/api_form_doctrine_phpcr.xml
+++ b/Resources/config/api_form_doctrine_phpcr.xml
@@ -13,6 +13,10 @@
             <tag name="form.type" alias="sonata_media_api_form_media"/>
             <argument type="service" id="sonata.media.pool"/>
             <argument>%sonata.media.admin.media.entity%</argument>
+            <call method="setLogger">
+                <argument type="service" id="logger" on-invalid="ignore"/>
+                <!-- NEXT_MAJOR: make symfony/monolog-bundle a require dependency and remove on-invalid here -->
+            </call>
         </service>
         <service id="sonata.media.api.form.type.gallery" class="Sonata\MediaBundle\Form\Type\ApiGalleryType">
             <tag name="form.type" alias="sonata_media_api_form_gallery"/>

--- a/Resources/config/form.xml
+++ b/Resources/config/form.xml
@@ -5,6 +5,10 @@
             <tag name="form.type" alias="sonata_media_type"/>
             <argument type="service" id="sonata.media.pool"/>
             <argument/>
+            <call method="setLogger">
+                <argument type="service" id="logger" on-invalid="ignore"/>
+                <!-- NEXT_MAJOR: make symfony/monolog-bundle a require dependency and remove on-invalid here -->
+            </call>
         </service>
     </services>
 </container>

--- a/Tests/Form/DataTransformer/ServiceProviderDataTransformerTest.php
+++ b/Tests/Form/DataTransformer/ServiceProviderDataTransformerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\Form\DataTransformer;
+
+use Prophecy\Argument;
+use Sonata\MediaBundle\Form\DataTransformer\ServiceProviderDataTransformer;
+use Sonata\MediaBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
+
+class ServiceProviderDataTransformerTest extends PHPUnit_Framework_TestCase
+{
+    public function testTransformNoop()
+    {
+        $provider = $this->prophesize('Sonata\MediaBundle\Provider\MediaProviderInterface');
+
+        $transformer = new ServiceProviderDataTransformer($provider->reveal());
+
+        $value = new \stdClass();
+        $this->assertSame($value, $transformer->transform($value));
+    }
+
+    public function testReverseTransformSkipsProviderIfNotMedia()
+    {
+        $provider = $this->prophesize('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider->transform()->shouldNotBeCalled();
+
+        $transformer = new ServiceProviderDataTransformer($provider->reveal());
+
+        $media = new \stdClass();
+        $this->assertSame($media, $transformer->reverseTransform($media));
+    }
+
+    public function testReverseTransformForwardsToProvider()
+    {
+        $media = $this->prophesize('Sonata\MediaBundle\Model\MediaInterface')->reveal();
+
+        $provider = $this->prophesize('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider->transform(Argument::is($media))->shouldBeCalledTimes(1);
+
+        $transformer = new ServiceProviderDataTransformer($provider->reveal());
+        $this->assertSame($media, $transformer->reverseTransform($media));
+    }
+
+    public function testReverseTransformWithThrowingProviderNoThrow()
+    {
+        $media = $this->prophesize('Sonata\MediaBundle\Model\MediaInterface')->reveal();
+
+        $provider = $this->prophesize('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider->transform(Argument::is($media))->shouldBeCalled()->willThrow(new \Exception());
+
+        $transformer = new ServiceProviderDataTransformer($provider->reveal());
+        $transformer->reverseTransform($media);
+    }
+
+    public function testReverseTransformWithThrowingProviderLogsException()
+    {
+        $media = $this->prophesize('Sonata\MediaBundle\Model\MediaInterface')->reveal();
+
+        $exception = new \Exception('foo');
+        $provider = $this->prophesize('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider->transform(Argument::is($media))->shouldBeCalled()->willThrow($exception);
+
+        $logger = $this->prophesize('Psr\Log\LoggerInterface');
+        $logger->error(
+            Argument::containingString('Caught Exception Exception: "foo" at'),
+            Argument::is(array('exception' => $exception))
+        )->shouldBeCalled();
+
+        $transformer = new ServiceProviderDataTransformer($provider->reveal());
+        $transformer->setLogger($logger->reveal());
+        $transformer->reverseTransform($media);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "jms/serializer-bundle": "^0.13 || ^1.0",
         "knplabs/gaufrette": "^0.1.6 || ^0.2 || ^0.3",
         "kriswallsmith/buzz": "^0.15",
+        "psr/log": "^1.0",
         "sonata-project/core-bundle": "^3.2",
         "sonata-project/doctrine-extensions": "^1.0",
         "sonata-project/easy-extends-bundle": "^2.2",
@@ -64,6 +65,7 @@
         "sonata-project/classification-bundle": "If you want to categorize your media items.",
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
         "sonata-project/seo-bundle": "^2.1",
+        "symfony/monolog-bundle": "^2.4",
         "tilleuls/ckeditor-sonata-media-bundle": "^1.0"
     },
     "conflict": {


### PR DESCRIPTION
I am targeting this branch (3.x), because this a fix for #1107 (and as per @jordisala1991's request).

Closes #1107. Before this PR, when there was an upload error (e.g., file too large), the DataTransformer was throwing an exception which was preventing the form from ever reaching the validation step. This was triggering a 500 Response instead of a 200 with a Form Error.

## Changelog
```markdown
### Changed
- The DataTransformers and MediaTypes (both standard and API) now depend on `Psr\Log\LoggerInterface` in order to log any exception that could arise from `$provider->transform()`

### Added
- Optional dependency on `@logger`. If the service is unavailable the exception will be silently caught and discarded.

### Fixed
- Now we have form errors when uploaded files are too big!
```

## Subject

Error message on upload fail (most of all, file too big).