### PR TITLE
Keep the old media asset untouched when using sonata_media_type

### DIFF
--- a/Form/DataTransformer/ProviderDataTransformer.php
+++ b/Form/DataTransformer/ProviderDataTransformer.php
@@ -116,6 +116,11 @@ class ProviderDataTransformer implements DataTransformerInterface, LoggerAwareIn
 
         $provider = $this->pool->getProvider($newMedia->getProviderName());
 
+        if ($media->getId() && $this->options['new_on_update']) {
+            // Prevent the provider reference from being erased
+            $media->setProviderReference($media->getPreviousProviderReference());
+        }
+
         try {
             $provider->transform($newMedia);
         } catch (\Exception $e) { // NEXT_MAJOR: When switching to PHP 7+, change this to \Throwable


### PR DESCRIPTION
I am targeting this branch, because it solve an issue when the `sonata_media_type ` form type is used with the option `new_on_update = true`.

Closes #974

## Changelog

```markdown
### Fixed

- If a media object is updated, keep the old media asset untouched when using `sonata_media_type` 
```

## To do

- [x] Add an upgrade note

## Subject

When the `sonata_media_type` form element is used and an entity is being updated, if a new image is uploaded, a new Media object is created (as expected) but the old Media object's image is also updated to the new image that was just uploaded, therefore ending up with two Media objects that look the same (although with different names).

I tested this with SonataMedia 2.3.1 and 3.6.0