### PR TITLE
add missing menuRegistry argument to breadcrumb service

### DIFF
--- a/src/Resources/config/seo_block.xml
+++ b/src/Resources/config/seo_block.xml
@@ -14,6 +14,7 @@
             <argument type="service" id="templating"/>
             <argument type="service" id="knp_menu.menu_provider"/>
             <argument type="service" id="knp_menu.factory"/>
+            <argument type="service" id="sonata.block.menu.registry"/>
         </service>
         <service id="sonata.media.block.breadcrumb_index" class="%sonata.media.block.breadcrumb_index.class%">
             <tag name="sonata.block"/>
@@ -23,6 +24,7 @@
             <argument type="service" id="templating"/>
             <argument type="service" id="knp_menu.menu_provider"/>
             <argument type="service" id="knp_menu.factory"/>
+            <argument type="service" id="sonata.block.menu.registry"/>
         </service>
         <service id="sonata.media.block.breadcrumb_view_media" class="%sonata.media.block.breadcrumb_media.class%">
             <tag name="sonata.block"/>
@@ -32,6 +34,7 @@
             <argument type="service" id="templating"/>
             <argument type="service" id="knp_menu.menu_provider"/>
             <argument type="service" id="knp_menu.factory"/>
+            <argument type="service" id="sonata.block.menu.registry"/>
         </service>
     </services>
 </container>


### PR DESCRIPTION
I am targeting this branch, because this is a BC.

See: https://github.com/sonata-project/SonataSeoBundle/pull/241

## Changelog

```markdown
### Added
- Missing `$menuRegistry` argument to breadcrumb services
```
