### PR TITLE
Always put src format in srcset

### DIFF
--- a/src/Provider/ImageProvider.php
+++ b/src/Provider/ImageProvider.php
@@ -92,6 +92,11 @@ class ImageProvider extends FileProvider
                     $srcSetFormats[$formatName] = $this->getFormat($formatName);
                 }
                 unset($options['srcset']);
+
+                // Make sure the requested format is also in the srcSetFormats
+                if (!isset($srcSetFormats[$format])) {
+                    $srcSetFormats[$format] = $this->getFormat($format);
+                }
             }
 
             if (!isset($options['srcset'])) {

--- a/tests/Provider/ImageProviderTest.php
+++ b/tests/Provider/ImageProviderTest.php
@@ -126,13 +126,10 @@ class ImageProviderTest extends AbstractProviderTest
         );
         $this->assertSame('(max-width: 1000px) 100vw, 1000px', $properties['sizes']);
 
-        $properties = $provider->getHelperProperties($media, 'default_medium', ['srcset' => ['default_large']]);
+        $properties = $provider->getHelperProperties($media, 'default_large', ['srcset' => ['default_medium']]);
+        $this->assertSame($srcSet, $properties['srcset']);
         $this->assertSame(
-            '/uploads/media/default/0001/01/thumb_10_default_large.png 500w, /uploads/media/default/0001/01/ASDASDAS.png 1500w',
-            $properties['srcset']
-        );
-        $this->assertSame(
-            '/uploads/media/default/0001/01/thumb_10_default_medium.png',
+            '/uploads/media/default/0001/01/thumb_10_default_large.png',
             $properties['src']
         );
         $this->assertSame('(max-width: 500px) 100vw, 500px', $properties['sizes']);


### PR DESCRIPTION
I am targeting this branch, because when defining srcsets, the src format needs to be added again.

## Changelog

```markdown
### Added
- Added automatically adding src format to srcset
```

## Subject

I just noticed that when defining your srcset formats, the src format itself wasn't printed. Now it's automatically added if it wasn't done by the user.
