### PR TITLE
Sf3 compatbility fix for sync-thumbnails command

### DIFF
--- a/Command/SyncThumbsCommand.php
+++ b/Command/SyncThumbsCommand.php
@@ -89,9 +89,9 @@ class SyncThumbsCommand extends BaseCommand
         $fsRegister->setAccessible(true);
 
         $batchCounter = 0;
-        $batchSize = intval($input->getOption('batchSize'));
-        $batchesLimit = intval($input->getOption('batchesLimit'));
-        $startOffset = intval($input->getOption('startOffset'));
+        $batchSize = (int) $input->getOption('batchSize');
+        $batchesLimit = (int) $input->getOption('batchesLimit');
+        $startOffset = (int) $input->getOption('startOffset');
         $totalMediasCount = 0;
         do {
             ++$batchCounter;

--- a/Command/SyncThumbsCommand.php
+++ b/Command/SyncThumbsCommand.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
 
 /**
  * This command can be used to re-generate the thumbnails for all uploaded medias.
@@ -57,18 +58,24 @@ class SyncThumbsCommand extends BaseCommand
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
+        $helper = $this->getHelper('question');
+
         $providerName = $input->getArgument('providerName');
         if (null === $providerName) {
             $providers = array_keys($this->getMediaPool()->getProviders());
-            $providerKey = $this->getHelperSet()->get('dialog')->select($output, 'Please select the provider', $providers);
-            $providerName = $providers[$providerKey];
+            $question = new ChoiceQuestion('Please select the provider', $providers, 0);
+            $question->setErrorMessage('Provider %s is invalid.');
+
+            $providerName = $helper->ask($input, $output, $question);
         }
 
         $context = $input->getArgument('context');
         if (null === $context) {
             $contexts = array_keys($this->getMediaPool()->getContexts());
-            $contextKey = $this->getHelperSet()->get('dialog')->select($output, 'Please select the context', $contexts);
-            $context = $contexts[$contextKey];
+            $question = new ChoiceQuestion('Please select the context', $contexts, 0);
+            $question->setErrorMessage('Context %s is invalid.');
+
+            $context = $helper->ask($input, $output, $question);
         }
 
         $this->quiet = $input->getOption('quiet');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because of sf3 compatibility fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Sf3 compatibility on the sync-thumbnails command (dialog helper)

```

## Subject

We had some issues with our images after adding a new image format, but we can't run the command as we use sf 3.3
