### PR TITLE
Drop old Symfony and PHP code

### DIFF
--- a/src/Admin/BaseMediaAdmin.php
+++ b/src/Admin/BaseMediaAdmin.php
@@ -14,11 +14,13 @@ namespace Sonata\MediaBundle\Admin;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\CoreBundle\Model\Metadata;
 use Sonata\MediaBundle\Form\DataTransformer\ProviderDataTransformer;
 use Sonata\MediaBundle\Model\CategoryManagerInterface;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\MediaBundle\Provider\Pool;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 
 abstract class BaseMediaAdmin extends AbstractAdmin
 {
@@ -109,15 +111,7 @@ abstract class BaseMediaAdmin extends AbstractAdmin
             if ($this->getRequest()->isMethod('POST')) {
                 $uniqid = $this->getUniqid();
 
-                if (method_exists('Symfony\Component\HttpFoundation\JsonResponse', 'transformJsonError')) {
-                    // NEXT_MAJOR remove this block when dropping sf < 2.8 compatibility
-                    $media->setProviderName(
-                        $this->getRequest()->get(sprintf('%s[providerName]', $uniqid), null, true)
-                    );
-                } else {
-                    $providerParams = $this->getRequest()->get($uniqid);
-                    $media->setProviderName($providerParams['providerName']);
-                }
+                $media->setProviderName($this->getRequest()->get($uniqid)['providerName']);
             } else {
                 $media->setProviderName($this->getRequest()->get('provider'));
             }
@@ -187,12 +181,7 @@ abstract class BaseMediaAdmin extends AbstractAdmin
             return;
         }
 
-        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
-        $hiddenType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
-            : 'hidden';
-
-        $formMapper->add('providerName', $hiddenType);
+        $formMapper->add('providerName', HiddenType::class);
 
         $formMapper->getFormBuilder()->addModelTransformer(new ProviderDataTransformer($this->pool, $this->getClass()), true);
 
@@ -205,12 +194,7 @@ abstract class BaseMediaAdmin extends AbstractAdmin
         }
 
         if (null !== $this->categoryManager) {
-            // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
-            $modelListType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Sonata\AdminBundle\Form\Type\ModelListType'
-                : 'sonata_type_model_list';
-
-            $formMapper->add('category', $modelListType, [], [
+            $formMapper->add('category', ModelListType::class, [], [
                 'link_parameters' => [
                     'context' => $media->getContext(),
                     'hide_context' => true,

--- a/src/Admin/GalleryAdmin.php
+++ b/src/Admin/GalleryAdmin.php
@@ -15,7 +15,9 @@ use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\CoreBundle\Form\Type\CollectionType;
 use Sonata\MediaBundle\Provider\Pool;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
 class GalleryAdmin extends AbstractAdmin
 {
@@ -116,27 +118,17 @@ class GalleryAdmin extends AbstractAdmin
             $contexts[$contextItem] = $contextItem;
         }
 
-        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
-        $choiceType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-            : 'choice';
-
-        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
-        $collectionType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\CoreBundle\Form\Type\CollectionType'
-            : 'sonata_type_collection';
-
         $formMapper
             ->with('Options')
-                ->add('context', $choiceType, ['choices' => $contexts])
+                ->add('context', ChoiceType::class, ['choices' => $contexts])
                 ->add('enabled', null, ['required' => false])
                 ->add('name')
                 ->ifTrue($formats)
-                    ->add('defaultFormat', $choiceType, ['choices' => $formats])
+                    ->add('defaultFormat', ChoiceType::class, ['choices' => $formats])
                 ->ifEnd()
             ->end()
             ->with('Gallery')
-                ->add('galleryHasMedias', $collectionType, [], [
+                ->add('galleryHasMedias', CollectionType::class, [], [
                     'edit' => 'inline',
                     'inline' => 'table',
                     'sortable' => 'position',

--- a/src/Admin/GalleryHasMediaAdmin.php
+++ b/src/Admin/GalleryHasMediaAdmin.php
@@ -14,6 +14,8 @@ namespace Sonata\MediaBundle\Admin;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Form\Type\ModelListType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 
 class GalleryHasMediaAdmin extends AbstractAdmin
 {
@@ -36,22 +38,12 @@ class GalleryHasMediaAdmin extends AbstractAdmin
             }
         }
 
-        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+
-        $modelListType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\AdminBundle\Form\Type\ModelListType'
-            : 'sonata_type_model_list';
-
-        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
-        $hiddenType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\HiddenType'
-            : 'hidden';
-
         $formMapper
-            ->add('media', $modelListType, ['required' => false], [
+            ->add('media', ModelListType::class, ['required' => false], [
                 'link_parameters' => $link_parameters,
             ])
             ->add('enabled', null, ['required' => false])
-            ->add('position', $hiddenType)
+            ->add('position', HiddenType::class)
         ;
     }
 

--- a/src/Admin/ORM/MediaAdmin.php
+++ b/src/Admin/ORM/MediaAdmin.php
@@ -12,7 +12,9 @@
 namespace Sonata\MediaBundle\Admin\ORM;
 
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\DoctrineORMAdminBundle\Filter\ChoiceFilter;
 use Sonata\MediaBundle\Admin\BaseMediaAdmin as Admin;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
 class MediaAdmin extends Admin
 {
@@ -29,18 +31,13 @@ class MediaAdmin extends Admin
             $options['choices'][$name] = $name;
         }
 
-        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
-        $choiceType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'
-            : 'choice';
-
         $datagridMapper
             ->add('name')
             ->add('providerReference')
             ->add('enabled')
             ->add('context', null, [
                 'show_filter' => true !== $this->getPersistentParameter('hide_context'),
-            ], $choiceType, $options);
+            ], ChoiceType::class, $options);
 
         if (null !== $this->categoryManager) {
             $datagridMapper->add('category', null, ['show_filter' => false]);
@@ -59,19 +56,14 @@ class MediaAdmin extends Admin
             $providers[$name] = $name;
         }
 
-        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
-        $ormChoiceType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\DoctrineORMAdminBundle\Filter\ChoiceFilter'
-            : 'doctrine_orm_choice';
-
-        $datagridMapper->add('providerName', $ormChoiceType, [
+        $datagridMapper->add('providerName', ChoiceFilter::class, [
             'field_options' => [
                 'choices' => $providers,
                 'required' => false,
                 'multiple' => false,
                 'expanded' => false,
             ],
-            'field_type' => $choiceType,
+            'field_type' => ChoiceType::class,
         ]);
     }
 }

--- a/src/Block/FeatureMediaBlockService.php
+++ b/src/Block/FeatureMediaBlockService.php
@@ -13,7 +13,11 @@ namespace Sonata\MediaBundle\Block;
 
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -45,30 +49,17 @@ class FeatureMediaBlockService extends MediaBlockService
     {
         $formatChoices = $this->getFormatChoices($block->getSetting('mediaId'));
 
-        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $immutableArrayType = 'Sonata\CoreBundle\Form\Type\ImmutableArrayType';
-            $textType = 'Symfony\Component\Form\Extension\Core\Type\TextType';
-            $textareaType = 'Symfony\Component\Form\Extension\Core\Type\TextareaType';
-            $choiceType = 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
-        } else {
-            $immutableArrayType = 'sonata_type_immutable_array';
-            $textType = 'text';
-            $textareaType = 'textarea';
-            $choiceType = 'choice';
-        }
-
-        $formMapper->add('settings', $immutableArrayType, [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['title', $textType, [
+                ['title', TextType::class, [
                     'required' => false,
                     'label' => 'form.label_title',
                 ]],
-                ['content', $textareaType, [
+                ['content', TextareaType::class, [
                     'required' => false,
                     'label' => 'form.label_content',
                 ]],
-                ['orientation', $choiceType, [
+                ['orientation', ChoiceType::class, [
                     'required' => false,
                     'choices' => [
                         'left' => 'form.label_orientation_left',
@@ -77,7 +68,7 @@ class FeatureMediaBlockService extends MediaBlockService
                     'label' => 'form.label_orientation',
                 ]],
                 [$this->getMediaBuilder($formMapper), null, []],
-                ['format', $choiceType, [
+                ['format', ChoiceType::class, [
                     'required' => count($formatChoices) > 0,
                     'choices' => $formatChoices,
                     'label' => 'form.label_format',

--- a/src/Block/GalleryBlockService.php
+++ b/src/Block/GalleryBlockService.php
@@ -14,15 +14,21 @@ namespace Sonata\MediaBundle\Block;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\ManagerInterface;
 use Sonata\CoreBundle\Model\Metadata;
 use Sonata\MediaBundle\Model\GalleryInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Templating\EngineInterface;
@@ -126,55 +132,38 @@ class GalleryBlockService extends AbstractAdminBlockService
         $fieldDescription->setOption('edit', 'list');
         $fieldDescription->setAssociationMapping(['fieldName' => 'gallery', 'type' => ClassMetadataInfo::MANY_TO_ONE]);
 
-        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $modelListType = 'Sonata\AdminBundle\Form\Type\ModelListType';
-            $immutableArrayType = 'Sonata\CoreBundle\Form\Type\ImmutableArrayType';
-            $textType = 'Symfony\Component\Form\Extension\Core\Type\TextType';
-            $choiceType = 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
-            $numberType = 'Symfony\Component\Form\Extension\Core\Type\NumberType';
-            $checkboxType = 'Symfony\Component\Form\Extension\Core\Type\CheckboxType';
-        } else {
-            $modelListType = 'sonata_type_model_list';
-            $immutableArrayType = 'sonata_type_immutable_array';
-            $textType = 'text';
-            $choiceType = 'choice';
-            $numberType = 'number';
-            $checkboxType = 'checkbox';
-        }
-
-        $builder = $formMapper->create('galleryId', $modelListType, [
+        $builder = $formMapper->create('galleryId', ModelListType::class, [
             'sonata_field_description' => $fieldDescription,
             'class' => $this->getGalleryAdmin()->getClass(),
             'model_manager' => $this->getGalleryAdmin()->getModelManager(),
             'label' => 'form.label_gallery',
         ]);
 
-        $formMapper->add('settings', $immutableArrayType, [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['title', $textType, [
+                ['title', TextType::class, [
                     'required' => false,
                     'label' => 'form.label_title',
                 ]],
-                ['context', $choiceType, [
+                ['context', ChoiceType::class, [
                     'required' => true,
                     'choices' => $contextChoices,
                     'label' => 'form.label_context',
                 ]],
-                ['format', $choiceType, [
+                ['format', ChoiceType::class, [
                     'required' => count($formatChoices) > 0,
                     'choices' => $formatChoices,
                     'label' => 'form.label_format',
                 ]],
                 [$builder, null, []],
-                ['pauseTime', $numberType, [
+                ['pauseTime', NumberType::class, [
                     'label' => 'form.label_pause_time',
                 ]],
-                ['startPaused', $checkboxType, [
+                ['startPaused', CheckboxType::class, [
                     'required' => false,
                     'label' => 'form.label_start_paused',
                 ]],
-                ['wrap', $checkboxType, [
+                ['wrap', CheckboxType::class, [
                     'required' => false,
                     'label' => 'form.label_wrap',
                 ]],

--- a/src/Block/GalleryListBlockService.php
+++ b/src/Block/GalleryListBlockService.php
@@ -15,10 +15,14 @@ use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\Metadata;
 use Sonata\MediaBundle\Model\GalleryManagerInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -59,42 +63,29 @@ class GalleryListBlockService extends AbstractAdminBlockService
             $contextChoices[$name] = $name;
         }
 
-        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $immutableArrayType = 'Sonata\CoreBundle\Form\Type\ImmutableArrayType';
-            $textType = 'Symfony\Component\Form\Extension\Core\Type\TextType';
-            $integerType = 'Symfony\Component\Form\Extension\Core\Type\IntegerType';
-            $choiceType = 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
-        } else {
-            $immutableArrayType = 'sonata_type_immutable_array';
-            $textType = 'text';
-            $integerType = 'integer';
-            $choiceType = 'choice';
-        }
-
-        $formMapper->add('settings', $immutableArrayType, [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['title', $textType, [
+                ['title', TextType::class, [
                     'label' => 'form.label_title',
                     'required' => false,
                 ]],
-                ['number', $integerType, [
+                ['number', IntegerType::class, [
                     'label' => 'form.label_number',
                     'required' => true,
                 ]],
-                ['context', $choiceType, [
+                ['context', ChoiceType::class, [
                     'required' => true,
                     'label' => 'form.label_context',
                     'choices' => $contextChoices,
                 ]],
-                ['mode', $choiceType, [
+                ['mode', ChoiceType::class, [
                     'label' => 'form.label_mode',
                     'choices' => [
                         'public' => 'form.label_mode_public',
                         'admin' => 'form.label_mode_admin',
                     ],
                 ]],
-                ['order', $choiceType,  [
+                ['order', ChoiceType::class,  [
                     'label' => 'form.label_order',
                     'choices' => [
                         'name' => 'form.label_order_name',
@@ -102,7 +93,7 @@ class GalleryListBlockService extends AbstractAdminBlockService
                         'updatedAt' => 'form.label_order_updated_at',
                     ],
                 ]],
-                ['sort', $choiceType, [
+                ['sort', ChoiceType::class, [
                     'label' => 'form.label_sort',
                     'choices' => [
                         'desc' => 'form.label_sort_desc',

--- a/src/Block/MediaBlockService.php
+++ b/src/Block/MediaBlockService.php
@@ -13,15 +13,19 @@ namespace Sonata\MediaBundle\Block;
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
 use Sonata\CoreBundle\Model\ManagerInterface;
 use Sonata\CoreBundle\Model\Metadata;
 use Sonata\MediaBundle\Admin\BaseMediaAdmin;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -102,25 +106,14 @@ class MediaBlockService extends AbstractAdminBlockService
 
         $formatChoices = $this->getFormatChoices($block->getSetting('mediaId'));
 
-        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $immutableArrayType = 'Sonata\CoreBundle\Form\Type\ImmutableArrayType';
-            $textType = 'Symfony\Component\Form\Extension\Core\Type\TextType';
-            $choiceType = 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
-        } else {
-            $immutableArrayType = 'sonata_type_immutable_array';
-            $textType = 'text';
-            $choiceType = 'choice';
-        }
-
-        $formMapper->add('settings', $immutableArrayType, [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['title', $textType, [
+                ['title', TextType::class, [
                     'required' => false,
                     'label' => 'form.label_title',
                 ]],
                 [$this->getMediaBuilder($formMapper), null, []],
-                ['format', $choiceType, [
+                ['format', ChoiceType::class, [
                     'required' => count($formatChoices) > 0,
                     'choices' => $formatChoices,
                     'label' => 'form.label_format',
@@ -233,12 +226,7 @@ class MediaBlockService extends AbstractAdminBlockService
             'type' => ClassMetadataInfo::MANY_TO_ONE,
         ]);
 
-        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
-        $modelListType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\AdminBundle\Form\Type\ModelListType'
-            : 'sonata_type_model_list';
-
-        return $formMapper->create('mediaId', $modelListType, [
+        return $formMapper->create('mediaId', ModelListType::class, [
             'sonata_field_description' => $fieldDescription,
             'class' => $this->getMediaAdmin()->getClass(),
             'model_manager' => $this->getMediaAdmin()->getModelManager(),

--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -48,25 +48,6 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
         $loader->load('extra.xml');
         $loader->load('form.xml');
         $loader->load('gaufrette.xml');
-
-        // NEXT_MAJOR: Remove Following lines
-        $amazonS3Definition = $container->getDefinition('sonata.media.adapter.service.s3');
-        if (method_exists($amazonS3Definition, 'setFactory')) {
-            $amazonS3Definition->setFactory(['Aws\S3\S3Client', 'factory']);
-        } else {
-            $amazonS3Definition->setFactoryClass('Aws\S3\S3Client');
-            $amazonS3Definition->setFactoryMethod('factory');
-        }
-
-        // NEXT_MAJOR: Remove Following lines
-        $openCloudDefinition = $container->getDefinition('sonata.media.adapter.filesystem.opencloud.objectstore');
-        if (method_exists($openCloudDefinition, 'setFactory')) {
-            $openCloudDefinition->setFactory([new Reference('sonata.media.adapter.filesystem.opencloud.connection'), 'ObjectStore']);
-        } else {
-            $openCloudDefinition->setFactoryService('sonata.media.adapter.filesystem.opencloud.connection');
-            $openCloudDefinition->setFactoryMethod('ObjectStore');
-        }
-
         $loader->load('validators.xml');
         $loader->load('serializer.xml');
 

--- a/src/Form/DataTransformer/ProviderDataTransformer.php
+++ b/src/Form/DataTransformer/ProviderDataTransformer.php
@@ -12,7 +12,7 @@
 namespace Sonata\MediaBundle\Form\DataTransformer;
 
 use Psr\Log\LoggerAwareInterface;
-use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Provider\Pool;
@@ -20,6 +20,8 @@ use Symfony\Component\Form\DataTransformerInterface;
 
 class ProviderDataTransformer implements DataTransformerInterface, LoggerAwareInterface
 {
+    use LoggerAwareTrait;
+
     /**
      * @var Pool
      */
@@ -29,13 +31,6 @@ class ProviderDataTransformer implements DataTransformerInterface, LoggerAwareIn
      * @var array
      */
     protected $options;
-
-    /**
-     * NEXT_MAJOR: When switching to PHP 5.4+, replace by LoggerAwareTrait.
-     *
-     * @var LoggerInterface
-     */
-    private $logger;
 
     /**
      * @param Pool   $pool
@@ -49,16 +44,6 @@ class ProviderDataTransformer implements DataTransformerInterface, LoggerAwareIn
         $this->class = $class;
 
         $this->logger = new NullLogger();
-    }
-
-    /**
-     * NEXT_MAJOR: When switching to PHP 5.4+, replace by LoggerAwareTrait.
-     *
-     * @param LoggerInterface $logger
-     */
-    public function setLogger(LoggerInterface $logger)
-    {
-        $this->logger = $logger;
     }
 
     /**

--- a/src/Form/DataTransformer/ServiceProviderDataTransformer.php
+++ b/src/Form/DataTransformer/ServiceProviderDataTransformer.php
@@ -12,7 +12,7 @@
 namespace Sonata\MediaBundle\Form\DataTransformer;
 
 use Psr\Log\LoggerAwareInterface;
-use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
@@ -20,17 +20,12 @@ use Symfony\Component\Form\DataTransformerInterface;
 
 class ServiceProviderDataTransformer implements DataTransformerInterface, LoggerAwareInterface
 {
+    use LoggerAwareTrait;
+
     /**
      * @var MediaProviderInterface
      */
     protected $provider;
-
-    /**
-     * NEXT_MAJOR: When switching to PHP 5.4+, replace by LoggerAwareTrait.
-     *
-     * @var LoggerInterface
-     */
-    private $logger;
 
     /**
      * @param MediaProviderInterface $provider
@@ -40,16 +35,6 @@ class ServiceProviderDataTransformer implements DataTransformerInterface, Logger
         $this->provider = $provider;
 
         $this->logger = new NullLogger();
-    }
-
-    /**
-     * NEXT_MAJOR: When switching to PHP 5.4+, replace by LoggerAwareTrait.
-     *
-     * @param LoggerInterface $logger
-     */
-    public function setLogger(LoggerInterface $logger)
-    {
-        $this->logger = $logger;
     }
 
     /**

--- a/src/Form/Type/ApiMediaType.php
+++ b/src/Form/Type/ApiMediaType.php
@@ -12,7 +12,7 @@
 namespace Sonata\MediaBundle\Form\Type;
 
 use Psr\Log\LoggerAwareInterface;
-use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
 use Sonata\MediaBundle\Form\DataTransformer\ProviderDataTransformer;
 use Sonata\MediaBundle\Provider\Pool;
@@ -26,6 +26,8 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
  */
 class ApiMediaType extends AbstractType implements LoggerAwareInterface
 {
+    use LoggerAwareTrait;
+
     /**
      * @var Pool
      */
@@ -37,13 +39,6 @@ class ApiMediaType extends AbstractType implements LoggerAwareInterface
     protected $class;
 
     /**
-     * NEXT_MAJOR: When switching to PHP 5.4+, replace by LoggerAwareTrait.
-     *
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    /**
      * @param Pool   $mediaPool
      * @param string $class
      */
@@ -52,16 +47,6 @@ class ApiMediaType extends AbstractType implements LoggerAwareInterface
         $this->mediaPool = $mediaPool;
         $this->class = $class;
         $this->logger = new NullLogger();
-    }
-
-    /**
-     * NEXT_MAJOR: When switching to PHP 5.4+, replace by LoggerAwareTrait.
-     *
-     * @param LoggerInterface $logger
-     */
-    public function setLogger(LoggerInterface $logger)
-    {
-        $this->logger = $logger;
     }
 
     /**
@@ -108,11 +93,7 @@ class ApiMediaType extends AbstractType implements LoggerAwareInterface
      */
     public function getParent()
     {
-        // NEXT_MAJOR: Return 'Sonata\MediaBundle\Form\Type\ApiDoctrineMediaType'
-        // (when requirement of Symfony is >= 2.8)
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Sonata\MediaBundle\Form\Type\ApiDoctrineMediaType'
-            : 'sonata_media_api_form_doctrine_media';
+        return ApiDoctrineMediaType::class;
     }
 
     /**

--- a/src/Form/Type/MediaType.php
+++ b/src/Form/Type/MediaType.php
@@ -12,11 +12,13 @@
 namespace Sonata\MediaBundle\Form\Type;
 
 use Psr\Log\LoggerAwareInterface;
-use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
 use Sonata\MediaBundle\Form\DataTransformer\ProviderDataTransformer;
 use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -27,6 +29,8 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class MediaType extends AbstractType implements LoggerAwareInterface
 {
+    use LoggerAwareTrait;
+
     /**
      * @var Pool
      */
@@ -38,13 +42,6 @@ class MediaType extends AbstractType implements LoggerAwareInterface
     protected $class;
 
     /**
-     * NEXT_MAJOR: When switching to PHP 5.4+, replace by LoggerAwareTrait.
-     *
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    /**
      * @param Pool   $pool
      * @param string $class
      */
@@ -53,16 +50,6 @@ class MediaType extends AbstractType implements LoggerAwareInterface
         $this->pool = $pool;
         $this->class = $class;
         $this->logger = new NullLogger();
-    }
-
-    /**
-     * NEXT_MAJOR: When switching to PHP 5.4+, replace by LoggerAwareTrait.
-     *
-     * @param LoggerInterface $logger
-     */
-    public function setLogger(LoggerInterface $logger)
-    {
-        $this->logger = $logger;
     }
 
     /**
@@ -88,20 +75,12 @@ class MediaType extends AbstractType implements LoggerAwareInterface
 
         $this->pool->getProvider($options['provider'])->buildMediaType($builder);
 
-        // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\CheckboxType' value.
-        // (when requirement of Symfony is >= 2.8)
-        $builder->add(
-            'unlink',
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\CheckboxType'
-                : 'checkbox',
-            [
-                'label' => 'widget_label_unlink',
-                'mapped' => false,
-                'data' => false,
-                'required' => false,
-            ]
-        );
+        $builder->add('unlink', CheckboxType::class, [
+            'label' => 'widget_label_unlink',
+            'mapped' => false,
+            'data' => false,
+            'required' => false,
+        ]);
     }
 
     /**
@@ -137,30 +116,11 @@ class MediaType extends AbstractType implements LoggerAwareInterface
                 'new_on_update' => true,
                 'translation_domain' => 'SonataMediaBundle',
             ])
-            ->setRequired([
-                'provider',
-                'context',
-            ]);
-
-        // NEXT_MAJOR: Remove this hack when dropping support for symfony 2.3
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $resolver
-                ->setAllowedTypes('provider', 'string')
-                ->setAllowedTypes('context', 'string')
-                ->setAllowedValues('provider', $this->pool->getProviderList())
-                ->setAllowedValues('context', array_keys($this->pool->getContexts()))
-            ;
-        } else {
-            $resolver
-                ->setAllowedTypes([
-                    'provider' => 'string',
-                    'context' => 'string',
-                ])
-                ->setAllowedValues([
-                    'provider' => $this->pool->getProviderList(),
-                    'context' => array_keys($this->pool->getContexts()),
-                ]);
-        }
+            ->setRequired(['provider', 'context'])
+            ->setAllowedTypes('provider', 'string')
+            ->setAllowedTypes('context', 'string')
+            ->setAllowedValues('provider', $this->pool->getProviderList())
+            ->setAllowedValues('context', array_keys($this->pool->getContexts()));
     }
 
     /**
@@ -168,11 +128,7 @@ class MediaType extends AbstractType implements LoggerAwareInterface
      */
     public function getParent()
     {
-        // NEXT_MAJOR: Return 'Symfony\Component\Form\Extension\Core\Type\FormType'
-        // (when requirement of Symfony is >= 2.8)
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\FormType'
-            : 'form';
+        return FormType::class;
     }
 
     /**

--- a/src/Provider/BaseVideoProvider.php
+++ b/src/Provider/BaseVideoProvider.php
@@ -21,6 +21,7 @@ use Sonata\MediaBundle\Generator\GeneratorInterface;
 use Sonata\MediaBundle\Metadata\MetadataBuilderInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Thumbnail\ThumbnailInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;
@@ -129,14 +130,7 @@ abstract class BaseVideoProvider extends BaseProvider
         $formMapper->add('cdnIsFlushable');
         $formMapper->add('description');
         $formMapper->add('copyright');
-        $formMapper->add(
-            'binaryContent',
-            // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\TextType' value
-            // (when requirement of Symfony is >= 2.8)
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
-                : 'text',
-            ['required' => false]);
+        $formMapper->add('binaryContent', TextType::class, ['required' => false]);
     }
 
     /**
@@ -144,20 +138,12 @@ abstract class BaseVideoProvider extends BaseProvider
      */
     public function buildCreateForm(FormMapper $formMapper)
     {
-        $formMapper->add(
-            'binaryContent',
-            // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\TextType' value
-            // (when requirement of Symfony is >= 2.8)
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
-                : 'text',
-            [
-                'constraints' => [
-                    new NotBlank(),
-                    new NotNull(),
-                ],
-            ]
-        );
+        $formMapper->add('binaryContent', TextType::class, [
+            'constraints' => [
+                new NotBlank(),
+                new NotNull(),
+            ],
+        ]);
     }
 
     /**
@@ -165,17 +151,9 @@ abstract class BaseVideoProvider extends BaseProvider
      */
     public function buildMediaType(FormBuilder $formBuilder)
     {
-        // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\TextType'
-        // (when requirement of Symfony is >= 2.8)
-        $formBuilder->add(
-            'binaryContent',
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
-                : 'text',
-            [
-                'label' => 'widget_label_binary_content',
-            ]
-        );
+        $formBuilder->add('binaryContent', TextType::class, [
+            'label' => 'widget_label_binary_content',
+        ]);
     }
 
     /**

--- a/src/Provider/FileProvider.php
+++ b/src/Provider/FileProvider.php
@@ -21,6 +21,7 @@ use Sonata\MediaBundle\Generator\GeneratorInterface;
 use Sonata\MediaBundle\Metadata\MetadataBuilderInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Thumbnail\ThumbnailInterface;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\File\Exception\UploadException;
@@ -97,15 +98,7 @@ class FileProvider extends BaseProvider
         $formMapper->add('cdnIsFlushable');
         $formMapper->add('description');
         $formMapper->add('copyright');
-        $formMapper->add(
-            'binaryContent',
-            // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\FileType' value
-            // (when requirement of Symfony is >= 2.8)
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\FileType'
-                : 'file',
-            ['required' => false]
-        );
+        $formMapper->add('binaryContent', FileType::class, ['required' => false]);
     }
 
     /**
@@ -113,20 +106,12 @@ class FileProvider extends BaseProvider
      */
     public function buildCreateForm(FormMapper $formMapper)
     {
-        $formMapper->add(
-            'binaryContent',
-            // NEXT_MAJOR: Remove ternary and keep 'Symfony\Component\Form\Extension\Core\Type\FileType' value
-            // (when requirement of Symfony is >= 2.8)
-            method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-                ? 'Symfony\Component\Form\Extension\Core\Type\FileType'
-                : 'file',
-            [
-                'constraints' => [
-                    new NotBlank(),
-                    new NotNull(),
-                ],
-            ]
-        );
+        $formMapper->add('binaryContent', FileType::class, [
+            'constraints' => [
+                new NotBlank(),
+                new NotNull(),
+            ],
+        ]);
     }
 
     /**
@@ -134,17 +119,11 @@ class FileProvider extends BaseProvider
      */
     public function buildMediaType(FormBuilder $formBuilder)
     {
-        // NEXT_MAJOR: Remove $fileType variable and inline 'Symfony\Component\Form\Extension\Core\Type\FileType'
-        // (when requirement of Symfony is >= 2.8)
-        $fileType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
-            ? 'Symfony\Component\Form\Extension\Core\Type\FileType'
-            : 'file';
-
         if ('api' == $formBuilder->getOption('context')) {
-            $formBuilder->add('binaryContent', $fileType);
+            $formBuilder->add('binaryContent', FileType::class);
             $formBuilder->add('contentType');
         } else {
-            $formBuilder->add('binaryContent', $fileType, [
+            $formBuilder->add('binaryContent', FileType::class, [
                 'required' => false,
                 'label' => 'widget_label_binary_content',
             ]);

--- a/src/Resources/config/gaufrette.xml
+++ b/src/Resources/config/gaufrette.xml
@@ -10,9 +10,7 @@
         <service id="sonata.media.adapter.filesystem.local" class="Sonata\MediaBundle\Filesystem\Local"/>
         <service id="sonata.media.adapter.filesystem.ftp" class="Gaufrette\Adapter\Ftp"/>
         <service id="sonata.media.adapter.service.s3" class="Aws\S3\S3Client">
-            <!-- NEXT_MAJOR: Uncomment Following line
             <factory class="Aws\S3\S3Client" method="factory"/>
-            -->
             <argument type="collection"/>
         </service>
         <service id="sonata.media.adapter.filesystem.s3" class="Gaufrette\Adapter\AwsS3">
@@ -39,9 +37,7 @@
             <argument/>
         </service>
         <service id="sonata.media.adapter.filesystem.opencloud.objectstore" class="OpenCloud\ObjectSource\Service">
-            <!-- NEXT_MAJOR: Uncomment Following line
             <factory service="sonata.media.adapter.filesystem.opencloud.connection" method="ObjectStore"/>
-            -->
             <argument/>
             <argument/>
         </service>

--- a/tests/Admin/BaseMediaAdminTest.php
+++ b/tests/Admin/BaseMediaAdminTest.php
@@ -99,12 +99,7 @@ class BaseMediaAdminTest extends TestCase
 
     private function configureGetProviderName($media)
     {
-        // NEXT_MAJOR remove this block when dropping sf < 2.8 compatibility
-        if (method_exists('Symfony\Component\HttpFoundation\JsonResponse', 'transformJsonError')) {
-            $this->request->get('uniqid[providerName]', null, true)->willReturn('providerName');
-        } else {
-            $this->request->get('uniqid')->willReturn(['providerName' => 'providerName']);
-        }
+        $this->request->get('uniqid')->willReturn(['providerName' => 'providerName']);
         $media->setProviderName('providerName')->shouldBeCalled();
     }
 }

--- a/tests/Controller/GalleryAdminControllerTest.php
+++ b/tests/Controller/GalleryAdminControllerTest.php
@@ -19,6 +19,9 @@ use Symfony\Bridge\Twig\Command\DebugCommand;
 use Symfony\Bridge\Twig\Extension\FormExtension;
 use Symfony\Bridge\Twig\Form\TwigRenderer;
 use Symfony\Component\Form\FormRenderer;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 class GalleryAdminControllerTest extends TestCase
 {
@@ -89,38 +92,22 @@ class GalleryAdminControllerTest extends TestCase
 
     private function configureGetCurrentRequest($request)
     {
-        // NEXT_MAJOR: Remove this trick when bumping Symfony requirement to 2.8+.
-        if (class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            $requestStack = $this->prophesize('Symfony\Component\HttpFoundation\RequestStack');
+        $requestStack = $this->prophesize(RequestStack::class);
 
-            $this->container->has('request_stack')->willReturn(true);
-            $this->container->get('request_stack')->willReturn($requestStack->reveal());
-            $requestStack->getCurrentRequest()->willReturn($request);
-        } else {
-            $this->container->has('request_stack')->willReturn(false);
-            $this->container->get('request')->willReturn($request);
-        }
+        $this->container->has('request_stack')->willReturn(true);
+        $this->container->get('request_stack')->willReturn($requestStack->reveal());
+        $requestStack->getCurrentRequest()->willReturn($request);
     }
 
     private function configureSetCsrfToken($intention)
     {
-        // NEXT_MAJOR: Remove this trick when bumping Symfony requirement to 2.8+.
-        if (interface_exists('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface')) {
-            $tokenManager = $this->prophesize('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface');
-            $token = $this->prophesize('Symfony\Component\Security\Csrf\CsrfToken');
+        $tokenManager = $this->prophesize(CsrfTokenManagerInterface::class);
+        $token = $this->prophesize(CsrfToken::class);
 
-            $tokenManager->getToken($intention)->willReturn($token->reveal());
-            $token->getValue()->willReturn('token');
-            $this->container->has('security.csrf.token_manager')->willReturn(true);
-            $this->container->get('security.csrf.token_manager')->willReturn($tokenManager->reveal());
-        } else {
-            $csrfProvider = $this->prophesize('Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface');
-
-            $csrfProvider->generateCsrfToken($intention)->shouldBeCalled('token');
-            $this->container->has('security.csrf.token_manager')->willReturn(false);
-            $this->container->has('form.csrf_provider')->willReturn(true);
-            $this->container->get('form.csrf_provider')->willReturn($csrfProvider->reveal());
-        }
+        $tokenManager->getToken($intention)->willReturn($token->reveal());
+        $token->getValue()->willReturn('token');
+        $this->container->has('security.csrf.token_manager')->willReturn(true);
+        $this->container->get('security.csrf.token_manager')->willReturn($tokenManager->reveal());
     }
 
     private function configureSetFormTheme($formView, $formTheme)

--- a/tests/Controller/MediaAdminControllerTest.php
+++ b/tests/Controller/MediaAdminControllerTest.php
@@ -19,6 +19,9 @@ use Symfony\Bridge\Twig\Command\DebugCommand;
 use Symfony\Bridge\Twig\Extension\FormExtension;
 use Symfony\Bridge\Twig\Form\TwigRenderer;
 use Symfony\Component\Form\FormRenderer;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 class EntityWithGetId
 {
@@ -167,17 +170,11 @@ class MediaAdminControllerTest extends TestCase
 
     private function configureGetCurrentRequest($request)
     {
-        // NEXT_MAJOR: Remove this trick when bumping Symfony requirement to 2.8+.
-        if (class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            $requestStack = $this->prophesize('Symfony\Component\HttpFoundation\RequestStack');
+        $requestStack = $this->prophesize(RequestStack::class);
 
-            $this->container->has('request_stack')->willReturn(true);
-            $this->container->get('request_stack')->willReturn($requestStack->reveal());
-            $requestStack->getCurrentRequest()->willReturn($request);
-        } else {
-            $this->container->has('request_stack')->willReturn(false);
-            $this->container->get('request')->willReturn($request);
-        }
+        $this->container->has('request_stack')->willReturn(true);
+        $this->container->get('request_stack')->willReturn($requestStack->reveal());
+        $requestStack->getCurrentRequest()->willReturn($request);
     }
 
     private function configureSetFormTheme($formView, $formTheme)
@@ -211,23 +208,13 @@ class MediaAdminControllerTest extends TestCase
 
     private function configureSetCsrfToken($intention)
     {
-        // NEXT_MAJOR: Remove this trick when bumping Symfony requirement to 2.8+.
-        if (interface_exists('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface')) {
-            $tokenManager = $this->prophesize('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface');
-            $token = $this->prophesize('Symfony\Component\Security\Csrf\CsrfToken');
+        $tokenManager = $this->prophesize(CsrfTokenManagerInterface::class);
+        $token = $this->prophesize(CsrfToken::class);
 
-            $tokenManager->getToken($intention)->willReturn($token->reveal());
-            $token->getValue()->willReturn('token');
-            $this->container->has('security.csrf.token_manager')->willReturn(true);
-            $this->container->get('security.csrf.token_manager')->willReturn($tokenManager->reveal());
-        } else {
-            $csrfProvider = $this->prophesize('Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface');
-
-            $csrfProvider->generateCsrfToken($intention)->shouldBeCalled('token');
-            $this->container->has('security.csrf.token_manager')->willReturn(false);
-            $this->container->has('form.csrf_provider')->willReturn(true);
-            $this->container->get('form.csrf_provider')->willReturn($csrfProvider->reveal());
-        }
+        $tokenManager->getToken($intention)->willReturn($token->reveal());
+        $token->getValue()->willReturn('token');
+        $this->container->has('security.csrf.token_manager')->willReturn(true);
+        $this->container->get('security.csrf.token_manager')->willReturn($tokenManager->reveal());
     }
 
     private function configureRender($template, $data, $rendered)

--- a/tests/Controller/MediaControllerTest.php
+++ b/tests/Controller/MediaControllerTest.php
@@ -13,6 +13,7 @@ namespace Sonata\MediaBundle\Tests\Controller;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\MediaBundle\Controller\MediaController;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class MediaControllerTest extends TestCase
 {
@@ -147,17 +148,11 @@ class MediaControllerTest extends TestCase
 
     private function configureGetCurrentRequest($request)
     {
-        // NEXT_MAJOR: Remove this trick when bumping Symfony requirement to 2.8+.
-        if (class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
-            $requestStack = $this->prophesize('Symfony\Component\HttpFoundation\RequestStack');
+        $requestStack = $this->prophesize(RequestStack::class);
 
-            $this->container->has('request_stack')->willReturn(true);
-            $this->container->get('request_stack')->willReturn($requestStack->reveal());
-            $requestStack->getCurrentRequest()->willReturn($request);
-        } else {
-            $this->container->has('request_stack')->willReturn(false);
-            $this->container->get('request')->willReturn($request);
-        }
+        $this->container->has('request_stack')->willReturn(true);
+        $this->container->get('request_stack')->willReturn($requestStack->reveal());
+        $requestStack->getCurrentRequest()->willReturn($request);
     }
 
     private function configureRender($template, $data, $rendered)

--- a/tests/Entity/GalleryManagerTest.php
+++ b/tests/Entity/GalleryManagerTest.php
@@ -22,16 +22,15 @@ class GalleryManagerTest extends TestCase
 {
     public function testGetPager()
     {
-        $self = $this;
         $this
-            ->getGalleryManager(function ($qb) use ($self) {
-                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(['g']));
-                $qb->expects($self->never())->method('andWhere');
-                $qb->expects($self->once())->method('orderBy')->with(
-                    $self->equalTo('g.name'),
-                    $self->equalTo('ASC')
+            ->getGalleryManager(function ($qb) {
+                $qb->expects($this->once())->method('getRootAliases')->will($this->returnValue(['g']));
+                $qb->expects($this->never())->method('andWhere');
+                $qb->expects($this->once())->method('orderBy')->with(
+                    $this->equalTo('g.name'),
+                    $this->equalTo('ASC')
                 );
-                $qb->expects($self->once())->method('setParameters')->with($self->equalTo([]));
+                $qb->expects($this->once())->method('setParameters')->with($this->equalTo([]));
             })
             ->getPager([], 1);
     }
@@ -41,31 +40,29 @@ class GalleryManagerTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Invalid sort field \'invalid\' in \'Sonata\\MediaBundle\\Entity\\BaseGallery\' class');
 
-        $self = $this;
         $this
-            ->getGalleryManager(function ($qb) use ($self) {
+            ->getGalleryManager(function ($qb) {
             })
             ->getPager([], 1, 10, ['invalid' => 'ASC']);
     }
 
     public function testGetPagerWithMultipleSort()
     {
-        $self = $this;
         $this
-            ->getGalleryManager(function ($qb) use ($self) {
-                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(['g']));
-                $qb->expects($self->never())->method('andWhere');
-                $qb->expects($self->exactly(2))->method('orderBy')->with(
-                    $self->logicalOr(
-                        $self->equalTo('g.name'),
-                        $self->equalTo('g.context')
+            ->getGalleryManager(function ($qb) {
+                $qb->expects($this->once())->method('getRootAliases')->will($this->returnValue(['g']));
+                $qb->expects($this->never())->method('andWhere');
+                $qb->expects($this->exactly(2))->method('orderBy')->with(
+                    $this->logicalOr(
+                        $this->equalTo('g.name'),
+                        $this->equalTo('g.context')
                     ),
-                    $self->logicalOr(
-                        $self->equalTo('ASC'),
-                        $self->equalTo('DESC')
+                    $this->logicalOr(
+                        $this->equalTo('ASC'),
+                        $this->equalTo('DESC')
                     )
                 );
-                $qb->expects($self->once())->method('setParameters')->with($self->equalTo([]));
+                $qb->expects($this->once())->method('setParameters')->with($this->equalTo([]));
             })
             ->getPager([], 1, 10, [
                 'name' => 'ASC',
@@ -75,24 +72,22 @@ class GalleryManagerTest extends TestCase
 
     public function testGetPagerWithEnabledGalleries()
     {
-        $self = $this;
         $this
-            ->getGalleryManager(function ($qb) use ($self) {
-                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(['g']));
-                $qb->expects($self->once())->method('andWhere')->with($self->equalTo('g.enabled = :enabled'));
-                $qb->expects($self->once())->method('setParameters')->with($self->equalTo(['enabled' => true]));
+            ->getGalleryManager(function ($qb) {
+                $qb->expects($this->once())->method('getRootAliases')->will($this->returnValue(['g']));
+                $qb->expects($this->once())->method('andWhere')->with($this->equalTo('g.enabled = :enabled'));
+                $qb->expects($this->once())->method('setParameters')->with($this->equalTo(['enabled' => true]));
             })
             ->getPager(['enabled' => true], 1);
     }
 
     public function testGetPagerWithNoEnabledGalleries()
     {
-        $self = $this;
         $this
-            ->getGalleryManager(function ($qb) use ($self) {
-                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(['g']));
-                $qb->expects($self->once())->method('andWhere')->with($self->equalTo('g.enabled = :enabled'));
-                $qb->expects($self->once())->method('setParameters')->with($self->equalTo(['enabled' => false]));
+            ->getGalleryManager(function ($qb) {
+                $qb->expects($this->once())->method('getRootAliases')->will($this->returnValue(['g']));
+                $qb->expects($this->once())->method('andWhere')->with($this->equalTo('g.enabled = :enabled'));
+                $qb->expects($this->once())->method('setParameters')->with($this->equalTo(['enabled' => false]));
             })
             ->getPager(['enabled' => false], 1);
     }

--- a/tests/Form/Type/AbstractTypeTest.php
+++ b/tests/Form/Type/AbstractTypeTest.php
@@ -45,32 +45,13 @@ abstract class AbstractTypeTest extends TypeTestCase
         $this->mediaPool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
         $this->mediaPool->expects($this->any())->method('getProvider')->willReturn($provider);
 
-        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
-        $that = $this;
-
         $this->formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
         $this->formBuilder
             ->expects($this->any())
             ->method('add')
-            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
-                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-                    if (null !== $type) {
-                        $isFQCN = class_exists($type);
-                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                            // 2.8
-                            @trigger_error(
-                                sprintf(
-                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                                    .' Use the fully-qualified type class name instead.',
-                                    $type
-                                ),
-                                E_USER_DEPRECATED)
-                            ;
-                        }
-
-                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
-                    }
+            ->will($this->returnCallback(function ($name, $type = null) {
+                if (null !== $type) {
+                    $this->assertTrue(class_exists($type), sprintf('Unable to ensure %s is a FQCN', $type));
                 }
             }));
 
@@ -90,25 +71,8 @@ abstract class AbstractTypeTest extends TypeTestCase
 
     public function testGetParent()
     {
-        // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            $parentRef = $this->formType->getParent();
-
-            $isFQCN = class_exists($parentRef);
-            if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                // 2.8
-                @trigger_error(
-                    sprintf(
-                        'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                        .' Use the fully-qualified type class name instead.',
-                        $parentRef
-                    ),
-                    E_USER_DEPRECATED)
-                ;
-            }
-
-            $this->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $parentRef));
-        }
+        $parentRef = $this->formType->getParent();
+        $this->assertTrue(class_exists($parentRef), sprintf('Unable to ensure %s is a FQCN', $parentRef));
     }
 
     /**

--- a/tests/Form/Type/MediaTypeTest.php
+++ b/tests/Form/Type/MediaTypeTest.php
@@ -13,6 +13,7 @@ namespace Sonata\MediaBundle\Tests\Form\Type;
 
 use Sonata\MediaBundle\Form\Type\MediaType;
 use Symfony\Component\Form\Forms;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 /**
  * @author Virgile Vivier <virgilevivier@gmail.com>
@@ -108,22 +109,10 @@ class MediaTypeTest extends AbstractTypeTest
             'pic' => [],
         ]));
 
-        // NEXT_MAJOR: Remove this hack when dropping support for symfony 2.3
-        if (class_exists('Symfony\Component\Validator\Validator\RecursiveValidator')) {
-            $this->expectException(
-                'Symfony\Component\OptionsResolver\Exception\InvalidOptionsException'
-            );
-            $this->expectExceptionMessage(
-                'The option "provider" with value "provider_c" is invalid. Accepted values are: "provider_a", "provider_b".'
-            );
-        } else {
-            $this->expectException(
-                'Symfony\Component\OptionsResolver\Exception\InvalidOptionsException'
-            );
-            $this->expectExceptionMessage(
-                'The option "provider" has the value "provider_c", but is expected to be one of "provider_a", "provider_b"'
-            );
-        }
+        $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessage(
+            'The option "provider" with value "provider_c" is invalid. Accepted values are: "provider_a", "provider_b".'
+        );
 
         $this->factory->create($this->getFormType(), null, [
             'provider' => 'provider_c',
@@ -142,22 +131,10 @@ class MediaTypeTest extends AbstractTypeTest
             'pic' => [],
         ]));
 
-        // NEXT_MAJOR: Remove this hack when dropping support for symfony 2.3
-        if (class_exists('Symfony\Component\Validator\Validator\RecursiveValidator')) {
-            $this->expectException(
-                'Symfony\Component\OptionsResolver\Exception\InvalidOptionsException'
-            );
-            $this->expectExceptionMessage(
-                'The option "context" with value "photo" is invalid. Accepted values are: "video", "pic".'
-            );
-        } else {
-            $this->expectException(
-                'Symfony\Component\OptionsResolver\Exception\InvalidOptionsException'
-            );
-            $this->expectExceptionMessage(
-                'The option "context" has the value "photo", but is expected to be one of "video", "pic"'
-            );
-        }
+        $this->expectException(InvalidOptionsException::class);
+        $this->expectExceptionMessage(
+            'The option "context" with value "photo" is invalid. Accepted values are: "video", "pic".'
+        );
 
         $this->factory->create($this->getFormType(), null, [
             'provider' => 'provider_b',
@@ -172,8 +149,6 @@ class MediaTypeTest extends AbstractTypeTest
 
     private function getFormType()
     {
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ?
-            'Sonata\MediaBundle\Form\Type\MediaType' :
-            'sonata_media_type';
+        return MediaType::class;
     }
 }

--- a/tests/Provider/AbstractProviderTest.php
+++ b/tests/Provider/AbstractProviderTest.php
@@ -44,32 +44,13 @@ abstract class AbstractProviderTest extends TestCase
 
     protected function setUp()
     {
-        // NEXT_MAJOR: Hack for php 5.3 only, remove it when requirement of PHP is >= 5.4
-        $that = $this;
-
         $this->formMapper = $this->getMockBuilder('Sonata\AdminBundle\Form\FormMapper')->disableOriginalConstructor()->getMock();
         $this->formMapper
             ->expects($this->any())
             ->method('add')
-            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
-                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-                    if (null !== $type) {
-                        $isFQCN = class_exists($type);
-                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                            // 2.8
-                            @trigger_error(
-                                sprintf(
-                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                                    .' Use the fully-qualified type class name instead.',
-                                    $type
-                                ),
-                                E_USER_DEPRECATED)
-                            ;
-                        }
-
-                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
-                    }
+            ->will($this->returnCallback(function ($name, $type = null) {
+                if (null !== $type) {
+                    $this->assertTrue(class_exists($type), sprintf('Unable to ensure %s is a FQCN', $type));
                 }
             }));
 
@@ -77,25 +58,9 @@ abstract class AbstractProviderTest extends TestCase
         $this->formBuilder
             ->expects($this->any())
             ->method('add')
-            ->will($this->returnCallback(function ($name, $type = null) use ($that) {
-                // NEXT_MAJOR: Remove this "if" (when requirement of Symfony is >= 2.8)
-                if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-                    if (null !== $type) {
-                        $isFQCN = class_exists($type);
-                        if (!$isFQCN && method_exists('Symfony\Component\Form\AbstractType', 'getName')) {
-                            // 2.8
-                            @trigger_error(
-                                sprintf(
-                                    'Accessing type "%s" by its string name is deprecated since version 2.8 and will be removed in 3.0.'
-                                    .' Use the fully-qualified type class name instead.',
-                                    $type
-                                ),
-                                E_USER_DEPRECATED)
-                            ;
-                        }
-
-                        $that->assertTrue($isFQCN, sprintf('Unable to ensure %s is a FQCN', $type));
-                    }
+            ->will($this->returnCallback(function ($name, $type = null) {
+                if (null !== $type) {
+                    $this->assertTrue(class_exists($type), sprintf('Unable to ensure %s is a FQCN', $type));
                 }
             }));
 

--- a/tests/Provider/FileProviderTest.php
+++ b/tests/Provider/FileProviderTest.php
@@ -175,14 +175,12 @@ class FileProviderTest extends AbstractProviderTest
      */
     public function testTransform($expected, $media)
     {
-        $self = $this;
-
-        $closure = function () use ($self, $expected, $media) {
-            $provider = $self->getProvider();
+        $closure = function () use ($expected, $media) {
+            $provider = $this->getProvider();
 
             $provider->transform($media);
 
-            $self->assertInstanceOf($expected, $media->getBinaryContent());
+            $this->assertInstanceOf($expected, $media->getBinaryContent());
         };
 
         $closure();

--- a/tests/Security/RolesDownloadStrategyTest.php
+++ b/tests/Security/RolesDownloadStrategyTest.php
@@ -13,6 +13,7 @@ namespace Sonata\MediaBundle\Tests\Security;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\MediaBundle\Security\RolesDownloadStrategy;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class RolesDownloadStrategyTest extends TestCase
 {
@@ -21,13 +22,7 @@ class RolesDownloadStrategyTest extends TestCase
         $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
         $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
-
-        // Prefer the Symfony 2.6+ API if available
-        if (interface_exists('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')) {
-            $security = $this->createMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
-        } else {
-            $security = $this->createMock('Symfony\Component\Security\Core\SecurityContextInterface');
-        }
+        $security = $this->createMock(AuthorizationCheckerInterface::class);
 
         $security->expects($this->any())
             ->method('isGranted')
@@ -44,13 +39,7 @@ class RolesDownloadStrategyTest extends TestCase
         $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
         $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
         $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
-
-        // Prefer the Symfony 2.6+ API if available
-        if (interface_exists('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')) {
-            $security = $this->createMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
-        } else {
-            $security = $this->createMock('Symfony\Component\Security\Core\SecurityContextInterface');
-        }
+        $security = $this->createMock(AuthorizationCheckerInterface::class);
 
         $security->expects($this->any())
             ->method('isGranted')

--- a/tests/Validator/FormatValidatorTest.php
+++ b/tests/Validator/FormatValidatorTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Sonata\MediaBundle\Provider\Pool;
 use Sonata\MediaBundle\Validator\Constraints\ValidMediaFormat;
 use Sonata\MediaBundle\Validator\FormatValidator;
+use Symfony\Component\Validator\Context\ExecutionContext;
 
 class FormatValidatorTest extends TestCase
 {
@@ -27,16 +28,7 @@ class FormatValidatorTest extends TestCase
         $gallery->expects($this->once())->method('getDefaultFormat')->will($this->returnValue('format1'));
         $gallery->expects($this->once())->method('getContext')->will($this->returnValue('test'));
 
-        // Prefer the Symfony 2.5+ API if available
-        if (class_exists('Symfony\Component\Validator\Context\ExecutionContext')) {
-            $contextClass = 'Symfony\Component\Validator\Context\ExecutionContext';
-        } else {
-            $contextClass = 'Symfony\Component\Validator\ExecutionContext';
-        }
-
-        $context = $this->getMockBuilder($contextClass)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $context = $this->createMock(ExecutionContext::class);
         $context->expects($this->never())->method('addViolation');
 
         $validator = new FormatValidator($pool);
@@ -54,16 +46,7 @@ class FormatValidatorTest extends TestCase
         $gallery->expects($this->once())->method('getDefaultFormat')->will($this->returnValue('non_existing_format'));
         $gallery->expects($this->once())->method('getContext')->will($this->returnValue('test'));
 
-        // Prefer the Symfony 2.5+ API if available
-        if (class_exists('Symfony\Component\Validator\Context\ExecutionContext')) {
-            $contextClass = 'Symfony\Component\Validator\Context\ExecutionContext';
-        } else {
-            $contextClass = 'Symfony\Component\Validator\ExecutionContext';
-        }
-
-        $context = $this->getMockBuilder($contextClass)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $context = $this->createMock(ExecutionContext::class);
         $context->expects($this->once())->method('addViolation');
 
         $validator = new FormatValidator($pool);
@@ -81,16 +64,7 @@ class FormatValidatorTest extends TestCase
         $gallery->expects($this->once())->method('getDefaultFormat')->will($this->returnValue('format_that_is_not_reference'));
         $gallery->expects($this->once())->method('getContext')->will($this->returnValue('test'));
 
-        // Prefer the Symfony 2.5+ API if available
-        if (class_exists('Symfony\Component\Validator\Context\ExecutionContext')) {
-            $contextClass = 'Symfony\Component\Validator\Context\ExecutionContext';
-        } else {
-            $contextClass = 'Symfony\Component\Validator\ExecutionContext';
-        }
-
-        $context = $this->getMockBuilder($contextClass)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $context = $this->createMock(ExecutionContext::class);
         $context->expects($this->once())->method('addViolation');
 
         $validator = new FormatValidator($pool);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataCoreBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

### Subject

<!-- Describe your Pull Request content here -->
Removing old code that never gets executed because we dropped SF 2.3 to 2.7