### PR TITLE
Properly resolve paramters in application config

### DIFF
--- a/src/DependencyInjection/Compiler/AddProviderCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddProviderCompilerPass.php
@@ -85,14 +85,14 @@ class AddProviderCompilerPass implements CompilerPassInterface
                     $definition = $container->getDefinition($id);
 
                     $definition
-                        ->replaceArgument(1, new Reference($config['filesystem']))
-                        ->replaceArgument(2, new Reference($config['cdn']))
-                        ->replaceArgument(3, new Reference($config['generator']))
-                        ->replaceArgument(4, new Reference($config['thumbnail']))
+                        ->replaceArgument(1, new Reference($container->getParameterBag()->resolveValue($config['filesystem'])))
+                        ->replaceArgument(2, new Reference($container->getParameterBag()->resolveValue($config['cdn'])))
+                        ->replaceArgument(3, new Reference($container->getParameterBag()->resolveValue($config['generator'])))
+                        ->replaceArgument(4, new Reference($container->getParameterBag()->resolveValue($config['thumbnail'])))
                     ;
 
                     if ($config['resizer']) {
-                        $definition->addMethodCall('setResizer', [new Reference($config['resizer'])]);
+                        $definition->addMethodCall('setResizer', [new Reference($container->getParameterBag()->resolveValue($config['resizer']))]);
                     }
                 }
             }


### PR DESCRIPTION
I am targeting this branch, because it fixes problems with latest 3.X release.

Closes #1271 

## Changelog
```markdown
### Fixed
- Fixes problem with parameter resolution in extension config
```

### Fixed
Recently the AddCompilerPass was refactored and an ugly hack was removed to resolve paramters in extension config. Now parameters (from parameters.yml) and used in config.yml are no longer replaced. With this PR the parameters are resolved again.
