### PR TITLE
Fixed deleting a file if deleting throw the error.

### DIFF
--- a/Provider/BaseProvider.php
+++ b/Provider/BaseProvider.php
@@ -187,6 +187,13 @@ abstract class BaseProvider implements MediaProviderInterface
      */
     public function preRemove(MediaInterface $media)
     {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function postRemove(MediaInterface $media)
+    {
         $path = $this->getReferenceImage($media);
 
         if ($this->getFilesystem()->has($path)) {
@@ -196,13 +203,6 @@ abstract class BaseProvider implements MediaProviderInterface
         if ($this->requireThumbnails()) {
             $this->thumbnail->delete($this, $media);
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function postRemove(MediaInterface $media)
-    {
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is patch.

## Changelog
```markdown
### Fixed
- Prevent file from being removed if an error occurred while deleting its database entry.
```

## Subject

Moved deleting a file from file system from preRemove to postRemove.
Without it first deleting file and then trying to remove record. And if record, for example, has dependecies, it not deleted, but the file will already be deleted.
