### PR TITLE
Separate the persistence backend configuration

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -63,9 +63,9 @@ Next, add the correct routing files:
             prefix: /media
 
 
-Then you must configure the interaction with the orm and add the mediaBundles settings:
+Then, you must configure the interaction with the persistence backend you picked:
 
-Doctrine ORM:
+If you picked Doctrine ORM:
 
 .. configuration-block::
 
@@ -84,7 +84,7 @@ Doctrine ORM:
                 types:
                     json: Sonata\Doctrine\Types\JsonType
 
-Doctrine PHPCR:
+If you picked Doctrine PHPCR:
 
 .. configuration-block::
 
@@ -98,6 +98,10 @@ Doctrine PHPCR:
                 mappings:
                     SonataMediaBundle:
                         prefix: Sonata\MediaBundle\PHPCR
+
+Once you have done that, you can configure the Media bundle itself:
+
+.. configuration-block::
 
     .. code-block:: yaml
 


### PR DESCRIPTION
People are confused because it looks as if the main configuration is
under the PHPCR section.

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is docs
