### PR TITLE
Fixed some hardcoded paths related to integration with SonataEasyExtendsBundle

### DIFF
--- a/Resources/config/doctrine/Gallery.mongodb.xml.skeleton
+++ b/Resources/config/doctrine/Gallery.mongodb.xml.skeleton
@@ -11,7 +11,7 @@
             xml mapping          : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/xml-mapping/en
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
-    <document name="Application\Sonata\MediaBundle\Document\Gallery" >
+    <document name="{{ namespace }}\Document\Gallery" >
         <field fieldName="id" id="true" />
     </document>
 </doctrine-mongo-mapping>

--- a/Resources/config/doctrine/Gallery.orm.xml.skeleton
+++ b/Resources/config/doctrine/Gallery.orm.xml.skeleton
@@ -9,7 +9,7 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
     <entity
-        name="Application\Sonata\MediaBundle\Entity\Gallery"
+        name="{{ namespace }}\Entity\Gallery"
         table="media__gallery"
         >
 

--- a/Resources/config/doctrine/Gallery.phpcr.xml.skeleton
+++ b/Resources/config/doctrine/Gallery.phpcr.xml.skeleton
@@ -14,8 +14,8 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
 
-    <document name="Application\Sonata\MediaBundle\PHPCR\Gallery"
-              repository-class="Application\Sonata\MediaBundle\PHPCR\GalleryRepository">
+    <document name="{{ namespace }}\PHPCR\Gallery"
+              repository-class="{{ namespace }}\PHPCR\GalleryRepository">
 
         <id name="id">
             <generator strategy="REPOSITORY" />

--- a/Resources/config/doctrine/GalleryHasMedia.orm.xml.skeleton
+++ b/Resources/config/doctrine/GalleryHasMedia.orm.xml.skeleton
@@ -9,7 +9,7 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
     <entity
-        name="Application\Sonata\MediaBundle\Entity\GalleryHasMedia"
+        name="{{ namespace }}\Entity\GalleryHasMedia"
         table="media__gallery_media"
         >
 

--- a/Resources/config/doctrine/GalleryHasMedia.phpcr.xml.skeleton
+++ b/Resources/config/doctrine/GalleryHasMedia.phpcr.xml.skeleton
@@ -14,14 +14,14 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
 
-    <document name="Application\Sonata\MediaBundle\PHPCR\GalleryHasMedia"
-              repository-class="Application\Sonata\MediaBundle\PHPCR\GalleryHasMediaRepository">
+    <document name="{{ namespace }}\PHPCR\GalleryHasMedia"
+              repository-class="{{ namespace }}\PHPCR\GalleryHasMediaRepository">
 
         <id name="id">
             <generator strategy="REPOSITORY" />
         </id>
 
-        <reference-many name="media" target-document="Application\Sonata\MediaBundle\PHPCR\Media" />
+        <reference-many name="media" target-document="{{ namespace }}\PHPCR\Media" />
 
     </document>
 

--- a/Resources/config/doctrine/Media.mongodb.xml.skeleton
+++ b/Resources/config/doctrine/Media.mongodb.xml.skeleton
@@ -11,7 +11,7 @@
             xml mapping          : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/xml-mapping/en
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
-    <document name="Application\Sonata\MediaBundle\Document\Media" >
+    <document name="{{ namespace }}\Document\Media" >
         <field fieldName="id" id="true" />
     </document>
 </doctrine-mongo-mapping>

--- a/Resources/config/doctrine/Media.orm.xml.skeleton
+++ b/Resources/config/doctrine/Media.orm.xml.skeleton
@@ -9,7 +9,7 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
     <entity
-        name="Application\Sonata\MediaBundle\Entity\Media"
+        name="{{ namespace }}\Entity\Media"
         table="media__media"
         >
 

--- a/Resources/config/doctrine/Media.phpcr.xml.skeleton
+++ b/Resources/config/doctrine/Media.phpcr.xml.skeleton
@@ -14,8 +14,8 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
 
-    <document name="Application\Sonata\MediaBundle\PHPCR\Media"
-              repository-class="Application\Sonata\MediaBundle\PHPCR\MediaRepository" >
+    <document name="{{ namespace }}\PHPCR\Media"
+              repository-class="{{ namespace }}\PHPCR\MediaRepository" >
 
         <id name="id">
             <generator strategy="REPOSITORY" />

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "kriswallsmith/buzz": "^0.15",
         "sonata-project/core-bundle": "^3.2",
         "sonata-project/doctrine-extensions": "^1.0",
-        "sonata-project/easy-extends-bundle": "^2.1",
+        "sonata-project/easy-extends-bundle": "^2.2",
         "sonata-project/notification-bundle": "^3.0",
         "symfony/config": "^2.3.9 || ^3.0",
         "symfony/console": "^2.3 || ^3.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because my patch is fixing the bug, arisen due to the hardcoded class-path.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed hardcoded paths to classes in `.xml.skeleton` files of config
```

## Subject

<!-- Describe your Pull Request content here -->
Fixed some hardroded paths, which become invalid after enabling '--namespace' option in SonataEasyExtendsBundle's last release (https://github.com/sonata-project/SonataEasyExtendsBundle/releases/tag/2.2.0).