### PR TITLE
Return correct size cropped image

### DIFF
--- a/src/Resizer/SquareResizer.php
+++ b/src/Resizer/SquareResizer.php
@@ -126,7 +126,7 @@ class SquareResizer implements ResizerInterface
             }
 
             if ($higher - $lower > 0) {
-                return new Box($lower, $lower);
+                $size = new Box($lower, $lower);
             }
         }
 

--- a/tests/Resizer/SquareResizerTest.php
+++ b/tests/Resizer/SquareResizerTest.php
@@ -57,7 +57,7 @@ class SquareResizerTest extends TestCase
     public static function getBoxSettings()
     {
         return [
-            [['width' => 90, 'height' => 90], new Box(100, 120), new Box(100, 100)],
+            [['width' => 90, 'height' => 90], new Box(100, 120), new Box(90, 90)],
             [['width' => 90, 'height' => 90], new Box(50, 50), new Box(50, 50)],
             [['width' => 90, 'height' => null], new Box(50, 50), new Box(50, 50)],
             [['width' => 90, 'height' => null], new Box(567, 50), new Box(90, 7)],


### PR DESCRIPTION
I am targeting this branch, because the wrong size is returned for a cropped image.

## Changelog

```markdown
### Fixed
- Return size after resize in cropping flow, not just the cropped dimensions
```
## Subject

Function `getBox` is supposed to return the dimensions for given media with applied settings. However, when an image is cropped, that size was returned directly. Resizing is the next step and should also be done before returning the actual size.
