### PR TITLE
RemoveThumbsCommand dialog error fix

### DIFF
--- a/Command/CleanMediaCommand.php
+++ b/Command/CleanMediaCommand.php
@@ -13,7 +13,6 @@ namespace Sonata\MediaBundle\Command;
 
 use Sonata\MediaBundle\Provider\FileProvider;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
-use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/Tests/Command/RemoveThumbsCommandTest.php
+++ b/Tests/Command/RemoveThumbsCommandTest.php
@@ -1,0 +1,174 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\Command;
+
+use Gaufrette\Filesystem;
+use Sonata\MediaBundle\Command\RemoveThumbsCommand;
+use Sonata\MediaBundle\Model\MediaManagerInterface;
+use Sonata\MediaBundle\Provider\FileProvider;
+use Sonata\MediaBundle\Provider\Pool;
+use Sonata\MediaBundle\Tests\Entity\Media;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Filesystem\Tests\FilesystemTestCase;
+
+/**
+ * @author Anton Dyshkant <vyshkant@gmail.com>
+ *
+ * @requires function Symfony\Component\Console\Tester\CommandTester::setInputs
+ */
+final class RemoveThumbsCommandTest extends FilesystemTestCase
+{
+    /**
+     * @var ContainerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $container;
+
+    /**
+     * @var Application
+     */
+    private $application;
+
+    /**
+     * @var RemoveThumbsCommand
+     */
+    private $command;
+
+    /**
+     * @var CommandTester
+     */
+    private $tester;
+
+    /**
+     * @var Pool|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $pool;
+
+    /**
+     * @var MediaManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $mediaManager;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->container = $this->createMock(ContainerInterface::class);
+
+        $this->command = new RemoveThumbsCommand();
+        $this->command->setContainer($this->container);
+
+        $this->application = new Application();
+        $this->application->add($this->command);
+
+        $this->tester = new CommandTester($this->application->find('sonata:media:remove-thumbnails'));
+
+        $this->pool = $this->createMock(Pool::class);
+
+        $this->mediaManager = $this->createMock(MediaManagerInterface::class);
+
+        $this->container->expects($this->any())
+            ->method('get')
+            ->will($this->returnCallback(function ($id) {
+                switch ($id) {
+                    case 'sonata.media.pool':
+                        return $this->pool;
+                    case 'sonata.media.manager.media':
+                        return $this->mediaManager;
+                }
+
+                return;
+            }));
+    }
+
+    public function testExecuteWithoutArguments()
+    {
+        $this->filesystem->mkdir($this->workspace.DIRECTORY_SEPARATOR.'foo');
+        $this->filesystem->touch($this->workspace.DIRECTORY_SEPARATOR.'foo'.DIRECTORY_SEPARATOR.'thumb_1_foo.ext');
+        $this->filesystem->touch($this->workspace.DIRECTORY_SEPARATOR.'foo'.DIRECTORY_SEPARATOR.'thumb_2_bar.ext');
+
+        $context = [
+            'providers' => [],
+            'formats' => [],
+            'download' => [],
+        ];
+
+        $formats = [
+            'small' => [],
+        ];
+
+        $fileProvider = $this->createMock(FileProvider::class);
+
+        $fileProvider->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue('fooprovider'));
+        $fileProvider->expects($this->once())
+            ->method('getFormats')
+            ->will($this->returnValue($formats));
+        $fileProvider->expects($this->exactly(2))
+            ->method('removeThumbnails');
+        $fileProvider->expects($this->exactly(2))
+            ->method('getFilesystem')
+            ->will($this->returnValue($this->createMock(Filesystem::class)));
+
+        $this->pool->expects($this->once())
+            ->method('getContexts')
+            ->will($this->returnValue(['foo' => $context]));
+        $this->pool->expects($this->once())
+            ->method('getProviders')
+            ->will($this->returnValue(['fooprovider' => $fileProvider]));
+        $this->pool->expects($this->once())
+            ->method('getProvider')
+            ->will($this->returnValue($fileProvider));
+
+        $medias = [];
+
+        $media = new Media();
+        $media->setId(1);
+        $media->setName('foo');
+        $medias[] = $media;
+
+        $media = new Media();
+        $media->setId(2);
+        $media->setName('bar');
+        $medias[] = $media;
+
+        $findByReturnCallback = function (
+            array $criteria,
+            array $orderBy = null,
+            $limit = null,
+            $offset = null
+        ) use ($medias) {
+            if (null !== $offset && $offset > 0) {
+                return [];
+            }
+
+            return $medias;
+        };
+
+        $this->mediaManager->expects($this->exactly(2))
+            ->method('findBy')
+            ->will($this->returnCallback($findByReturnCallback));
+
+        $this->tester->setInputs(['fooprovider', 'foo', 'small']);
+
+        $statusCode = $this->tester->execute(['command' => $this->command->getName()]);
+
+        $this->assertStringEndsWith('Done (total medias processed: 2).'.PHP_EOL, $this->tester->getDisplay());
+
+        $this->assertSame(0, $statusCode);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "knplabs/gaufrette": "^0.1.6 || ^0.2 || ^0.3",
         "kriswallsmith/buzz": "^0.15",
         "psr/log": "^1.0",
+        "sensio/generator-bundle": "^3.1",
         "sonata-project/core-bundle": "^3.2",
         "sonata-project/doctrine-extensions": "^1.0",
         "sonata-project/easy-extends-bundle": "^2.2",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because my patch is fixing the bug existing in this branch.


<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1258 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Silent `sonata:media:remove-thumbnails` command when running this command without arguments.
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests

## Subject

I'have fixed the call to undefined helper 'dialog'. Intead of 'dialog' the 'question' helper is used.
