### PR TITLE
Ensure that repository calculations work with UUIDs

### DIFF
--- a/src/Generator/DefaultGenerator.php
+++ b/src/Generator/DefaultGenerator.php
@@ -40,8 +40,12 @@ class DefaultGenerator implements GeneratorInterface
      */
     public function generatePath(MediaInterface $media)
     {
-        $rep_first_level = (int) ($media->getId() / $this->firstLevel);
-        $rep_second_level = (int) (($media->getId() - ($rep_first_level * $this->firstLevel)) / $this->secondLevel);
+        $mediaId = $media->getId();
+        if (preg_match("/^\{?[a-f\d]{8}-(?:[a-f\d]{4}-){3}[a-f\d]{12}\}?$/i", $mediaId)) {
+            $mediaId = (int) hexdec(implode("", array_slice(explode("-", $mediaId), 0, 2)));
+        }
+        $rep_first_level = (int) ($mediaId / $this->firstLevel);
+        $rep_second_level = (int) (($mediaId - ($rep_first_level * $this->firstLevel)) / $this->secondLevel);
 
         return sprintf('%s/%04s/%02s', $media->getContext(), $rep_first_level + 1, $rep_second_level + 1);
     }


### PR DESCRIPTION
I am targeting this branch, because this is not a BC but affects all versions of MediaBundle.
Closes #1342 

## Changelog
```markdown
### Fixed
- Fix thrown exception if media::id is UUID on PHP 7.1
```

### Fixed
Here media::id is used for some calculations to define a repository foldername. If media::id is UUID (string) instead of integer, this calculation will throw an exception in PHP 7.1 becauce math operations on strings are not allowed.

This commit uses the first two segments of UUID and converts their hex value to decimal to use as base of calculation.