### PR TITLE
better formatting for code block in doc

### DIFF
--- a/Resources/doc/reference/amazon_s3.rst
+++ b/Resources/doc/reference/amazon_s3.rst
@@ -17,7 +17,7 @@ This is a sample config file to enable amazon S3 as a filesystem & provider:
     sonata_media:
         cdn:
             server:
-                path: http://%s3_bucket_name%.s3-website-%s3_region%.amazonaws.com
+                path: 'http://%s3_bucket_name%.s3-website-%s3_region%.amazonaws.com'
 
         providers:
             image:
@@ -26,13 +26,13 @@ This is a sample config file to enable amazon S3 as a filesystem & provider:
 
         filesystem:
             s3:
-                bucket:      %s3_bucket_name%
-                accessKey:   %s3_access_key%
-                secretKey:   %s3_secret_key%
-                region:      %s3_region%
-                version:     %s3_version% # latest by default (cf. https://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/configuration.html#version)
-                sdk_version: %s3_sdk_version% # 2 by default
+                bucket:      '%s3_bucket_name%'
+                accessKey:   '%s3_access_key%'
+                secretKey:   '%s3_secret_key%'
+                region:      '%s3_region%'
+                version:     '%s3_version%' # latest by default (cf. https://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/configuration.html#version)
+                sdk_version: '%s3_sdk_version%' # 2 by default
 
 
-Note: This bundle is currently using KNP Gaufrette as S3 adapter and the default sdk used is version 2.
+.. note:: This bundle is currently using KNP Gaufrette as S3 adapter and the default sdk used is version 2.
 Changes have been made in the bundle to allow you to use version 3, simply update `sdk_version` parameter for this.

--- a/Resources/doc/reference/amazon_s3.rst
+++ b/Resources/doc/reference/amazon_s3.rst
@@ -35,4 +35,4 @@ This is a sample config file to enable amazon S3 as a filesystem & provider:
 
 
 .. note:: This bundle is currently using KNP Gaufrette as S3 adapter and the default sdk used is version 2.
-Changes have been made in the bundle to allow you to use version 3, simply update `sdk_version` parameter for this.
+  Changes have been made in the bundle to allow you to use version 3, simply update `sdk_version` parameter for this.

--- a/Resources/doc/reference/amazon_s3.rst
+++ b/Resources/doc/reference/amazon_s3.rst
@@ -34,5 +34,7 @@ This is a sample config file to enable amazon S3 as a filesystem & provider:
                 sdk_version: '%s3_sdk_version%' # 2 by default
 
 
-.. note:: This bundle is currently using KNP Gaufrette as S3 adapter and the default sdk used is version 2.
-  Changes have been made in the bundle to allow you to use version 3, simply update `sdk_version` parameter for this.
+.. note:: 
+
+   This bundle is currently using KNP Gaufrette as S3 adapter and the default sdk used is version 2.
+   Changes have been made in the bundle to allow you to use version 3, simply update `sdk_version` parameter for this.

--- a/Resources/doc/reference/amazon_s3.rst
+++ b/Resources/doc/reference/amazon_s3.rst
@@ -3,12 +3,16 @@ Amazon S3
 
 In order to use Amazon S3, you will need to add the following dependency to your composer.json:
 
+.. code-block:: bash
+
     composer require aws/aws-sdk-php
 
 Configuration
 -------------
 
 This is a sample config file to enable amazon S3 as a filesystem & provider:
+
+.. code-block:: yaml
 
     sonata_media:
         cdn:


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because in v.2.x everything it's ok.


## Subject

In version 2.x code block was properly formatted ( https://github.com/sonata-project/SonataMediaBundle/blob/2.x/Resources/doc/reference/amazon_s3.rst) but in version 3.x was not.
