### PR TITLE
Drop old versions of php/sf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
+        "php": "^7.1",
         "imagine/imagine": "^0.6",
         "jms/serializer-bundle": "^0.13 || ^1.0 || ^2.0",
         "knplabs/gaufrette": "^0.1.6 || ^0.2 || ^0.3",
@@ -27,21 +27,21 @@
         "sonata-project/doctrine-extensions": "^1.0",
         "sonata-project/easy-extends-bundle": "^2.2",
         "sonata-project/notification-bundle": "^3.0",
-        "symfony/config": "^2.3.9 || ^3.0",
-        "symfony/console": "^2.3 || ^3.0",
-        "symfony/dependency-injection": "^2.3.3 || ^3.0",
-        "symfony/event-dispatcher": "^2.3 || ^3.0",
-        "symfony/filesystem": "^2.3 || ^3.0",
-        "symfony/finder": "^2.3 || ^3.0",
-        "symfony/form": "^2.3.5 || ^3.0",
-        "symfony/http-foundation": "^2.3 || ^3.0",
-        "symfony/http-kernel": "^2.3 || ^3.0",
-        "symfony/options-resolver": "^2.3 || ^3.0",
-        "symfony/routing": "^2.3 || ^3.0",
-        "symfony/security":"^2.3 || ^3.0",
-        "symfony/templating":"^2.3 || ^3.0",
-        "symfony/translation": "^2.3 || ^3.0",
-        "symfony/validator": "^2.3 || ^3.0",
+        "symfony/config": "^2.8 || ^3.2",
+        "symfony/console": "^2.8 || ^3.2",
+        "symfony/dependency-injection": "^2.8 || ^3.2",
+        "symfony/event-dispatcher": "^2.8 || ^3.2",
+        "symfony/filesystem": "^2.8 || ^3.2",
+        "symfony/finder": "^2.8 || ^3.2",
+        "symfony/form": "^2.8 || ^3.2",
+        "symfony/http-foundation": "^2.8 || ^3.2",
+        "symfony/http-kernel": "^2.8 || ^3.2",
+        "symfony/options-resolver": "^2.8 || ^3.2",
+        "symfony/routing": "^2.8 || ^3.2",
+        "symfony/security":"^2.8 || ^3.2",
+        "symfony/templating":"^2.8 || ^3.2",
+        "symfony/translation": "^2.8 || ^3.2",
+        "symfony/validator": "^2.8 || ^3.2",
         "twig/twig": "^1.28 || ^2.0"
     },
     "require-dev": {
@@ -58,7 +58,7 @@
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
         "sonata-project/formatter-bundle": "^3.2",
         "sonata-project/seo-bundle": "^2.1",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0"
+        "symfony/phpunit-bridge": "^3.3"
     },
     "suggest": {
         "liip/imagine-bundle": "^0.9",
@@ -66,7 +66,7 @@
         "sonata-project/classification-bundle": "If you want to categorize your media items.",
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
         "sonata-project/seo-bundle": "^2.1",
-        "symfony/monolog-bundle": "^2.4",
+        "symfony/monolog-bundle": "If you want to log exceptions produced when dealing with images.",
         "tilleuls/ckeditor-sonata-media-bundle": "^1.0"
     },
     "conflict": {
@@ -75,7 +75,8 @@
         "sonata-project/block-bundle": "<3.1.1 || >=4.0",
         "sonata-project/classification-bundle": "<3.0 || >= 5.0",
         "sonata-project/formatter-bundle": "<3.2",
-        "sonata-project/seo-bundle": "<2.1 || >=3.0"
+        "sonata-project/seo-bundle": "<2.1 || >=3.0",
+        "symfony/monolog-bundle": "<2.4"
     },
     "autoload": {
         "psr-4": { "Sonata\\MediaBundle\\": "" },


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

```markdown
### Removed
- Support for old versions of php and Symfony.
```
