### PR TITLE
Only add classes to compile on PHP < 7.0

### DIFF
--- a/DependencyInjection/SonataMediaExtension.php
+++ b/DependencyInjection/SonataMediaExtension.php
@@ -494,6 +494,10 @@ class SonataMediaExtension extends Extension
      */
     public function configureClassesToCompile()
     {
+        if (\PHP_VERSION_ID >= 70000) {
+            return;
+        }
+
         $this->addClassesToCompile(array(
             'Sonata\\MediaBundle\\CDN\\CDNInterface',
             'Sonata\\MediaBundle\\CDN\\CloudFront',


### PR DESCRIPTION
I am targeting this branch, because this fix a deprecation warning and is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- deprecation notices related to `addClassesToCompile`
```

## Subject

Only call addClassesToCompile on PHP < 7.0 since it is deprecated and doesn't improve performances with PHP >= 7.0
