### PR TITLE
Fix unit test warning if Twig 2.x is used

### DIFF
--- a/Tests/Twig/Extension/MediaExtensionTest.php
+++ b/Tests/Twig/Extension/MediaExtensionTest.php
@@ -24,7 +24,7 @@ class MediaExtensionTest extends PHPUnit_Framework_TestCase
     private $provider;
 
     /**
-     * @var Twig_TemplateInterface
+     * @var Twig_Template
      */
     private $template;
 
@@ -101,7 +101,10 @@ class MediaExtensionTest extends PHPUnit_Framework_TestCase
     public function getTemplate()
     {
         if (is_null($this->template)) {
-            $this->template = $this->createMock('Twig_TemplateInterface');
+            $this->template = $this->getMockBuilder('Twig_Template')
+                                   ->disableOriginalConstructor()
+                                   ->setMethods(array('render'))
+                                   ->getMockForAbstractClass();
         }
 
         return $this->template;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is bug fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->
There is no need to describe this in changelog

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Make it work on PHP <= 5.5

## Subject

<!-- Describe your Pull Request content here -->
`Twig_TemplateInterface` is deprecated since Twig 1.12 and removed in Twig 2.0. Composer require minimum Twig 1.28 so it is ok. Fix warning in PHP 7.x platform tests where Twig 2 is used (because require PHP 7.x).
```
There was 1 warning:

1) MediaExtensionTest::testThumbnailHasAllNecessaryAttributes
Cannot stub or mock class or interface "Twig_TemplateInterface" which does not exist
```