### PR TITLE
Remove Twig nodes from classes to compile

### DIFF
--- a/DependencyInjection/SonataMediaExtension.php
+++ b/DependencyInjection/SonataMediaExtension.php
@@ -542,9 +542,6 @@ class SonataMediaExtension extends Extension
             'Sonata\\MediaBundle\\Thumbnail\\FormatThumbnail',
             'Sonata\\MediaBundle\\Thumbnail\\ThumbnailInterface',
             'Sonata\\MediaBundle\\Twig\\Extension\\MediaExtension',
-            'Sonata\\MediaBundle\\Twig\\Node\\MediaNode',
-            'Sonata\\MediaBundle\\Twig\\Node\\PathNode',
-            'Sonata\\MediaBundle\\Twig\\Node\\ThumbnailNode',
         ));
     }
 


### PR DESCRIPTION
Twig nodes are template-compilation time only. There is no reason to inline them, they should be far from required all the time, isn't it?

## Changelog

Remove Twig nodes from classes to compile

