### PR TITLE
Use FormRenderer runtime to maintain compatibility with Symfony 3.4

### DIFF
--- a/src/Controller/GalleryAdminController.php
+++ b/src/Controller/GalleryAdminController.php
@@ -12,6 +12,11 @@
 namespace Sonata\MediaBundle\Controller;
 
 use Sonata\AdminBundle\Controller\CRUDController as Controller;
+use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Bridge\Twig\Command\DebugCommand;
+use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Bridge\Twig\Form\TwigRenderer;
+use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -75,20 +80,19 @@ class GalleryAdminController extends Controller
         $twig = $this->get('twig');
 
         // BC for Symfony < 3.2 where this runtime does not exists
-        if (!method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
-            $twig->getExtension('Symfony\Bridge\Twig\Extension\FormExtension')
-                ->renderer->setTheme($formView, $theme);
+        if (!method_exists(AppVariable::class, 'getToken')) {
+            $twig->getExtension(FormExtension::class)->renderer->setTheme($formView, $theme);
 
             return;
         }
 
-        // BC for Symfony < 3.4 which deprecated this runtime in favor of FormRenderer
-        if (!method_exists('Symfony\Bridge\Twig\Command\DebugCommand', 'getLoaderPaths')) {
-            $twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')->setTheme($formView, $theme);
+        // BC for Symfony < 3.4 where runtime should be TwigRenderer
+        if (!method_exists(DebugCommand::class, 'getLoaderPaths')) {
+            $twig->getRuntime(TwigRenderer::class)->setTheme($formView, $theme);
 
             return;
         }
 
-        $twig->getRuntime('Symfony\Component\Form\FormRenderer')->setTheme($formView, $theme);
+        $twig->getRuntime(FormRenderer::class)->setTheme($formView, $theme);
     }
 }

--- a/src/Controller/GalleryAdminController.php
+++ b/src/Controller/GalleryAdminController.php
@@ -81,6 +81,14 @@ class GalleryAdminController extends Controller
 
             return;
         }
-        $twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')->setTheme($formView, $theme);
+
+        // BC for Symfony < 3.4 which deprecated this runtime in favor of FormRenderer
+        if (!method_exists('Symfony\Bridge\Twig\Command\DebugCommand', 'getLoaderPaths')) {
+            $twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')->setTheme($formView, $theme);
+
+            return;
+        }
+
+        $twig->getRuntime('Symfony\Component\Form\FormRenderer')->setTheme($formView, $theme);
     }
 }

--- a/src/Controller/MediaAdminController.php
+++ b/src/Controller/MediaAdminController.php
@@ -125,6 +125,14 @@ class MediaAdminController extends Controller
 
             return;
         }
-        $twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')->setTheme($formView, $theme);
+
+        // BC for Symfony < 3.4 which deprecated this runtime in favor of FormRenderer
+        if (!method_exists('Symfony\Bridge\Twig\Command\DebugCommand', 'getLoaderPaths')) {
+            $twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')->setTheme($formView, $theme);
+
+            return;
+        }
+
+        $twig->getRuntime('Symfony\Component\Form\FormRenderer')->setTheme($formView, $theme);
     }
 }

--- a/src/Controller/MediaAdminController.php
+++ b/src/Controller/MediaAdminController.php
@@ -12,6 +12,11 @@
 namespace Sonata\MediaBundle\Controller;
 
 use Sonata\AdminBundle\Controller\CRUDController as Controller;
+use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Bridge\Twig\Command\DebugCommand;
+use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Bridge\Twig\Form\TwigRenderer;
+use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -119,20 +124,19 @@ class MediaAdminController extends Controller
         $twig = $this->get('twig');
 
         // BC for Symfony < 3.2 where this runtime does not exists
-        if (!method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
-            $twig->getExtension('Symfony\Bridge\Twig\Extension\FormExtension')
-                ->renderer->setTheme($formView, $theme);
+        if (!method_exists(AppVariable::class, 'getToken')) {
+            $twig->getExtension(FormExtension::class)->renderer->setTheme($formView, $theme);
 
             return;
         }
 
-        // BC for Symfony < 3.4 which deprecated this runtime in favor of FormRenderer
-        if (!method_exists('Symfony\Bridge\Twig\Command\DebugCommand', 'getLoaderPaths')) {
-            $twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')->setTheme($formView, $theme);
+        // BC for Symfony < 3.4 where runtime should be TwigRenderer
+        if (!method_exists(DebugCommand::class, 'getLoaderPaths')) {
+            $twig->getRuntime(TwigRenderer::class)->setTheme($formView, $theme);
 
             return;
         }
 
-        $twig->getRuntime('Symfony\Component\Form\FormRenderer')->setTheme($formView, $theme);
+        $twig->getRuntime(FormRenderer::class)->setTheme($formView, $theme);
     }
 }

--- a/tests/Controller/GalleryAdminControllerTest.php
+++ b/tests/Controller/GalleryAdminControllerTest.php
@@ -121,13 +121,21 @@ class GalleryAdminControllerTest extends TestCase
     private function configureSetFormTheme($formView, $formTheme)
     {
         $twig = $this->prophesize('\Twig_Environment');
-        $twigRenderer = $this->prophesize('Symfony\Bridge\Twig\Form\TwigRenderer');
+
+        // Remove this trick when bumping Symfony requirement to 3.4+
+        if (method_exists('Symfony\Bridge\Twig\Command\DebugCommand', 'getLoaderPaths')) {
+            $rendererClass = 'Symfony\Component\Form\FormRenderer';
+        } else {
+            $rendererClass = 'Symfony\Bridge\Twig\Form\TwigRenderer';
+        }
+
+        $twigRenderer = $this->prophesize($rendererClass);
 
         $this->container->get('twig')->willReturn($twig->reveal());
 
         // Remove this trick when bumping Symfony requirement to 3.2+.
         if (method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
-            $twig->getRuntime('Symfony\Bridge\Twig\Form\TwigRenderer')->willReturn($twigRenderer->reveal());
+            $twig->getRuntime($rendererClass)->willReturn($twigRenderer->reveal());
         } else {
             $formExtension = $this->prophesize('Symfony\Bridge\Twig\Extension\FormExtension');
             $formExtension->renderer = $twigRenderer->reveal();

--- a/tests/Controller/GalleryAdminControllerTest.php
+++ b/tests/Controller/GalleryAdminControllerTest.php
@@ -14,6 +14,11 @@ namespace Sonata\MediaBundle\Tests\Controller;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sonata\MediaBundle\Controller\GalleryAdminController;
+use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Bridge\Twig\Command\DebugCommand;
+use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Bridge\Twig\Form\TwigRenderer;
+use Symfony\Component\Form\FormRenderer;
 
 class GalleryAdminControllerTest extends TestCase
 {
@@ -120,13 +125,13 @@ class GalleryAdminControllerTest extends TestCase
 
     private function configureSetFormTheme($formView, $formTheme)
     {
-        $twig = $this->prophesize('\Twig_Environment');
+        $twig = $this->prophesize(\Twig_Environment::class);
 
         // Remove this trick when bumping Symfony requirement to 3.4+
-        if (method_exists('Symfony\Bridge\Twig\Command\DebugCommand', 'getLoaderPaths')) {
-            $rendererClass = 'Symfony\Component\Form\FormRenderer';
+        if (method_exists(DebugCommand::class, 'getLoaderPaths')) {
+            $rendererClass = FormRenderer::class;
         } else {
-            $rendererClass = 'Symfony\Bridge\Twig\Form\TwigRenderer';
+            $rendererClass = TwigRenderer::class;
         }
 
         $twigRenderer = $this->prophesize($rendererClass);
@@ -134,13 +139,13 @@ class GalleryAdminControllerTest extends TestCase
         $this->container->get('twig')->willReturn($twig->reveal());
 
         // Remove this trick when bumping Symfony requirement to 3.2+.
-        if (method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
+        if (method_exists(AppVariable::class, 'getToken')) {
             $twig->getRuntime($rendererClass)->willReturn($twigRenderer->reveal());
         } else {
-            $formExtension = $this->prophesize('Symfony\Bridge\Twig\Extension\FormExtension');
+            $formExtension = $this->prophesize(FormExtension::class);
             $formExtension->renderer = $twigRenderer->reveal();
 
-            $twig->getExtension('Symfony\Bridge\Twig\Extension\FormExtension')->willReturn($formExtension->reveal());
+            $twig->getExtension(FormExtension::class)->willReturn($formExtension->reveal());
         }
         $twigRenderer->setTheme($formView, $formTheme)->shouldBeCalled();
     }

--- a/tests/Controller/MediaAdminControllerTest.php
+++ b/tests/Controller/MediaAdminControllerTest.php
@@ -14,6 +14,11 @@ namespace Sonata\MediaBundle\Tests\Controller;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Sonata\MediaBundle\Controller\MediaAdminController;
+use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Bridge\Twig\Command\DebugCommand;
+use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Bridge\Twig\Form\TwigRenderer;
+use Symfony\Component\Form\FormRenderer;
 
 class EntityWithGetId
 {
@@ -177,13 +182,13 @@ class MediaAdminControllerTest extends TestCase
 
     private function configureSetFormTheme($formView, $formTheme)
     {
-        $twig = $this->prophesize('\Twig_Environment');
+        $twig = $this->prophesize(\Twig_Environment::class);
 
         // Remove this trick when bumping Symfony requirement to 3.4+
-        if (method_exists('Symfony\Bridge\Twig\Command\DebugCommand', 'getLoaderPaths')) {
-            $rendererClass = 'Symfony\Component\Form\FormRenderer';
+        if (method_exists(DebugCommand::class, 'getLoaderPaths')) {
+            $rendererClass = FormRenderer::class;
         } else {
-            $rendererClass = 'Symfony\Bridge\Twig\Form\TwigRenderer';
+            $rendererClass = TwigRenderer::class;
         }
 
         $twigRenderer = $this->prophesize($rendererClass);
@@ -191,15 +196,15 @@ class MediaAdminControllerTest extends TestCase
         $this->container->get('twig')->willReturn($twig->reveal());
 
         // Remove this trick when bumping Symfony requirement to 3.2+.
-        if (method_exists('Symfony\Bridge\Twig\AppVariable', 'getToken')) {
+        if (method_exists(AppVariable::class, 'getToken')) {
             $twig->getRuntime($rendererClass)->willReturn($twigRenderer->reveal());
         } else {
-            $formExtension = $this->prophesize('Symfony\Bridge\Twig\Extension\FormExtension');
+            $formExtension = $this->prophesize(FormExtension::class);
             $formExtension->renderer = $twigRenderer->reveal();
 
             // This Throw is for the CRUDController::setFormTheme()
-            $twig->getRuntime($rendererClass)->willThrow('\Twig_Error_Runtime');
-            $twig->getExtension('Symfony\Bridge\Twig\Extension\FormExtension')->willReturn($formExtension->reveal());
+            $twig->getRuntime($rendererClass)->willThrow(\Twig_Error_Runtime::class);
+            $twig->getExtension(FormExtension::class)->willReturn($formExtension->reveal());
         }
         $twigRenderer->setTheme($formView, $formTheme)->shouldBeCalled();
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it fixes a bug (Admin controllers do not work with Symfony 3.4)

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Use FormRenderer runtime to maintain compatibility with Symfony 3.4
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

## Subject

<!-- Describe your Pull Request content here -->

Symfony 3.4 deprecates `TwigRenderer` (TwigBridge) in favour of `FormRenderer` (Form component). While the old class is still available, it is not registered as a Twig runtime anymore. ([See this related changeset in the TwigBridge component.](https://github.com/symfony/symfony/pull/23437/files#diff-5eb0532c96734f6e23428e921225b2f0))

`MediaAdminController` and `GalleryAdminController` try to call this runtime by class name, which throws an Exception (tested with Symfony 3.4-BETA4).

```
Twig_Error_Runtime:
Unable to load the "Symfony\Bridge\Twig\Form\TwigRenderer" runtime.

  at vendor/twig/twig/lib/Twig/Environment.php:931
  at Twig_Environment->getRuntime('Symfony\\Bridge\\Twig\\Form\\TwigRenderer')
     (vendor/sonata-project/media-bundle/Controller/MediaAdminController.php:128)
  at Sonata\MediaBundle\Controller\MediaAdminController->setFormTheme(object(FormView), array('SonataDoctrineORMAdminBundle:Form:filter_admin_fields.html.twig'))
     (vendor/sonata-project/media-bundle/Controller/MediaAdminController.php:100)
  at Sonata\MediaBundle\Controller\MediaAdminController->listAction(object(Request))
  at call_user_func_array(array(object(MediaAdminController), 'listAction'), array(object(Request)))
     (vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php:153)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php:68)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (web/app_dev.php:21)
  at require('/home/hanzi/Projects/gi/get-in-it/web/app_dev.php')
     (vendor/symfony/symfony/src/Symfony/Bundle/WebServerBundle/Resources/router.php:42)
```

This PR changes both controllers to use the new `FormRenderer` runtime instead.

The `method_exists` check is based on [this PR](https://github.com/symfony/symfony/pull/24064) which got merged for the same version as the PR that caused this bug (Symfony 3.4-BETA1.)