### PR TITLE
Set img srcset tag by format names

### DIFF
--- a/docs/reference/helpers.rst
+++ b/docs/reference/helpers.rst
@@ -78,6 +78,13 @@ To override the ``sizes`` to fit your particular design, just pass a ``sizes`` o
 
     {% media media, 'large' with {'sizes': '(min-width: 20em) 50vw, 100vw'} %}
 
+To override the ``srcset`` attribute, just pass a ``srcset`` option to the
+helper. The option expects either a string or an array of formats.
+
+.. code-block:: jinja
+
+    {% media media, 'large' with {'srcset': ['small', 'big']} %}
+
 
 Thumbnails for files
 --------------------

--- a/tests/Provider/ImageProviderTest.php
+++ b/tests/Provider/ImageProviderTest.php
@@ -126,8 +126,11 @@ class ImageProviderTest extends AbstractProviderTest
         );
         $this->assertSame('(max-width: 1000px) 100vw, 1000px', $properties['sizes']);
 
-        $properties = $provider->getHelperProperties($media, 'default_medium');
-        $this->assertSame($srcSet, $properties['srcset']);
+        $properties = $provider->getHelperProperties($media, 'default_medium', ['srcset' => ['default_large']]);
+        $this->assertSame(
+            '/uploads/media/default/0001/01/thumb_10_default_large.png 500w, /uploads/media/default/0001/01/ASDASDAS.png 1500w',
+            $properties['srcset']
+        );
         $this->assertSame(
             '/uploads/media/default/0001/01/thumb_10_default_medium.png',
             $properties['src']


### PR DESCRIPTION
I am targeting this branch, because this was a missing feature.

```markdown
### Added
- Added option to set the img `srcset` tag by giving it an array of format names.
```
## Subject

Frontend developers need the possibility to explicitly choose which formats need to be available in the srcset tag. This was currently achievable by combining the *media* tag with the *path* tag, but this is not user friendly and hardly maintainable.
Instead I created the possiblity to give the srcset tag an array of format names, which will be converted to the correct URL and settings for each format.
