### PR TITLE
Fix sonata_template_box templates compatibility with twig 2.0

### DIFF
--- a/src/Resources/translations/SonataMediaBundle.bg.xliff
+++ b/src/Resources/translations/SonataMediaBundle.bg.xliff
@@ -427,10 +427,6 @@
                 <source>sonata_media_gallery_index</source>
                 <target>Галерия</target>
             </trans-unit>
-            <trans-unit id="sonata_template_box_media_gallery_block">
-                <source>sonata_template_box_media_gallery_block</source>
-                <target>Това блокът на медиа галерията. Свободни сте да го промените по ваш вкус. </target>
-            </trans-unit>
             <trans-unit id="list.label_description">
                 <source>list.label_description</source>
                 <target>Описание</target>

--- a/src/Resources/translations/SonataMediaBundle.de.xliff
+++ b/src/Resources/translations/SonataMediaBundle.de.xliff
@@ -423,10 +423,6 @@
                 <source>sonata_media_gallery_index</source>
                 <target>Galerie</target>
             </trans-unit>
-            <trans-unit id="sonata_template_box_media_gallery_block">
-                <source>sonata_template_box_media_gallery_block</source>
-                <target>as ist ein Galerie Media Block den Sie überschreiben können.</target>
-            </trans-unit>
             <trans-unit id="list.label_description">
                 <source>list.label_description</source>
                 <target>Beschreibung</target>

--- a/src/Resources/translations/SonataMediaBundle.en.xliff
+++ b/src/Resources/translations/SonataMediaBundle.en.xliff
@@ -423,10 +423,6 @@
                 <source>sonata_media_gallery_index</source>
                 <target>Gallery</target>
             </trans-unit>
-            <trans-unit id="sonata_template_box_media_gallery_block">
-                <source>sonata_template_box_media_gallery_block</source>
-                <target>This is the gallery media block. Feel free to override it.</target>
-            </trans-unit>
             <trans-unit id="list.label_description">
                 <source>list.label_description</source>
                 <target>Description</target>

--- a/src/Resources/translations/SonataMediaBundle.es.xliff
+++ b/src/Resources/translations/SonataMediaBundle.es.xliff
@@ -407,10 +407,6 @@
                 <source>sonata_media_gallery_index</source>
                 <target>Galería</target>
             </trans-unit>
-            <trans-unit id="sonata_template_box_media_gallery_block">
-                <source>sonata_template_box_media_gallery_block</source>
-                <target>Este es el bloque media para la galería. Puedes sobreescribirlo cuando gustes.</target>
-            </trans-unit>
             <trans-unit id="list.label_description">
                 <source>list.label_description</source>
                 <target>Descripción</target>

--- a/src/Resources/translations/SonataMediaBundle.fa.xliff
+++ b/src/Resources/translations/SonataMediaBundle.fa.xliff
@@ -419,10 +419,6 @@
                 <source>sonata_media_gallery_index</source>
                 <target>گالری</target>
             </trans-unit>
-            <trans-unit id="sonata_template_box_media_gallery_block">
-                <source>sonata_template_box_media_gallery_block</source>
-                <target>می توانید این قسمت را تغییر دهید</target>
-            </trans-unit>
             <trans-unit id="list.label_description">
                 <source>list.label_description</source>
                 <target>توضیحات</target>

--- a/src/Resources/translations/SonataMediaBundle.fi.xliff
+++ b/src/Resources/translations/SonataMediaBundle.fi.xliff
@@ -423,10 +423,6 @@
                 <source>sonata_media_gallery_index</source>
                 <target>Galleria</target>
             </trans-unit>
-            <trans-unit id="sonata_template_box_media_gallery_block">
-                <source>sonata_template_box_media_gallery_block</source>
-                <target>Tämä on galleriamedia -blokki. Voit ylikirjoittaa tämän.</target>
-            </trans-unit>
             <trans-unit id="list.label_description">
                 <source>list.label_description</source>
                 <target>Kuvaus</target>

--- a/src/Resources/translations/SonataMediaBundle.fr.xliff
+++ b/src/Resources/translations/SonataMediaBundle.fr.xliff
@@ -431,10 +431,6 @@
                 <source>sonata_media_gallery_index</source>
                 <target>Galeries</target>
             </trans-unit>
-            <trans-unit id="sonata_template_box_media_gallery_block">
-                <source>sonata_template_box_media_gallery_block</source>
-                <target>Ceci est un bloc de galerie de médias. Vous pouvez le surcharger librement.</target>
-            </trans-unit>
             <trans-unit id="list.label_description">
                 <source>list.label_description</source>
                 <target>Description</target>

--- a/src/Resources/translations/SonataMediaBundle.hu.xliff
+++ b/src/Resources/translations/SonataMediaBundle.hu.xliff
@@ -407,10 +407,6 @@
                 <source>sonata_media_gallery_index</source>
                 <target>Galéria</target>
             </trans-unit>
-            <trans-unit id="sonata_template_box_media_gallery_block">
-                <source>sonata_template_box_media_gallery_block</source>
-                <target>Ez itt a galéria blokja. Bátran módosítsd.</target>
-            </trans-unit>
             <trans-unit id="list.label_description">
                 <source>list.label_description</source>
                 <target>Leírás</target>

--- a/src/Resources/translations/SonataMediaBundle.it.xliff
+++ b/src/Resources/translations/SonataMediaBundle.it.xliff
@@ -427,10 +427,6 @@
                 <source>sonata_media_gallery_index</source>
                 <target>Galleria</target>
             </trans-unit>
-            <trans-unit id="sonata_template_box_media_gallery_block">
-                <source>sonata_template_box_media_gallery_block</source>
-                <target>Questo è il blocco galleria. Il blocco può essere sovrascritto a piacimento.</target>
-            </trans-unit>
             <trans-unit id="list.label_description">
                 <source>list.label_description</source>
                 <target>Descrizione</target>

--- a/src/Resources/translations/SonataMediaBundle.ja.xliff
+++ b/src/Resources/translations/SonataMediaBundle.ja.xliff
@@ -391,10 +391,6 @@
                 <source>sonata_media_gallery_index</source>
                 <target>ギャラリー</target>
             </trans-unit>
-            <trans-unit id="sonata_template_box_media_gallery_block">
-                <source>sonata_template_box_media_gallery_block</source>
-                <target>This is the gallery media block. Feel free to override it.</target>
-            </trans-unit>
             <trans-unit id="list.label_description">
                 <source>list.label_description</source>
                 <target>説明</target>

--- a/src/Resources/translations/SonataMediaBundle.lt.xliff
+++ b/src/Resources/translations/SonataMediaBundle.lt.xliff
@@ -407,10 +407,6 @@
                 <source>sonata_media_gallery_index</source>
                 <target>sonata_media_gallery_index</target>
             </trans-unit>
-            <trans-unit id="sonata_template_box_media_gallery_block">
-                <source>sonata_template_box_media_gallery_block</source>
-                <target>This is the gallery media block. Feel free to override it.</target>
-            </trans-unit>
             <trans-unit id="list.label_description">
                 <source>list.label_description</source>
                 <target>list.label_description</target>

--- a/src/Resources/translations/SonataMediaBundle.nl.xliff
+++ b/src/Resources/translations/SonataMediaBundle.nl.xliff
@@ -423,10 +423,6 @@
                 <source>sonata_media_gallery_index</source>
                 <target>Galerijen</target>
             </trans-unit>
-            <trans-unit id="sonata_template_box_media_gallery_block">
-                <source>sonata_template_box_media_gallery_block</source>
-                <target>This is the gallery media block. Feel free to override it.</target>
-            </trans-unit>
             <trans-unit id="list.label_description">
                 <source>list.label_description</source>
                 <target>Beschrijving</target>

--- a/src/Resources/translations/SonataMediaBundle.pl.xliff
+++ b/src/Resources/translations/SonataMediaBundle.pl.xliff
@@ -407,10 +407,6 @@
                 <source>sonata_media_gallery_index</source>
                 <target>sonata_media_gallery_index</target>
             </trans-unit>
-            <trans-unit id="sonata_template_box_media_gallery_block">
-                <source>sonata_template_box_media_gallery_block</source>
-                <target>This is the gallery media block. Feel free to override it.</target>
-            </trans-unit>
             <trans-unit id="list.label_description">
                 <source>list.label_description</source>
                 <target>list.label_description</target>

--- a/src/Resources/translations/SonataMediaBundle.pt_BR.xliff
+++ b/src/Resources/translations/SonataMediaBundle.pt_BR.xliff
@@ -399,10 +399,6 @@
                 <source>sonata_media_gallery_index</source>
                 <target>sonata_media_gallery_index</target>
             </trans-unit>
-            <trans-unit id="sonata_template_box_media_gallery_block">
-                <source>sonata_template_box_media_gallery_block</source>
-                <target>This is the gallery media block. Feel free to override it.</target>
-            </trans-unit>
             <trans-unit id="list.label_description">
                 <source>list.label_description</source>
                 <target>list.label_description</target>

--- a/src/Resources/translations/SonataMediaBundle.ro.xliff
+++ b/src/Resources/translations/SonataMediaBundle.ro.xliff
@@ -423,10 +423,6 @@
                 <source>sonata_media_gallery_index</source>
                 <target>Galerie</target>
             </trans-unit>
-            <trans-unit id="sonata_template_box_media_gallery_block">
-                <source>sonata_template_box_media_gallery_block</source>
-                <target>Acesta este blocul galeriei media. Puteți să-l inlocuiți.</target>
-            </trans-unit>
             <trans-unit id="list.label_description">
                 <source>list.label_description</source>
                 <target>Descriere</target>

--- a/src/Resources/translations/SonataMediaBundle.ru.xliff
+++ b/src/Resources/translations/SonataMediaBundle.ru.xliff
@@ -407,10 +407,6 @@
                 <source>sonata_media_gallery_index</source>
                 <target>Галерея</target>
             </trans-unit>
-            <trans-unit id="sonata_template_box_media_gallery_block">
-                <source>sonata_template_box_media_gallery_block</source>
-                <target>Это блок медиа галереи. Вы легко можете его переопределить.</target>
-            </trans-unit>
             <trans-unit id="list.label_description">
                 <source>list.label_description</source>
                 <target>Описание</target>

--- a/src/Resources/translations/SonataMediaBundle.sl.xliff
+++ b/src/Resources/translations/SonataMediaBundle.sl.xliff
@@ -423,10 +423,6 @@
                 <source>sonata_media_gallery_index</source>
                 <target>Galerija</target>
             </trans-unit>
-            <trans-unit id="sonata_template_box_media_gallery_block">
-                <source>sonata_template_box_media_gallery_block</source>
-                <target>To je blok medijske galerije. Lahko ga prepišete.</target>
-            </trans-unit>
             <trans-unit id="list.label_description">
                 <source>list.label_description</source>
                 <target>Opis</target>

--- a/src/Resources/translations/SonataMediaBundle.uk.xliff
+++ b/src/Resources/translations/SonataMediaBundle.uk.xliff
@@ -371,10 +371,6 @@
                 <source>sonata_media_gallery_index</source>
                 <target>Галерея</target>
             </trans-unit>
-            <trans-unit id="sonata_template_box_media_gallery_block">
-                <source>sonata_template_box_media_gallery_block</source>
-                <target>Це галерея медіаблок. Можна перевизначити її</target>
-            </trans-unit>
             <trans-unit id="list.label_description">
                 <source>list.label_description</source>
                 <target>Опис</target>

--- a/src/Resources/views/Block/block_gallery.html.twig
+++ b/src/Resources/views/Block/block_gallery.html.twig
@@ -16,7 +16,7 @@ file that was distributed with this source code.
             <h3 class="sonata-media-block-media-title">{{ settings.title }}</h3>
         {% endif %}
 
-        {% sonata_template_box 'sonata_template_box_media_gallery_block' 'SonataMediaBundle' %}
+        {% sonata_template_box 'This is the gallery media block. Feel free to override it.' %}
 
         <div id="carousel-{{ block.id }}" class="carousel slide sonata-media-block-gallery-container"
              data-interval="{{ settings.pauseTime }}"


### PR DESCRIPTION
I am targeting this branch, because this fixes a bug with twig 2.0.

## Changelog

```markdown

### Fixed
- fixed bug against twig 2.0 as `translationBundle` cannot be null

```

## Subject

After upgrading to twig 2.0 I got some errors from following templates. 
As I understand ```sonata_template_box``` requires 2 parameters now in order to be compliant, so I added the translation domain in this PR to address the issue.

```
- The template "SonataMediaBundle:Gallery:index.html.twig" contains an error: Using "null" for the value of node "translationBundle" of "Sonata\CoreBundle\Twig\Node\TemplateBoxNode" is not supported. You must pass a Twig_Node instance.
- The template "SonataMediaBundle:Gallery:view.html.twig" contains an error: Using "null" for the value of node "translationBundle" of "Sonata\CoreBundle\Twig\Node\TemplateBoxNode" is not supported. You must pass a Twig_Node instance.
- The template "SonataMediaBundle:Media:view.html.twig" contains an error: Using "null" for the value of node "translationBundle" of "Sonata\CoreBundle\Twig\Node\TemplateBoxNode" is not supported. You must pass a Twig_Node instance.
```
