### PR TITLE
Allow non SSL pixlr url return

### DIFF
--- a/Extra/Pixlr.php
+++ b/Extra/Pixlr.php
@@ -90,7 +90,7 @@ class Pixlr
         $this->container = $container;
 
         $this->validFormats = array('jpg', 'jpeg', 'png');
-        $this->allowEreg = '@https://([a-zA-Z0-9]*).pixlr.com/_temp/[0-9a-z]{24}\.[a-z]*@';
+        $this->allowEreg = '@https?://([a-zA-Z0-9]*).pixlr.com/_temp/[0-9a-z]{24}\.[a-z]*@';
     }
 
     /**


### PR DESCRIPTION
Working with SonataMediaBundle under a https protocol make pixrl url http://apps.pixlr.com not compatible with the platform.

## Changelog

```markdown
### Fixed
- fix protocol error from image url returned by pixlr when sonata is under https protocol
```
## Subject
Allow non SSL pixlr url return