### PR TITLE
Add default values in without __construct method

### DIFF
--- a/Model/GalleryHasMedia.php
+++ b/Model/GalleryHasMedia.php
@@ -26,7 +26,7 @@ abstract class GalleryHasMedia implements GalleryHasMediaInterface
     /**
      * @var int
      */
-    protected $position;
+    protected $position = 0;
 
     /**
      * @var \DateTime
@@ -41,16 +41,7 @@ abstract class GalleryHasMedia implements GalleryHasMediaInterface
     /**
      * @var bool
      */
-    protected $enabled;
-
-    /**
-     * Construct.
-     */
-    public function __construct()
-    {
-        $this->position = 0;
-        $this->enabled = false;
-    }
+    protected $enabled = false;
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
I am targeting this branch, because my little change is not a BC-break.

## Subject

Add default values in `GalleryHasMedia` model without `__construct` as `Media` model [does](https://github.com/sonata-project/SonataMediaBundle/blob/3.x/Model/Media.php).
With this little change no one needs to rewrite the `__construct` to setup different default `position` and `enabled` values.
[Default value in Doctrine](http://docs.doctrine-project.org/en/latest/reference/faq.html#how-can-i-add-default-values-to-a-column)

Thanks
