### PR TITLE
getRuntime now receives a non deprecated runtime

### DIFF
--- a/Controller/GalleryAdminController.php
+++ b/Controller/GalleryAdminController.php
@@ -12,6 +12,9 @@
 namespace Sonata\MediaBundle\Controller;
 
 use Sonata\AdminBundle\Controller\CRUDController as Controller;
+use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -75,12 +78,11 @@ class GalleryAdminController extends Controller
         $twig = $this->get('twig');
 
         // BC for Symfony < 3.2 where this runtime does not exists
-        if (!method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
-            $twig->getExtension('Symfony\Bridge\Twig\Extension\FormExtension')
-                ->renderer->setTheme($formView, $theme);
+        if (!method_exists(AppVariable::class, 'getToken')) {
+            $twig->getExtension(FormExtension::class)->renderer->setTheme($formView, $theme);
 
             return;
         }
-        $twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')->setTheme($formView, $theme);
+        $twig->getRuntime(FormRenderer::class)->setTheme($formView, $theme);
     }
 }

--- a/Controller/MediaAdminController.php
+++ b/Controller/MediaAdminController.php
@@ -12,6 +12,9 @@
 namespace Sonata\MediaBundle\Controller;
 
 use Sonata\AdminBundle\Controller\CRUDController as Controller;
+use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -119,12 +122,11 @@ class MediaAdminController extends Controller
         $twig = $this->get('twig');
 
         // BC for Symfony < 3.2 where this runtime does not exists
-        if (!method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
-            $twig->getExtension('Symfony\Bridge\Twig\Extension\FormExtension')
-                ->renderer->setTheme($formView, $theme);
+        if (!method_exists(AppVariable::class, 'getToken')) {
+            $twig->getExtension(FormExtension::class)->renderer->setTheme($formView, $theme);
 
             return;
         }
-        $twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')->setTheme($formView, $theme);
+        $twig->getRuntime(FormRenderer::class)->setTheme($formView, $theme);
     }
 }

--- a/Tests/Controller/MediaAdminControllerTest.php
+++ b/Tests/Controller/MediaAdminControllerTest.php
@@ -14,6 +14,10 @@ namespace Sonata\MediaBundle\Tests\Controller;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sonata\MediaBundle\Controller\MediaAdminController;
+use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Bridge\Twig\Form\TwigRenderer;
+use Symfony\Component\Form\FormRenderer;
 
 class EntityWithGetId
 {
@@ -178,22 +182,21 @@ class MediaAdminControllerTest extends TestCase
     private function configureSetFormTheme($formView, $formTheme)
     {
         $twig = $this->prophesize('\Twig_Environment');
-        $twigRenderer = $this->prophesize('Symfony\Bridge\Twig\Form\TwigRenderer');
-
         $this->container->get('twig')->willReturn($twig->reveal());
 
         // Remove this trick when bumping Symfony requirement to 3.2+.
-        if (method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
-            $twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')->willReturn($twigRenderer->reveal());
+        if (method_exists(AppVariable::class, 'getToken')) {
+            $twigRenderer = $this->prophesize(FormRenderer::class);
+            $twig->getRuntime(FormRenderer::class)->willReturn($twigRenderer->reveal());
+            $twigRenderer->setTheme($formView, $formTheme)->shouldBeCalled();
         } else {
-            $formExtension = $this->prophesize('Symfony\Bridge\Twig\Extension\FormExtension');
+            $twigRenderer = $this->prophesize(TwigRenderer::class);
+            $formExtension = $this->prophesize(FormExtension::class);
             $formExtension->renderer = $twigRenderer->reveal();
 
-            // This Throw is for the CRUDController::setFormTheme()
-            $twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')->willThrow('\Twig_Error_Runtime');
-            $twig->getExtension('Symfony\Bridge\Twig\Extension\FormExtension')->willReturn($formExtension->reveal());
+            $twig->getExtension(FormExtension::class)->willReturn($formExtension->reveal());
+            $twigRenderer->setTheme($formView, $formTheme)->shouldBeCalled();
         }
-        $twigRenderer->setTheme($formView, $formTheme)->shouldBeCalled();
     }
 
     private function configureSetCsrfToken($intention)


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

This PR is a *follow up* of: https://github.com/sonata-project/SonataAdminBundle/pull/4749

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- getRuntime now receives a non deprecated runtime
```

## Subject

<!-- Describe your Pull Request content here -->
Using Symfony 3.4 I found that this code does not work:

`$twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')`

I have been looking at Symfony docs and found the following:

`Symfony\Bridge\Twig\Form\TwigRenderer` is deprecated since 3.4
http://api.symfony.com/3.4/Symfony/Bridge/Twig/Form/TwigRenderer.html

And we should use `Symfony/Component/Form/FormRenderer` that is present since 2.8:
http://api.symfony.com/3.4/Symfony/Component/Form/FormRenderer.html

We probably never face an issue on this bundle because it is on a try/catch block but there are other bundles that use if/else: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/Controller/GalleryAdminController.php#L78

Also I did remove try/catch, not a good idea to rely on exceptions to make your code work.

## Stack trace

This stack trace is from SonataMediaBundle, because there we don't have the try/catch block:

```
Twig_Error_Runtime:
Unable to load the "Symfony\Bridge\Twig\Form\TwigRenderer" runtime.

  at /home/ubuntu/vendor/twig/twig/lib/Twig/Environment.php:663
  at Twig_Environment->getRuntime('Symfony\\Bridge\\Twig\\Form\\TwigRenderer')
     (/home/ubuntu/vendor/sonata-project/media-bundle/Controller/MediaAdminController.php:128)
  at Sonata\MediaBundle\Controller\MediaAdminController->setFormTheme(object(FormView), array('SonataDoctrineORMAdminBundle:Form:filter_admin_fields.html.twig'))
     (/home/ubuntu/vendor/sonata-project/media-bundle/Controller/MediaAdminController.php:100)
  at Sonata\MediaBundle\Controller\MediaAdminController->listAction(object(Request))
  at call_user_func_array(array(object(MediaAdminController), 'listAction'), array(object(Request)))
     (/home/ubuntu/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php:153)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (/home/ubuntu/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php:68)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (/home/ubuntu/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (web/app_dev.php:13)
```