### PR TITLE
Call new FOSRest API

### DIFF
--- a/src/Controller/Api/GalleryController.php
+++ b/src/Controller/Api/GalleryController.php
@@ -445,7 +445,13 @@ class GalleryController
             } else {
                 $context = new Context();
                 $context->setGroups(['sonata_api_read']);
-                $context->setMaxDepth(0);
+
+                // NEXT_MAJOR: simplify when dropping FOSRest < 2.1
+                if (method_exists($context, 'disableMaxDepth')) {
+                    $context->disableMaxDepth();
+                } else {
+                    $context->setMaxDepth(0);
+                }
                 $view->setContext($context);
             }
 
@@ -544,7 +550,13 @@ class GalleryController
             } else {
                 $context = new Context();
                 $context->setGroups(['sonata_api_read']);
-                $context->setMaxDepth(0);
+
+                // NEXT_MAJOR: simplify when dropping FOSRest < 2.1
+                if (method_exists($context, 'disableMaxDepth')) {
+                    $context->disableMaxDepth();
+                } else {
+                    $context->setMaxDepth(0);
+                }
                 $view->setContext($context);
             }
 

--- a/src/Controller/Api/MediaController.php
+++ b/src/Controller/Api/MediaController.php
@@ -415,7 +415,13 @@ class MediaController
             } else {
                 $context = new Context();
                 $context->setGroups(['sonata_api_read']);
-                $context->setMaxDepth(0);
+
+                // NEXT_MAJOR: simplify when dropping FOSRest < 2.1
+                if (method_exists($context, 'disableMaxDepth')) {
+                    $context->disableMaxDepth();
+                } else {
+                    $context->setMaxDepth(0);
+                }
                 $view->setContext($context);
             }
 


### PR DESCRIPTION
I am targeting this branch, because this is BC.

Refs #1267

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- FOSRest-related deprecations
```
## Subject


Apparently setMaxDepth was a misnomer.
See https://github.com/FriendsOfSymfony/FOSRestBundle/pull/1506

