### PR TITLE
Selected gallery context remained untranslated in dropdown

### DIFF
--- a/src/Resources/views/GalleryAdmin/list.html.twig
+++ b/src/Resources/views/GalleryAdmin/list.html.twig
@@ -18,7 +18,7 @@ file that was distributed with this source code.
                 {{ "label.select_context"|trans({}, 'SonataMediaBundle') }}
                 <div class="btn-group">
                     <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-                        <strong class="text-info">{{ persistent_parameters.context }}</strong> <span class="caret"></span>
+                        <strong class="text-info">{{ persistent_parameters.context|trans({}, 'SonataMediaBundle') }}</strong> <span class="caret"></span>
                     </button>
                     <ul class="dropdown-menu" role="menu">
                         {% for name, context in media_pool.contexts %}


### PR DESCRIPTION
I am targeting this branch, because it's just a missing translation.

## Changelog

```markdown
### Fixed
- Selected gallery context is now translated just like in the dropdown.
```

## Subject

This fixes a small translation bug: The name of the selected gallery context remained untranslated, although the options in the dropdown list are being translated correctly.
