### PR TITLE
Remove unnecesary bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "knplabs/gaufrette": "^0.1.6 || ^0.2 || ^0.3",
         "kriswallsmith/buzz": "^0.15",
         "psr/log": "^1.0",
-        "sensio/generator-bundle": "^3.1",
         "sonata-project/core-bundle": "^3.2",
         "sonata-project/doctrine-extensions": "^1.0",
         "sonata-project/easy-extends-bundle": "^2.2",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

<!-- Describe your Pull Request content here -->
The bundle was added here: https://github.com/sonata-project/SonataMediaBundle/pull/1259 without a good reason. It is making SF 4 compatibility impossible, since it won't update to symfony4 because of https://github.com/symfony/maker-bundle

To sumarize, not a good idea to add a dependency on a bundle that has no future