### PR TITLE
Fix liip imagine route

### DIFF
--- a/src/Thumbnail/LiipImagineThumbnail.php
+++ b/src/Thumbnail/LiipImagineThumbnail.php
@@ -39,9 +39,17 @@ class LiipImagineThumbnail implements ThumbnailInterface
             $path = $provider->getReferenceImage($media);
         } else {
             $path = $this->router->generate(
-                sprintf('_imagine_%s', $format),
-                ['path' => sprintf('%s/%s_%s.jpg', $provider->generatePath($media), $media->getId(), $format)]
+                'liip_imagine_filter',
+                [
+                    'filter' => $format,
+                    'path' => sprintf('%s/%s_%s.jpg', $provider->generatePath($media), $media->getId(), $format),
+                ]
             );
+
+            // @todo: find a cleaner way to generate the path without the site's relative path.
+            if ($this->router->getContext() instanceof \Sonata\PageBundle\Request\SiteRequestContextInterface) {
+                $path = substr($path, strlen($this->router->getContext()->getSite()->getRelativePath()));
+            }
         }
 
         return $provider->getCdnPath($path, $media->getCdnIsFlushable());


### PR DESCRIPTION
I am targeting this branch, because the LIIP Imagine integration is broken at the moment.

```markdown
### Fixed
- Got LIIP Imagine integration working again
- Using Symfony 2.8 Request injection
```

## To do

- [x] Integration working
- [ ] Update the documentation
- [x] Fix srcset by formats

## Subject

My focus in this PR is getting the LIIP Imagine integration working again. I will update the documentation and also add the srcset fix I already added to the twig media tag.

In this PR there is a workaround for finding the media path. This is a todo and will not be fixed in this PR.
