### PR TITLE
Use SonataAdminBundle configuration to configure bundle services

### DIFF
--- a/Resources/config/security.xml
+++ b/Resources/config/security.xml
@@ -11,10 +11,7 @@
             <argument type="service" id="translator"/>
             <argument/>
             <!-- Either security.context or security.authorization_checker -->
-            <argument type="collection">
-                <argument>ROLE_SUPER_ADMIN</argument>
-                <argument>ROLE_ADMIN</argument>
-            </argument>
+            <argument type="collection"/>
         </service>
         <service id="sonata.media.security.session_strategy" class="Sonata\MediaBundle\Security\SessionDownloadStrategy">
             <argument type="service" id="translator"/>

--- a/Resources/doc/reference/security.rst
+++ b/Resources/doc/reference/security.rst
@@ -7,10 +7,12 @@ a download strategy interface, which can be set per context and authorize the me
 
 Built-in security strategy:
 
-* ``sonata.media.security.superadmin_strategy`` : DEFAULT - the user need to have one of the following roles : ``ROLE_SUPER_ADMIN`` or ``ROLE_ADMIN``
+* ``sonata.media.security.superadmin_strategy`` : DEFAULT - the user needs to have one of the following roles :
+  ``ROLE_SUPER_ADMIN`` or ``ROLE_ADMIN`` (although these roles can be configured in SonataAdminBundle)
 * ``sonata.media.security.public_strategy`` : no restriction, files are public
 * ``sonata.media.security.forbidden_strategy`` : not possible to retrieve the original file
-* ``sonata.media.security.connected_strategy`` : the need to have one of the following roles : ``IS_AUTHENTICATED_FULLY`` or ``IS_AUTHENTICATED_REMEMBERED``
+* ``sonata.media.security.connected_strategy`` : the need to have one of the following roles :
+  ``IS_AUTHENTICATED_FULLY`` or ``IS_AUTHENTICATED_REMEMBERED``
 
 On top of that, there is 3 download modes which can be configured to download the media. The download mode depends on
 the HTTP server you used:


### PR DESCRIPTION
I am targeting this branch, because this PR make SonataMediaBundle compatible with configurable roles (see subject section).

## Changelog

```markdown
### Changed
- Use SonataAdminBundle configuration to configure bundle services
```

## Subject

This PR is related to https://github.com/sonata-project/SonataAdminBundle/pull/4548. We are introducing the ability to configure sonata "main" roles under the section `security` of SonataAdminBundle.

Without this PR, changing the SonataAdminBundle `ROLE_SUPER_ADMIN` to something else will break the role-based media download strategy.

No breaking changes are introduced and this may be merged at anytime.