### PR TITLE
Take client-reported mimetype into consideration for setting content …

### DIFF
--- a/Provider/FileProvider.php
+++ b/Provider/FileProvider.php
@@ -401,7 +401,10 @@ class FileProvider extends BaseProvider
             $media->setProviderReference($this->generateReferenceName($media));
         }
 
-        if ($media->getBinaryContent() instanceof File) {
+        if ($media->getBinaryContent() instanceof UploadedFile) {
+            $media->setContentType($media->getBinaryContent()->getClientMimeType());
+            $media->setSize($media->getBinaryContent()->getSize());
+        } elseif ($media->getBinaryContent() instanceof File) {
             $media->setContentType($media->getBinaryContent()->getMimeType());
             $media->setSize($media->getBinaryContent()->getSize());
         }

--- a/Provider/FileProvider.php
+++ b/Provider/FileProvider.php
@@ -401,12 +401,14 @@ class FileProvider extends BaseProvider
             $media->setProviderReference($this->generateReferenceName($media));
         }
 
-        if ($media->getBinaryContent() instanceof UploadedFile) {
-            $media->setContentType($media->getBinaryContent()->getClientMimeType());
+        if ($media->getBinaryContent() instanceof File) {
             $media->setSize($media->getBinaryContent()->getSize());
-        } elseif ($media->getBinaryContent() instanceof File) {
-            $media->setContentType($media->getBinaryContent()->getMimeType());
-            $media->setSize($media->getBinaryContent()->getSize());
+
+            if ($media->getBinaryContent() instanceof UploadedFile) {
+                $media->setContentType($media->getBinaryContent()->getClientMimeType());
+            } else {
+                $media->setContentType($media->getBinaryContent()->getMimeType());
+            }
         }
 
         $media->setProviderStatus(MediaInterface::STATUS_OK);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this fixes a bug where SVG file uploads were identified as having "text/html" Content Type.

In case of bug fix, `3.x` **MUST** be targeted.

## Changelog

```markdown
### Fixed
Client / browser reported mimetype of uploaded files was being ignored leading to misidentified media item content types for plain text files (SVG for example).
```

## Subject

Added a check for `UploadedFile` and use that class's `getClientMimeType` method to identify the file type instead of simply using `getMimeType` method of `File` which is unable to correctly identify plain text files like `text/css` or `image/svg+xml` for example and was resulting in `text/html` being used incorrectly.
