### PR TITLE
Replace FQCN strings with ::class constants

### DIFF
--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -11,7 +11,55 @@
 
 namespace Sonata\MediaBundle\DependencyInjection;
 
+use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\EasyExtendsBundle\Mapper\DoctrineCollector;
+use Sonata\MediaBundle\CDN\CDNInterface;
+use Sonata\MediaBundle\CDN\CloudFront;
+use Sonata\MediaBundle\CDN\Fallback;
+use Sonata\MediaBundle\CDN\PantherPortal;
+use Sonata\MediaBundle\CDN\Server;
+use Sonata\MediaBundle\Extra\Pixlr;
+use Sonata\MediaBundle\Filesystem\Local;
+use Sonata\MediaBundle\Filesystem\Replicate;
+use Sonata\MediaBundle\Generator\DefaultGenerator;
+use Sonata\MediaBundle\Generator\GeneratorInterface;
+use Sonata\MediaBundle\Generator\ODMGenerator;
+use Sonata\MediaBundle\Generator\PHPCRGenerator;
+use Sonata\MediaBundle\Metadata\AmazonMetadataBuilder;
+use Sonata\MediaBundle\Metadata\MetadataBuilderInterface;
+use Sonata\MediaBundle\Metadata\NoopMetadataBuilder;
+use Sonata\MediaBundle\Metadata\ProxyMetadataBuilder;
+use Sonata\MediaBundle\Model\Gallery;
+use Sonata\MediaBundle\Model\GalleryHasMedia;
+use Sonata\MediaBundle\Model\GalleryHasMediaInterface;
+use Sonata\MediaBundle\Model\GalleryInterface;
+use Sonata\MediaBundle\Model\GalleryManager;
+use Sonata\MediaBundle\Model\GalleryManagerInterface;
+use Sonata\MediaBundle\Model\Media;
+use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Model\MediaManagerInterface;
+use Sonata\MediaBundle\Provider\BaseProvider;
+use Sonata\MediaBundle\Provider\BaseVideoProvider;
+use Sonata\MediaBundle\Provider\DailyMotionProvider;
+use Sonata\MediaBundle\Provider\FileProvider;
+use Sonata\MediaBundle\Provider\ImageProvider;
+use Sonata\MediaBundle\Provider\MediaProviderInterface;
+use Sonata\MediaBundle\Provider\Pool;
+use Sonata\MediaBundle\Provider\VimeoProvider;
+use Sonata\MediaBundle\Provider\YouTubeProvider;
+use Sonata\MediaBundle\Resizer\ResizerInterface;
+use Sonata\MediaBundle\Resizer\SimpleResizer;
+use Sonata\MediaBundle\Resizer\SquareResizer;
+use Sonata\MediaBundle\Security\DownloadStrategyInterface;
+use Sonata\MediaBundle\Security\ForbiddenDownloadStrategy;
+use Sonata\MediaBundle\Security\PublicDownloadStrategy;
+use Sonata\MediaBundle\Security\RolesDownloadStrategy;
+use Sonata\MediaBundle\Security\SessionDownloadStrategy;
+use Sonata\MediaBundle\Templating\Helper\MediaHelper;
+use Sonata\MediaBundle\Thumbnail\ConsumerThumbnail;
+use Sonata\MediaBundle\Thumbnail\FormatThumbnail;
+use Sonata\MediaBundle\Thumbnail\ThumbnailInterface;
+use Sonata\MediaBundle\Twig\Extension\MediaExtension;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -506,53 +554,53 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
         }
 
         $this->addClassesToCompile([
-            'Sonata\\MediaBundle\\CDN\\CDNInterface',
-            'Sonata\\MediaBundle\\CDN\\CloudFront',
-            'Sonata\\MediaBundle\\CDN\\Fallback',
-            'Sonata\\MediaBundle\\CDN\\PantherPortal',
-            'Sonata\\MediaBundle\\CDN\\Server',
-            'Sonata\\MediaBundle\\Extra\\Pixlr',
-            'Sonata\\MediaBundle\\Filesystem\\Local',
-            'Sonata\\MediaBundle\\Filesystem\\Replicate',
-            'Sonata\\MediaBundle\\Generator\\DefaultGenerator',
-            'Sonata\\MediaBundle\\Generator\\GeneratorInterface',
-            'Sonata\\MediaBundle\\Generator\\ODMGenerator',
-            'Sonata\\MediaBundle\\Generator\\PHPCRGenerator',
-            'Sonata\\MediaBundle\\Metadata\\AmazonMetadataBuilder',
-            'Sonata\\MediaBundle\\Metadata\\MetadataBuilderInterface',
-            'Sonata\\MediaBundle\\Metadata\\NoopMetadataBuilder',
-            'Sonata\\MediaBundle\\Metadata\\ProxyMetadataBuilder',
-            'Sonata\\MediaBundle\\Model\\Gallery',
-            'Sonata\\MediaBundle\\Model\\GalleryHasMedia',
-            'Sonata\\MediaBundle\\Model\\GalleryHasMediaInterface',
-            'Sonata\\MediaBundle\\Model\\GalleryInterface',
-            'Sonata\\MediaBundle\\Model\\GalleryManager',
-            'Sonata\\MediaBundle\\Model\\GalleryManagerInterface',
-            'Sonata\\MediaBundle\\Model\\Media',
-            'Sonata\\MediaBundle\\Model\\MediaInterface',
-            'Sonata\\MediaBundle\\Model\\MediaManagerInterface',
-            'Sonata\\MediaBundle\\Provider\\BaseProvider',
-            'Sonata\\MediaBundle\\Provider\\BaseVideoProvider',
-            'Sonata\\MediaBundle\\Provider\\DailyMotionProvider',
-            'Sonata\\MediaBundle\\Provider\\FileProvider',
-            'Sonata\\MediaBundle\\Provider\\ImageProvider',
-            'Sonata\\MediaBundle\\Provider\\MediaProviderInterface',
-            'Sonata\\MediaBundle\\Provider\\Pool',
-            'Sonata\\MediaBundle\\Provider\\VimeoProvider',
-            'Sonata\\MediaBundle\\Provider\\YouTubeProvider',
-            'Sonata\\MediaBundle\\Resizer\\ResizerInterface',
-            'Sonata\\MediaBundle\\Resizer\\SimpleResizer',
-            'Sonata\\MediaBundle\\Resizer\\SquareResizer',
-            'Sonata\\MediaBundle\\Security\\DownloadStrategyInterface',
-            'Sonata\\MediaBundle\\Security\\ForbiddenDownloadStrategy',
-            'Sonata\\MediaBundle\\Security\\PublicDownloadStrategy',
-            'Sonata\\MediaBundle\\Security\\RolesDownloadStrategy',
-            'Sonata\\MediaBundle\\Security\\SessionDownloadStrategy',
-            'Sonata\\MediaBundle\\Templating\\Helper\\MediaHelper',
-            'Sonata\\MediaBundle\\Thumbnail\\ConsumerThumbnail',
-            'Sonata\\MediaBundle\\Thumbnail\\FormatThumbnail',
-            'Sonata\\MediaBundle\\Thumbnail\\ThumbnailInterface',
-            'Sonata\\MediaBundle\\Twig\\Extension\\MediaExtension',
+            CDNInterface::class,
+            CloudFront::class,
+            Fallback::class,
+            PantherPortal::class,
+            Server::class,
+            Pixlr::class,
+            Local::class,
+            Replicate::class,
+            DefaultGenerator::class,
+            GeneratorInterface::class,
+            ODMGenerator::class,
+            PHPCRGenerator::class,
+            AmazonMetadataBuilder::class,
+            MetadataBuilderInterface::class,
+            NoopMetadataBuilder::class,
+            ProxyMetadataBuilder::class,
+            Gallery::class,
+            GalleryHasMedia::class,
+            GalleryHasMediaInterface::class,
+            GalleryInterface::class,
+            GalleryManager::class,
+            GalleryManagerInterface::class,
+            Media::class,
+            MediaInterface::class,
+            MediaManagerInterface::class,
+            BaseProvider::class,
+            BaseVideoProvider::class,
+            DailyMotionProvider::class,
+            FileProvider::class,
+            ImageProvider::class,
+            MediaProviderInterface::class,
+            Pool::class,
+            VimeoProvider::class,
+            YouTubeProvider::class,
+            ResizerInterface::class,
+            SimpleResizer::class,
+            SquareResizer::class,
+            DownloadStrategyInterface::class,
+            ForbiddenDownloadStrategy::class,
+            PublicDownloadStrategy::class,
+            RolesDownloadStrategy::class,
+            SessionDownloadStrategy::class,
+            MediaHelper::class,
+            ConsumerThumbnail::class,
+            FormatThumbnail::class,
+            ThumbnailInterface::class,
+            MediaExtension::class,
         ]);
     }
 
@@ -580,7 +628,7 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
      */
     private function isClassificationEnabled(array $config)
     {
-        return interface_exists('Sonata\ClassificationBundle\Model\CategoryInterface')
+        return interface_exists(CategoryInterface::class)
             && !$config['force_disable_category'];
     }
 

--- a/src/Metadata/ProxyMetadataBuilder.php
+++ b/src/Metadata/ProxyMetadataBuilder.php
@@ -11,6 +11,8 @@
 
 namespace Sonata\MediaBundle\Metadata;
 
+use Gaufrette\Adapter\AmazonS3;
+use Gaufrette\Adapter\AwsS3;
 use Sonata\MediaBundle\Filesystem\Replicate;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -79,7 +81,7 @@ class ProxyMetadataBuilder implements MetadataBuilderInterface
         }
 
         //for amazon s3
-        if ((!in_array('Gaufrette\Adapter\AmazonS3', $adapterClassNames) && !in_array('Gaufrette\Adapter\AwsS3', $adapterClassNames)) || !$this->container->has('sonata.media.metadata.amazon')) {
+        if ((!in_array(AmazonS3::class, $adapterClassNames) && !in_array(AwsS3::class, $adapterClassNames)) || !$this->container->has('sonata.media.metadata.amazon')) {
             return false;
         }
 

--- a/src/Model/Media.php
+++ b/src/Model/Media.php
@@ -12,6 +12,7 @@
 namespace Sonata\MediaBundle\Model;
 
 use Imagine\Image\Box;
+use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -158,7 +159,7 @@ abstract class Media implements MediaInterface
     public function __set($property, $value)
     {
         if ('category' == $property) {
-            if (null !== $value && !is_a($value, 'Sonata\ClassificationBundle\Model\CategoryInterface')) {
+            if (null !== $value && !is_a($value, CategoryInterface::class)) {
                 throw new \InvalidArgumentException(
                     '$category should be an instance of Sonata\ClassificationBundle\Model\CategoryInterface or null'
                 );

--- a/src/PHPCR/BaseGallery.php
+++ b/src/PHPCR/BaseGallery.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\MediaBundle\PHPCR;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Sonata\MediaBundle\Model\Gallery;
 use Sonata\MediaBundle\Model\GalleryHasMediaInterface;
 
@@ -29,7 +30,7 @@ abstract class BaseGallery extends Gallery
      */
     public function __construct()
     {
-        $this->galleryHasMedias = new \Doctrine\Common\Collections\ArrayCollection();
+        $this->galleryHasMedias = new ArrayCollection();
     }
 
     /**

--- a/src/Provider/FileProvider.php
+++ b/src/Provider/FileProvider.php
@@ -17,6 +17,7 @@ use Sonata\CoreBundle\Model\Metadata;
 use Sonata\CoreBundle\Validator\ErrorElement;
 use Sonata\MediaBundle\CDN\CDNInterface;
 use Sonata\MediaBundle\Extra\ApiMediaFile;
+use Sonata\MediaBundle\Filesystem\Local;
 use Sonata\MediaBundle\Generator\GeneratorInterface;
 use Sonata\MediaBundle\Metadata\MetadataBuilderInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
@@ -261,7 +262,7 @@ class FileProvider extends BaseProvider
             }, 200, $headers);
         }
 
-        if (!$this->getFilesystem()->getAdapter() instanceof \Sonata\MediaBundle\Filesystem\Local) {
+        if (!$this->getFilesystem()->getAdapter() instanceof Local) {
             throw new \RuntimeException('Cannot use X-Sendfile or X-Accel-Redirect with non \Sonata\MediaBundle\Filesystem\Local');
         }
 

--- a/src/SonataMediaBundle.php
+++ b/src/SonataMediaBundle.php
@@ -15,6 +15,11 @@ use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\MediaBundle\DependencyInjection\Compiler\AddProviderCompilerPass;
 use Sonata\MediaBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass;
 use Sonata\MediaBundle\DependencyInjection\Compiler\SecurityContextCompilerPass;
+use Sonata\MediaBundle\Form\Type\ApiDoctrineMediaType;
+use Sonata\MediaBundle\Form\Type\ApiGalleryHasMediaType;
+use Sonata\MediaBundle\Form\Type\ApiGalleryType;
+use Sonata\MediaBundle\Form\Type\ApiMediaType;
+use Sonata\MediaBundle\Form\Type\MediaType;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -51,11 +56,11 @@ class SonataMediaBundle extends Bundle
     public function registerFormMapping()
     {
         FormHelper::registerFormTypeMapping([
-            'sonata_media_type' => 'Sonata\MediaBundle\Form\Type\MediaType',
-            'sonata_media_api_form_media' => 'Sonata\MediaBundle\Form\Type\ApiMediaType',
-            'sonata_media_api_form_doctrine_media' => 'Sonata\MediaBundle\Form\Type\ApiDoctrineMediaType',
-            'sonata_media_api_form_gallery' => 'Sonata\MediaBundle\Form\Type\ApiGalleryType',
-            'sonata_media_api_form_gallery_has_media' => 'Sonata\MediaBundle\Form\Type\ApiGalleryHasMediaType',
+            'sonata_media_type' => MediaType::class,
+            'sonata_media_api_form_media' => ApiMediaType::class,
+            'sonata_media_api_form_doctrine_media' => ApiDoctrineMediaType::class,
+            'sonata_media_api_form_gallery' => ApiGalleryType::class,
+            'sonata_media_api_form_gallery_has_media' => ApiGalleryHasMediaType::class,
         ]);
     }
 }

--- a/src/Twig/Extension/FormatterMediaExtension.php
+++ b/src/Twig/Extension/FormatterMediaExtension.php
@@ -12,6 +12,7 @@
 namespace Sonata\MediaBundle\Twig\Extension;
 
 use Sonata\FormatterBundle\Extension\BaseProxyExtension;
+use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Twig\TokenParser\MediaTokenParser;
 use Sonata\MediaBundle\Twig\TokenParser\PathTokenParser;
 use Sonata\MediaBundle\Twig\TokenParser\ThumbnailTokenParser;
@@ -49,7 +50,7 @@ class FormatterMediaExtension extends BaseProxyExtension
     public function getAllowedMethods()
     {
         return [
-            'Sonata\MediaBundle\Model\MediaInterface' => [
+            MediaInterface::class => [
                 'getproviderreference',
             ],
         ];

--- a/tests/Admin/BaseMediaAdminTest.php
+++ b/tests/Admin/BaseMediaAdminTest.php
@@ -12,7 +12,17 @@
 namespace Sonata\MediaBundle\Tests\Admin;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\ClassificationBundle\Model\CategoryInterface;
+use Sonata\ClassificationBundle\Model\ContextInterface;
 use Sonata\MediaBundle\Admin\BaseMediaAdmin;
+use Sonata\MediaBundle\Entity\BaseMedia;
+use Sonata\MediaBundle\Model\CategoryManagerInterface;
+use Sonata\MediaBundle\Model\Media;
+use Sonata\MediaBundle\Provider\MediaProviderInterface;
+use Sonata\MediaBundle\Provider\Pool;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
 
 class TestMediaAdmin extends BaseMediaAdmin
 {
@@ -35,14 +45,14 @@ class BaseMediaAdminTest extends TestCase
 
     protected function setUp()
     {
-        $this->pool = $this->prophesize('Sonata\MediaBundle\Provider\Pool');
-        $this->categoryManager = $this->prophesize('Sonata\MediaBundle\Model\CategoryManagerInterface');
-        $this->request = $this->prophesize('Symfony\Component\HttpFoundation\Request');
-        $this->modelManager = $this->prophesize('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $this->pool = $this->prophesize(Pool::class);
+        $this->categoryManager = $this->prophesize(CategoryManagerInterface::class);
+        $this->request = $this->prophesize(Request::class);
+        $this->modelManager = $this->prophesize(ModelManagerInterface::class);
 
         $this->mediaAdmin = new TestMediaAdmin(
             null,
-            'Sonata\MediaBundle\Entity\BaseMedia',
+            BaseMedia::class,
             'SonataMediaBundle:MediaAdmin',
             $this->pool->reveal(),
             $this->categoryManager->reveal()
@@ -54,17 +64,17 @@ class BaseMediaAdminTest extends TestCase
 
     public function testGetNewInstance()
     {
-        $media = $this->prophesize('Sonata\MediaBundle\Model\Media');
+        $media = $this->prophesize(Media::class);
         $category = $this->prophesize();
-        $category->willExtend('Sonata\MediaBundle\Tests\Admin\EntityWithGetId');
-        $category->willImplement('Sonata\ClassificationBundle\Model\CategoryInterface');
+        $category->willExtend(EntityWithGetId::class);
+        $category->willImplement(CategoryInterface::class);
         $context = $this->prophesize();
-        $context->willExtend('Sonata\MediaBundle\Tests\Admin\EntityWithGetId');
-        $context->willImplement('Sonata\ClassificationBundle\Model\ContextInterface');
+        $context->willExtend(EntityWithGetId::class);
+        $context->willImplement(ContextInterface::class);
 
         $this->configureGetPersistentParameters();
         $this->configureGetProviderName($media);
-        $this->modelManager->getModelInstance('Sonata\MediaBundle\Entity\BaseMedia')->willReturn($media->reveal());
+        $this->modelManager->getModelInstance(BaseMedia::class)->willReturn($media->reveal());
         $this->categoryManager->find(1)->willReturn($category->reveal());
         $this->request->isMethod('POST')->willReturn(true);
         $this->request->get('context')->willReturn('context');
@@ -79,11 +89,11 @@ class BaseMediaAdminTest extends TestCase
 
     private function configureGetPersistentParameters()
     {
-        $provider = $this->prophesize('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->prophesize(MediaProviderInterface::class);
         $category = $this->prophesize();
-        $category->willExtend('Sonata\MediaBundle\Tests\Admin\EntityWithGetId');
-        $category->willImplement('Sonata\ClassificationBundle\Model\CategoryInterface');
-        $query = $this->prophesize('Symfony\Component\HttpFoundation\ParameterBag');
+        $category->willExtend(EntityWithGetId::class);
+        $category->willImplement(CategoryInterface::class);
+        $query = $this->prophesize(ParameterBag::class);
         $this->request->query = $query->reveal();
 
         $this->pool->getDefaultContext()->willReturn('default_context');

--- a/tests/Admin/GalleryAdminTest.php
+++ b/tests/Admin/GalleryAdminTest.php
@@ -12,7 +12,10 @@
 namespace Sonata\MediaBundle\Tests\Admin;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\ClassificationBundle\Entity\CategoryManager;
 use Sonata\MediaBundle\Admin\GalleryAdmin;
+use Sonata\MediaBundle\Entity\BaseGallery;
+use Sonata\MediaBundle\Provider\Pool;
 
 class GalleryAdminTest extends TestCase
 {
@@ -22,12 +25,12 @@ class GalleryAdminTest extends TestCase
 
     protected function setUp()
     {
-        $this->pool = $this->prophesize('Sonata\MediaBundle\Provider\Pool');
-        $this->categoryManager = $this->prophesize('Sonata\ClassificationBundle\Entity\CategoryManager');
+        $this->pool = $this->prophesize(Pool::class);
+        $this->categoryManager = $this->prophesize(CategoryManager::class);
 
         $this->mediaAdmin = new GalleryAdmin(
             null,
-            'Sonata\MediaBundle\Entity\BaseGallery',
+            BaseGallery::class,
             'SonataMediaBundle:GalleryAdmin',
             $this->pool->reveal(),
             $this->categoryManager->reveal()

--- a/tests/Admin/GalleryHasMediaAdminTest.php
+++ b/tests/Admin/GalleryHasMediaAdminTest.php
@@ -13,6 +13,7 @@ namespace Sonata\MediaBundle\Tests\Admin;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\MediaBundle\Admin\GalleryHasMediaAdmin;
+use Sonata\MediaBundle\Entity\BaseGallery;
 
 class GalleryHasMediaAdminTest extends TestCase
 {
@@ -22,7 +23,7 @@ class GalleryHasMediaAdminTest extends TestCase
     {
         $this->mediaAdmin = new GalleryHasMediaAdmin(
             null,
-            'Sonata\MediaBundle\Entity\BaseGallery',
+            BaseGallery::class,
             'SonataMediaBundle:GalleryAdmin'
         );
     }

--- a/tests/Admin/ORM/MediaAdminTest.php
+++ b/tests/Admin/ORM/MediaAdminTest.php
@@ -13,6 +13,9 @@ namespace Sonata\MediaBundle\Tests\Admin\ORM;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\MediaBundle\Admin\ORM\MediaAdmin;
+use Sonata\MediaBundle\Entity\BaseMedia;
+use Sonata\MediaBundle\Model\CategoryManagerInterface;
+use Sonata\MediaBundle\Provider\Pool;
 
 class MediaAdminTest extends TestCase
 {
@@ -22,12 +25,12 @@ class MediaAdminTest extends TestCase
 
     protected function setUp()
     {
-        $this->pool = $this->prophesize('Sonata\MediaBundle\Provider\Pool');
-        $this->categoryManager = $this->prophesize('Sonata\MediaBundle\Model\CategoryManagerInterface');
+        $this->pool = $this->prophesize(Pool::class);
+        $this->categoryManager = $this->prophesize(CategoryManagerInterface::class);
 
         $this->mediaAdmin = new MediaAdmin(
             null,
-            'Sonata\MediaBundle\Entity\BaseMedia',
+            BaseMedia::class,
             'SonataMediaBundle:MediaAdmin',
             $this->pool->reveal(),
             $this->categoryManager->reveal()

--- a/tests/Block/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Block/Breadcrumb/BreadcrumbTest.php
@@ -11,8 +11,11 @@
 
 namespace Sonata\MediaBundle\Tests\Block\Breadcrumb;
 
+use Knp\Menu\FactoryInterface;
+use Knp\Menu\Provider\MenuProviderInterface;
 use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
 use Sonata\MediaBundle\Block\Breadcrumb\BaseGalleryBreadcrumbBlockService;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 
 class BreadcrumbGalleryBlockService_Test extends BaseGalleryBreadcrumbBlockService
 {
@@ -28,9 +31,9 @@ class BreadcrumbTest extends AbstractBlockServiceTestCase
         $blockService = new BreadcrumbGalleryBlockService_Test(
             'context',
             'name',
-            $this->prophesize('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface')->reveal(),
-            $this->prophesize('Knp\Menu\Provider\MenuProviderInterface')->reveal(),
-            $this->prophesize('Knp\Menu\FactoryInterface')->reveal()
+            $this->prophesize(EngineInterface::class)->reveal(),
+            $this->prophesize(MenuProviderInterface::class)->reveal(),
+            $this->prophesize(FactoryInterface::class)->reveal()
         );
 
         $this->assertTrue($blockService->handleContext('context'));

--- a/tests/Block/FeatureMediaBlockServiceTest.php
+++ b/tests/Block/FeatureMediaBlockServiceTest.php
@@ -13,6 +13,8 @@ namespace Sonata\MediaBundle\Tests\Block;
 
 use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
 use Sonata\MediaBundle\Block\FeatureMediaBlockService;
+use Sonata\MediaBundle\Model\GalleryManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class FeatureMediaBlockServiceTest extends AbstractBlockServiceTestCase
 {
@@ -24,8 +26,8 @@ class FeatureMediaBlockServiceTest extends AbstractBlockServiceTestCase
     {
         parent::setUp();
 
-        $this->container = $this->prophesize('Symfony\Component\DependencyInjection\ContainerInterface');
-        $this->galleryManager = $this->prophesize('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->galleryManager = $this->prophesize(GalleryManagerInterface::class);
 
         $this->blockService = new FeatureMediaBlockService(
             'block.service',

--- a/tests/Block/GalleryBlockServiceTest.php
+++ b/tests/Block/GalleryBlockServiceTest.php
@@ -11,8 +11,13 @@
 
 namespace Sonata\MediaBundle\Tests\Block;
 
+use Sonata\BlockBundle\Block\BlockContext;
+use Sonata\BlockBundle\Model\Block;
 use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
 use Sonata\MediaBundle\Block\GalleryBlockService;
+use Sonata\MediaBundle\Model\GalleryInterface;
+use Sonata\MediaBundle\Model\GalleryManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class GalleryBlockServiceTest extends AbstractBlockServiceTestCase
 {
@@ -24,8 +29,8 @@ class GalleryBlockServiceTest extends AbstractBlockServiceTestCase
     {
         parent::setUp();
 
-        $this->container = $this->prophesize('Symfony\Component\DependencyInjection\ContainerInterface');
-        $this->galleryManager = $this->prophesize('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->galleryManager = $this->prophesize(GalleryManagerInterface::class);
 
         $this->blockService = new GalleryBlockService(
             'block.service',
@@ -37,9 +42,9 @@ class GalleryBlockServiceTest extends AbstractBlockServiceTestCase
 
     public function testExecute()
     {
-        $block = $this->prophesize('Sonata\BlockBundle\Model\Block');
-        $gallery = $this->prophesize('Sonata\MediaBundle\Model\GalleryInterface');
-        $blockContext = $this->prophesize('Sonata\BlockBundle\Block\BlockContext');
+        $block = $this->prophesize(Block::class);
+        $gallery = $this->prophesize(GalleryInterface::class);
+        $blockContext = $this->prophesize(BlockContext::class);
 
         $blockContext->getBlock()->willReturn($block->reveal());
         $blockContext->getSettings()->willReturn(['settings']);

--- a/tests/Block/GalleryListBlockServiceTest.php
+++ b/tests/Block/GalleryListBlockServiceTest.php
@@ -13,7 +13,9 @@ namespace Sonata\MediaBundle\Tests\Block;
 
 use Sonata\BlockBundle\Block\BlockContext;
 use Sonata\BlockBundle\Model\Block;
+use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
+use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\MediaBundle\Block\GalleryListBlockService;
 use Sonata\MediaBundle\Model\GalleryManagerInterface;
 use Sonata\MediaBundle\Provider\Pool;
@@ -34,13 +36,13 @@ class GalleryListBlockServiceTest extends AbstractBlockServiceTestCase
     {
         parent::setUp();
 
-        $this->galleryManager = $this->getMockBuilder('Sonata\MediaBundle\Model\GalleryManagerInterface')->getMock();
-        $this->pool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
+        $this->galleryManager = $this->getMockBuilder(GalleryManagerInterface::class)->getMock();
+        $this->pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
     }
 
     public function testExecute()
     {
-        $pager = $this->getMockBuilder('Sonata\DatagridBundle\Pager\PagerInterface')->getMock();
+        $pager = $this->getMockBuilder(PagerInterface::class)->getMock();
         $this->galleryManager->expects($this->once())->method('getPager')->will($this->returnValue($pager));
 
         $block = new Block();
@@ -62,7 +64,7 @@ class GalleryListBlockServiceTest extends AbstractBlockServiceTestCase
 
         $this->assertSame($blockContext, $this->templating->parameters['context']);
         $this->assertInternalType('array', $this->templating->parameters['settings']);
-        $this->assertInstanceOf('Sonata\BlockBundle\Model\BlockInterface', $this->templating->parameters['block']);
+        $this->assertInstanceOf(BlockInterface::class, $this->templating->parameters['block']);
         $this->assertSame($pager, $this->templating->parameters['pager']);
     }
 

--- a/tests/Block/MediaBlockServiceTest.php
+++ b/tests/Block/MediaBlockServiceTest.php
@@ -11,8 +11,15 @@
 
 namespace Sonata\MediaBundle\Tests\Block;
 
+use Sonata\BlockBundle\Block\BlockContext;
+use Sonata\BlockBundle\Model\Block;
 use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
+use Sonata\MediaBundle\Admin\BaseMediaAdmin;
 use Sonata\MediaBundle\Block\MediaBlockService;
+use Sonata\MediaBundle\Model\GalleryManagerInterface;
+use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Provider\Pool;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class MediaBlockServiceTest extends AbstractBlockServiceTestCase
 {
@@ -24,8 +31,8 @@ class MediaBlockServiceTest extends AbstractBlockServiceTestCase
     {
         parent::setUp();
 
-        $this->container = $this->prophesize('Symfony\Component\DependencyInjection\ContainerInterface');
-        $this->galleryManager = $this->prophesize('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->galleryManager = $this->prophesize(GalleryManagerInterface::class);
 
         $this->blockService = new MediaBlockService(
             'block.service',
@@ -37,9 +44,9 @@ class MediaBlockServiceTest extends AbstractBlockServiceTestCase
 
     public function testExecute()
     {
-        $block = $this->prophesize('Sonata\BlockBundle\Model\Block');
-        $media = $this->prophesize('Sonata\MediaBundle\Model\MediaInterface');
-        $blockContext = $this->prophesize('Sonata\BlockBundle\Block\BlockContext');
+        $block = $this->prophesize(Block::class);
+        $media = $this->prophesize(MediaInterface::class);
+        $blockContext = $this->prophesize(BlockContext::class);
 
         $this->configureGetFormatChoices($media, ['format1' => 'format1']);
         $blockContext->getBlock()->willReturn($block->reveal());
@@ -78,8 +85,8 @@ class MediaBlockServiceTest extends AbstractBlockServiceTestCase
 
     private function configureGetFormatChoices($media, $choices)
     {
-        $mediaAdmin = $this->prophesize('Sonata\MediaBundle\Admin\BaseMediaAdmin');
-        $pool = $this->prophesize('Sonata\MediaBundle\Provider\Pool');
+        $mediaAdmin = $this->prophesize(BaseMediaAdmin::class);
+        $pool = $this->prophesize(Pool::class);
 
         $this->container->get('sonata.media.admin.media')->willReturn($mediaAdmin->reveal());
         $mediaAdmin->getPool()->willReturn($pool->reveal());

--- a/tests/CDN/CloudFrontTest.php
+++ b/tests/CDN/CloudFrontTest.php
@@ -12,6 +12,7 @@
 namespace Sonata\MediaBundle\Tests\CDN;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\MediaBundle\CDN\CloudFront;
 
 /**
  * @author Javier Spagnoletti <phansys@gmail.com>
@@ -23,14 +24,14 @@ class CloudFrontTest extends TestCase
      */
     public function testLegacyCloudFront()
     {
-        $client = $this->getMockBuilder('Sonata\MediaBundle\Tests\CDN\CloudFrontClientSpy')
+        $client = $this->getMockBuilder(CloudFrontClientSpy::class)
             ->setMethods(['createInvalidation'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $client->expects($this->exactly(3))->method('createInvalidation')->will($this->returnValue(new CloudFrontResultSpy()));
 
-        $cloudFront = $this->getMockBuilder('Sonata\MediaBundle\CDN\CloudFront')
+        $cloudFront = $this->getMockBuilder(CloudFront::class)
             ->setConstructorArgs(['/foo', 'secret', 'key', 'xxxxxxxxxxxxxx'])
             ->setMethods(null)
             ->getMock();
@@ -50,14 +51,14 @@ class CloudFrontTest extends TestCase
      */
     public function testLegacyException()
     {
-        $this->expectException('\RuntimeException');
+        $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Unable to flush : ');
-        $client = $this->getMockBuilder('Sonata\MediaBundle\Tests\CDN\CloudFrontClientSpy')
+        $client = $this->getMockBuilder(CloudFrontClientSpy::class)
             ->setMethods(['createInvalidation'])
             ->disableOriginalConstructor()
             ->getMock();
         $client->expects($this->exactly(1))->method('createInvalidation')->will($this->returnValue(new CloudFrontResultSpy(true)));
-        $cloudFront = $this->getMockBuilder('Sonata\MediaBundle\CDN\CloudFront')
+        $cloudFront = $this->getMockBuilder(CloudFront::class)
             ->setConstructorArgs(['/foo', 'secret', 'key', 'xxxxxxxxxxxxxx'])
             ->setMethods(null)
             ->getMock();

--- a/tests/CDN/PantherPortalTest.php
+++ b/tests/CDN/PantherPortalTest.php
@@ -19,7 +19,7 @@ class PantherPortalTest extends TestCase
     public function testPortal()
     {
         $client = $this->createMock(
-            'Sonata\MediaBundle\Tests\CDN\ClientSpy',
+            ClientSpy::class,
             ['flush'],
             [],
             '',
@@ -41,11 +41,11 @@ class PantherPortalTest extends TestCase
 
     public function testException()
     {
-        $this->expectException('\RuntimeException');
+        $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Unable to flush : Failed!!');
 
         $client = $this->createMock(
-            'Sonata\MediaBundle\Tests\CDN\ClientSpy',
+            ClientSpy::class,
             ['flush'],
             [],
             '',

--- a/tests/Command/CleanMediaCommandTest.php
+++ b/tests/Command/CleanMediaCommandTest.php
@@ -13,7 +13,9 @@ namespace Sonata\MediaBundle\Tests\Command;
 
 use Sonata\MediaBundle\Command\CleanMediaCommand;
 use Sonata\MediaBundle\Filesystem\Local;
+use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Model\MediaManagerInterface;
+use Sonata\MediaBundle\Provider\FileProvider;
 use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Application;
@@ -69,7 +71,7 @@ class CleanMediaCommandTest extends FilesystemTestCase
     {
         parent::setUp();
 
-        $this->container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
+        $this->container = $this->getMockBuilder(ContainerInterface::class)->getMock();
 
         $this->command = new CleanMediaCommand();
         $this->command->setContainer($this->container);
@@ -79,11 +81,11 @@ class CleanMediaCommandTest extends FilesystemTestCase
 
         $this->tester = new CommandTester($this->application->find('sonata:media:clean-uploads'));
 
-        $this->pool = $pool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
+        $this->pool = $pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
 
-        $this->mediaManager = $mediaManager = $this->getMockBuilder('Sonata\MediaBundle\Model\MediaManagerInterface')->getMock();
+        $this->mediaManager = $mediaManager = $this->getMockBuilder(MediaManagerInterface::class)->getMock();
 
-        $this->fileSystemLocal = $fileSystemLocal = $this->getMockBuilder('Sonata\MediaBundle\Filesystem\Local')->disableOriginalConstructor()->getMock();
+        $this->fileSystemLocal = $fileSystemLocal = $this->getMockBuilder(Local::class)->disableOriginalConstructor()->getMock();
         $this->fileSystemLocal->expects($this->once())->method('getDirectory')->will($this->returnValue($this->workspace));
 
         $this->container->expects($this->any())
@@ -148,13 +150,13 @@ class CleanMediaCommandTest extends FilesystemTestCase
             'download' => [],
         ];
 
-        $provider = $this->getMockBuilder('Sonata\MediaBundle\Provider\FileProvider')->disableOriginalConstructor()->getMock();
+        $provider = $this->getMockBuilder(FileProvider::class)->disableOriginalConstructor()->getMock();
         $provider->expects($this->any())->method('getName')->will($this->returnValue('fooprovider'));
 
         $this->pool->expects($this->any())->method('getContexts')->will($this->returnValue(['foo' => $context]));
         $this->pool->expects($this->any())->method('getProviders')->will($this->returnValue([$provider]));
 
-        $media = $this->getMockBuilder('Sonata\MediaBundle\Model\MediaInterface')->getMock();
+        $media = $this->getMockBuilder(MediaInterface::class)->getMock();
 
         $this->mediaManager->expects($this->once())->method('findOneBy')
             ->with($this->equalTo(['id' => 1, 'context' => 'foo']))
@@ -182,13 +184,13 @@ class CleanMediaCommandTest extends FilesystemTestCase
             'download' => [],
         ];
 
-        $provider = $this->getMockBuilder('Sonata\MediaBundle\Provider\FileProvider')->disableOriginalConstructor()->getMock();
+        $provider = $this->getMockBuilder(FileProvider::class)->disableOriginalConstructor()->getMock();
         $provider->expects($this->any())->method('getName')->will($this->returnValue('fooprovider'));
 
         $this->pool->expects($this->any())->method('getContexts')->will($this->returnValue(['foo' => $context]));
         $this->pool->expects($this->any())->method('getProviders')->will($this->returnValue([$provider]));
 
-        $media = $this->getMockBuilder('Sonata\MediaBundle\Model\MediaInterface')->getMock();
+        $media = $this->getMockBuilder(MediaInterface::class)->getMock();
 
         $this->mediaManager->expects($this->once())->method('findOneBy')
             ->with($this->equalTo(['id' => 1, 'context' => 'foo']))
@@ -225,7 +227,7 @@ class CleanMediaCommandTest extends FilesystemTestCase
             'download' => [],
         ];
 
-        $provider = $this->getMockBuilder('Sonata\MediaBundle\Provider\FileProvider')->disableOriginalConstructor()->getMock();
+        $provider = $this->getMockBuilder(FileProvider::class)->disableOriginalConstructor()->getMock();
         $provider->expects($this->any())->method('getName')->will($this->returnValue('fooprovider'));
 
         $this->pool->expects($this->any())->method('getContexts')->will($this->returnValue(['foo' => $context]));
@@ -263,7 +265,7 @@ class CleanMediaCommandTest extends FilesystemTestCase
             'download' => [],
         ];
 
-        $provider = $this->getMockBuilder('Sonata\MediaBundle\Provider\FileProvider')->disableOriginalConstructor()->getMock();
+        $provider = $this->getMockBuilder(FileProvider::class)->disableOriginalConstructor()->getMock();
         $provider->expects($this->any())->method('getName')->will($this->returnValue('fooprovider'));
 
         $this->pool->expects($this->any())->method('getContexts')->will($this->returnValue(['foo' => $context]));

--- a/tests/Command/FixMediaContextCommandTest.php
+++ b/tests/Command/FixMediaContextCommandTest.php
@@ -12,12 +12,15 @@
 namespace Sonata\MediaBundle\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\ClassificationBundle\Model\CategoryInterface;
+use Sonata\ClassificationBundle\Model\ContextInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
 use Sonata\MediaBundle\Command\FixMediaContextCommand;
 use Sonata\MediaBundle\Model\CategoryManagerInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class FixMediaContextCommandTest extends TestCase
 {
@@ -61,7 +64,7 @@ class FixMediaContextCommandTest extends TestCase
      */
     protected function setUp()
     {
-        $this->container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
+        $this->container = $this->getMockBuilder(ContainerInterface::class)->getMock();
 
         $this->command = new FixMediaContextCommand();
         $this->command->setContainer($this->container);
@@ -71,11 +74,11 @@ class FixMediaContextCommandTest extends TestCase
 
         $this->tester = new CommandTester($this->application->find('sonata:media:fix-media-context'));
 
-        $this->pool = $pool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
+        $this->pool = $pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
 
-        $this->contextManger = $contextManger = $this->getMockBuilder('Sonata\ClassificationBundle\Model\ContextManagerInterface')->getMock();
+        $this->contextManger = $contextManger = $this->getMockBuilder(ContextManagerInterface::class)->getMock();
 
-        $this->categoryManger = $categoryManger = $this->createMock('Sonata\MediaBundle\Model\CategoryManagerInterface');
+        $this->categoryManger = $categoryManger = $this->createMock(CategoryManagerInterface::class);
 
         $this->container->expects($this->any())
             ->method('get')
@@ -96,7 +99,7 @@ class FixMediaContextCommandTest extends TestCase
         $this->container->method('has')->with($this->equalTo('sonata.media.manager.category'))
             ->will($this->returnValue(false));
 
-        $this->expectException('\LogicException');
+        $this->expectException(\LogicException::class);
 
         $this->tester->execute(['command' => $this->command->getName()]);
     }
@@ -114,11 +117,11 @@ class FixMediaContextCommandTest extends TestCase
 
         $this->pool->expects($this->any())->method('getContexts')->will($this->returnValue(['foo' => $context]));
 
-        $contextModel = $this->getMockBuilder('Sonata\ClassificationBundle\Model\ContextInterface')->getMock();
+        $contextModel = $this->getMockBuilder(ContextInterface::class)->getMock();
 
         $this->contextManger->expects($this->once())->method('findOneBy')->with($this->equalTo(['id' => 'foo']))->will($this->returnValue($contextModel));
 
-        $category = $this->getMockBuilder('Sonata\ClassificationBundle\Model\CategoryInterface')->getMock();
+        $category = $this->getMockBuilder(CategoryInterface::class)->getMock();
 
         $this->categoryManger->expects($this->once())->method('getRootCategory')->with($this->equalTo($contextModel))->will($this->returnValue($category));
 
@@ -142,11 +145,11 @@ class FixMediaContextCommandTest extends TestCase
 
         $this->pool->expects($this->any())->method('getContexts')->will($this->returnValue(['foo' => $context]));
 
-        $contextModel = $this->getMockBuilder('Sonata\ClassificationBundle\Model\ContextInterface')->getMock();
+        $contextModel = $this->getMockBuilder(ContextInterface::class)->getMock();
 
         $this->contextManger->expects($this->once())->method('findOneBy')->with($this->equalTo(['id' => 'foo']))->will($this->returnValue($contextModel));
 
-        $category = $this->getMockBuilder('Sonata\ClassificationBundle\Model\CategoryInterface')->getMock();
+        $category = $this->getMockBuilder(CategoryInterface::class)->getMock();
 
         $this->categoryManger->expects($this->once())->method('getRootCategory')->with($this->equalTo($contextModel))->will($this->returnValue(null));
         $this->categoryManger->expects($this->once())->method('create')->will($this->returnValue($category));
@@ -172,13 +175,13 @@ class FixMediaContextCommandTest extends TestCase
 
         $this->pool->expects($this->any())->method('getContexts')->will($this->returnValue(['foo' => $context]));
 
-        $contextModel = $this->getMockBuilder('Sonata\ClassificationBundle\Model\ContextInterface')->getMock();
+        $contextModel = $this->getMockBuilder(ContextInterface::class)->getMock();
 
         $this->contextManger->expects($this->once())->method('findOneBy')->with($this->equalTo(['id' => 'foo']))->will($this->returnValue(null));
         $this->contextManger->expects($this->once())->method('create')->will($this->returnValue($contextModel));
         $this->contextManger->expects($this->once())->method('save')->with($this->equalTo($contextModel));
 
-        $category = $this->getMockBuilder('Sonata\ClassificationBundle\Model\CategoryInterface')->getMock();
+        $category = $this->getMockBuilder(CategoryInterface::class)->getMock();
 
         $this->categoryManger->expects($this->once())->method('getRootCategory')->with($this->equalTo($contextModel))->will($this->returnValue(null));
         $this->categoryManger->expects($this->once())->method('create')->will($this->returnValue($category));

--- a/tests/Controller/Api/GalleryControllerTest.php
+++ b/tests/Controller/Api/GalleryControllerTest.php
@@ -12,10 +12,21 @@
 namespace Sonata\MediaBundle\Tests\Controller\Api;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use FOS\RestBundle\Request\ParamFetcher;
+use FOS\RestBundle\View\View;
 use PHPUnit\Framework\TestCase;
 use Sonata\MediaBundle\Controller\Api\GalleryController;
 use Sonata\MediaBundle\Model\GalleryHasMedia;
+use Sonata\MediaBundle\Model\GalleryHasMediaInterface;
+use Sonata\MediaBundle\Model\GalleryInterface;
+use Sonata\MediaBundle\Model\GalleryManagerInterface;
+use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Model\MediaManagerInterface;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class GalleryTest extends GalleryHasMedia
 {
@@ -28,15 +39,15 @@ class GalleryControllerTest extends TestCase
 {
     public function testGetGalleriesAction()
     {
-        $gManager = $this->createMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
-        $mediaManager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $gManager = $this->createMock(GalleryManagerInterface::class);
+        $mediaManager = $this->createMock(MediaManagerInterface::class);
+        $formFactory = $this->createMock(FormFactoryInterface::class);
 
         $gManager->expects($this->once())->method('getPager')->will($this->returnValue([]));
 
         $gController = new GalleryController($gManager, $mediaManager, $formFactory, 'test');
 
-        $paramFetcher = $this->getMockBuilder('FOS\RestBundle\Request\ParamFetcher')
+        $paramFetcher = $this->getMockBuilder(ParamFetcher::class)
             ->disableOriginalConstructor()
             ->getMock();
         $paramFetcher->expects($this->exactly(3))->method('get');
@@ -47,10 +58,10 @@ class GalleryControllerTest extends TestCase
 
     public function testGetGalleryAction()
     {
-        $gManager = $this->createMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
-        $mediaManager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
-        $gallery = $this->createMock('Sonata\MediaBundle\Model\GalleryInterface');
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $gManager = $this->createMock(GalleryManagerInterface::class);
+        $mediaManager = $this->createMock(MediaManagerInterface::class);
+        $gallery = $this->createMock(GalleryInterface::class);
+        $formFactory = $this->createMock(FormFactoryInterface::class);
 
         $gManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
 
@@ -61,13 +72,13 @@ class GalleryControllerTest extends TestCase
 
     public function testGetGalleryNotFoundAction()
     {
-        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+        $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('Gallery (42) not found');
 
-        $gManager = $this->createMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
-        $mediaManager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $gManager = $this->createMock(GalleryManagerInterface::class);
+        $mediaManager = $this->createMock(MediaManagerInterface::class);
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
 
         $gManager->expects($this->once())->method('findOneBy');
 
@@ -78,16 +89,16 @@ class GalleryControllerTest extends TestCase
 
     public function testGetGalleryGalleryhasmediasAction()
     {
-        $gManager = $this->createMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
-        $galleryHasMedia = $this->createMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
-        $gallery = $this->createMock('Sonata\MediaBundle\Model\GalleryInterface');
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $gManager = $this->createMock(GalleryManagerInterface::class);
+        $galleryHasMedia = $this->createMock(GalleryHasMediaInterface::class);
+        $gallery = $this->createMock(GalleryInterface::class);
+        $formFactory = $this->createMock(FormFactoryInterface::class);
 
         $gallery->expects($this->once())->method('getGalleryHasMedias')->will($this->returnValue([$galleryHasMedia]));
 
         $gManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
 
-        $mediaManager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $mediaManager = $this->createMock(MediaManagerInterface::class);
 
         $gController = new GalleryController($gManager, $mediaManager, $formFactory, 'test');
 
@@ -96,19 +107,19 @@ class GalleryControllerTest extends TestCase
 
     public function testGetGalleryMediaAction()
     {
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $media = $this->createMock(MediaInterface::class);
+        $formFactory = $this->createMock(FormFactoryInterface::class);
 
-        $galleryHasMedia = $this->createMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
+        $galleryHasMedia = $this->createMock(GalleryHasMediaInterface::class);
         $galleryHasMedia->expects($this->once())->method('getMedia')->will($this->returnValue($media));
 
-        $gallery = $this->createMock('Sonata\MediaBundle\Model\GalleryInterface');
+        $gallery = $this->createMock(GalleryInterface::class);
         $gallery->expects($this->once())->method('getGalleryHasMedias')->will($this->returnValue([$galleryHasMedia]));
 
-        $gManager = $this->createMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $gManager = $this->createMock(GalleryManagerInterface::class);
         $gManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
 
-        $mediaManager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $mediaManager = $this->createMock(MediaManagerInterface::class);
 
         $gController = new GalleryController($gManager, $mediaManager, $formFactory, 'test');
 
@@ -117,146 +128,146 @@ class GalleryControllerTest extends TestCase
 
     public function testPostGalleryMediaGalleryhasmediaAction()
     {
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
 
-        $media2 = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media2 = $this->createMock(MediaInterface::class);
         $media2->expects($this->any())->method('getId')->will($this->returnValue(1));
 
-        $galleryHasMedia = $this->createMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
+        $galleryHasMedia = $this->createMock(GalleryHasMediaInterface::class);
         $galleryHasMedia->expects($this->once())->method('getMedia')->will($this->returnValue($media2));
 
-        $gallery = $this->createMock('Sonata\MediaBundle\Model\GalleryInterface');
+        $gallery = $this->createMock(GalleryInterface::class);
         $gallery->expects($this->once())->method('getGalleryHasMedias')->will($this->returnValue([$galleryHasMedia]));
 
-        $galleryManager = $this->createMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $galleryManager = $this->createMock(GalleryManagerInterface::class);
         $galleryManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
 
-        $mediaManager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $mediaManager = $this->createMock(MediaManagerInterface::class);
         $mediaManager->expects($this->once())->method('findOneBy')->will($this->returnValue($media));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($galleryHasMedia));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
-        $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, 'Sonata\MediaBundle\Tests\Controller\Api\GalleryTest');
+        $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, GalleryTest::class);
         $view = $galleryController->postGalleryMediaGalleryhasmediaAction(1, 2, new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
         $this->assertSame(200, $view->getResponse()->getStatusCode(), 'Should return 200');
     }
 
     public function testPostGalleryMediaGalleryhasmediaInvalidAction()
     {
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
         $media->expects($this->any())->method('getId')->will($this->returnValue(1));
 
-        $galleryHasMedia = $this->createMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
+        $galleryHasMedia = $this->createMock(GalleryHasMediaInterface::class);
         $galleryHasMedia->expects($this->once())->method('getMedia')->will($this->returnValue($media));
 
-        $gallery = $this->createMock('Sonata\MediaBundle\Model\GalleryInterface');
+        $gallery = $this->createMock(GalleryInterface::class);
         $gallery->expects($this->once())->method('getGalleryHasMedias')->will($this->returnValue([$galleryHasMedia]));
 
-        $galleryManager = $this->createMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $galleryManager = $this->createMock(GalleryManagerInterface::class);
         $galleryManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
 
-        $mediaManager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $mediaManager = $this->createMock(MediaManagerInterface::class);
         $mediaManager->expects($this->once())->method('findOneBy')->will($this->returnValue($media));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
 
-        $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, 'Sonata\MediaBundle\Tests\Controller\Api\GalleryTest');
+        $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, GalleryTest::class);
         $view = $galleryController->postGalleryMediaGalleryhasmediaAction(1, 1, new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
         $this->assertSame(400, $view->getResponse()->getStatusCode(), 'Should return 400');
     }
 
     public function testPutGalleryMediaGalleryhasmediaAction()
     {
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
         $media->expects($this->any())->method('getId')->will($this->returnValue(1));
 
-        $galleryHasMedia = $this->createMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
+        $galleryHasMedia = $this->createMock(GalleryHasMediaInterface::class);
         $galleryHasMedia->expects($this->once())->method('getMedia')->will($this->returnValue($media));
 
-        $gallery = $this->createMock('Sonata\MediaBundle\Model\GalleryInterface');
+        $gallery = $this->createMock(GalleryInterface::class);
         $gallery->expects($this->once())->method('getGalleryHasMedias')->will($this->returnValue([$galleryHasMedia]));
 
-        $galleryManager = $this->createMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $galleryManager = $this->createMock(GalleryManagerInterface::class);
         $galleryManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
 
-        $mediaManager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $mediaManager = $this->createMock(MediaManagerInterface::class);
         $mediaManager->expects($this->once())->method('findOneBy')->will($this->returnValue($media));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($galleryHasMedia));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
-        $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, 'Sonata\MediaBundle\Tests\Controller\Api\GalleryTest');
+        $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, GalleryTest::class);
         $view = $galleryController->putGalleryMediaGalleryhasmediaAction(1, 1, new Request());
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
         $this->assertSame(200, $view->getResponse()->getStatusCode(), 'Should return 200');
     }
 
     public function testPutGalleryMediaGalleryhasmediaInvalidAction()
     {
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
         $media->expects($this->any())->method('getId')->will($this->returnValue(1));
 
-        $galleryHasMedia = $this->createMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
+        $galleryHasMedia = $this->createMock(GalleryHasMediaInterface::class);
         $galleryHasMedia->expects($this->once())->method('getMedia')->will($this->returnValue($media));
 
-        $gallery = $this->createMock('Sonata\MediaBundle\Model\GalleryInterface');
+        $gallery = $this->createMock(GalleryInterface::class);
         $gallery->expects($this->once())->method('getGalleryHasMedias')->will($this->returnValue([$galleryHasMedia]));
 
-        $galleryManager = $this->createMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $galleryManager = $this->createMock(GalleryManagerInterface::class);
         $galleryManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
 
-        $mediaManager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $mediaManager = $this->createMock(MediaManagerInterface::class);
         $mediaManager->expects($this->once())->method('findOneBy')->will($this->returnValue($media));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
-        $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, 'Sonata\MediaBundle\Tests\Controller\Api\GalleryTest');
+        $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, GalleryTest::class);
         $view = $galleryController->putGalleryMediaGalleryhasmediaAction(1, 1, new Request());
 
-        $this->assertInstanceOf('Symfony\Component\Form\FormInterface', $view);
+        $this->assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testDeleteGalleryMediaGalleryhasmediaAction()
     {
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
         $media->expects($this->any())->method('getId')->will($this->returnValue(1));
 
-        $galleryHasMedia = $this->createMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
+        $galleryHasMedia = $this->createMock(GalleryHasMediaInterface::class);
         $galleryHasMedia->expects($this->once())->method('getMedia')->will($this->returnValue($media));
 
-        $gallery = $this->createMock('Sonata\MediaBundle\Model\GalleryInterface');
+        $gallery = $this->createMock(GalleryInterface::class);
         $gallery->expects($this->any())->method('getGalleryHasMedias')->will($this->returnValue(new ArrayCollection([$galleryHasMedia])));
 
-        $galleryManager = $this->createMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $galleryManager = $this->createMock(GalleryManagerInterface::class);
         $galleryManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
 
-        $mediaManager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $mediaManager = $this->createMock(MediaManagerInterface::class);
         $mediaManager->expects($this->once())->method('findOneBy')->will($this->returnValue($media));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
 
-        $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, 'Sonata\MediaBundle\Tests\Controller\Api\GalleryTest');
+        $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, GalleryTest::class);
         $view = $galleryController->deleteGalleryMediaGalleryhasmediaAction(1, 1);
 
         $this->assertSame(['deleted' => true], $view);
@@ -264,29 +275,29 @@ class GalleryControllerTest extends TestCase
 
     public function testDeleteGalleryMediaGalleryhasmediaInvalidAction()
     {
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
 
-        $media2 = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media2 = $this->createMock(MediaInterface::class);
         $media2->expects($this->any())->method('getId')->will($this->returnValue(2));
 
-        $galleryHasMedia = $this->createMock('Sonata\MediaBundle\Model\GalleryHasMediaInterface');
+        $galleryHasMedia = $this->createMock(GalleryHasMediaInterface::class);
         $galleryHasMedia->expects($this->once())->method('getMedia')->will($this->returnValue($media2));
 
-        $gallery = $this->createMock('Sonata\MediaBundle\Model\GalleryInterface');
+        $gallery = $this->createMock(GalleryInterface::class);
         $gallery->expects($this->any())->method('getGalleryHasMedias')->will($this->returnValue(new ArrayCollection([$galleryHasMedia])));
 
-        $galleryManager = $this->createMock('Sonata\MediaBundle\Model\GalleryManagerInterface');
+        $galleryManager = $this->createMock(GalleryManagerInterface::class);
         $galleryManager->expects($this->once())->method('findOneBy')->will($this->returnValue($gallery));
 
-        $mediaManager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $mediaManager = $this->createMock(MediaManagerInterface::class);
         $mediaManager->expects($this->once())->method('findOneBy')->will($this->returnValue($media));
 
-        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock(FormFactoryInterface::class);
 
-        $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, 'Sonata\MediaBundle\Tests\Controller\Api\GalleryTest');
+        $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, GalleryTest::class);
         $view = $galleryController->deleteGalleryMediaGalleryhasmediaAction(1, 1);
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $view);
+        $this->assertInstanceOf(View::class, $view);
         $this->assertSame(400, $view->getResponse()->getStatusCode(), 'Should return 400');
     }
 }

--- a/tests/Controller/Api/MediaControllerTest.php
+++ b/tests/Controller/Api/MediaControllerTest.php
@@ -11,9 +11,19 @@
 
 namespace Sonata\MediaBundle\Tests\Controller\Api;
 
+use FOS\RestBundle\Request\ParamFetcher;
+use FOS\RestBundle\View\View;
 use PHPUnit\Framework\TestCase;
 use Sonata\MediaBundle\Controller\Api\MediaController;
+use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Model\MediaManagerInterface;
+use Sonata\MediaBundle\Provider\MediaProviderInterface;
+use Sonata\MediaBundle\Provider\Pool;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -22,14 +32,14 @@ class MediaControllerTest extends TestCase
 {
     public function testGetMediaAction()
     {
-        $mManager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $mManager = $this->createMock(MediaManagerInterface::class);
+        $media = $this->createMock(MediaInterface::class);
 
         $mManager->expects($this->once())->method('getPager')->will($this->returnValue([$media]));
 
         $mController = $this->createMediaController($mManager);
 
-        $paramFetcher = $this->getMockBuilder('FOS\RestBundle\Request\ParamFetcher')
+        $paramFetcher = $this->getMockBuilder(ParamFetcher::class)
             ->disableOriginalConstructor()
             ->getMock();
         $paramFetcher->expects($this->exactly(3))->method('get');
@@ -40,9 +50,9 @@ class MediaControllerTest extends TestCase
 
     public function testGetMediumAction()
     {
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
 
-        $manager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $manager = $this->createMock(MediaManagerInterface::class);
         $manager->expects($this->once())->method('findOneBy')->will($this->returnValue($media));
 
         $controller = $this->createMediaController($manager);
@@ -52,7 +62,7 @@ class MediaControllerTest extends TestCase
 
     public function testGetMediumNotFoundExceptionAction()
     {
-        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+        $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('Media (42) was not found');
 
         $this->createMediaController()->getMediumAction(42);
@@ -60,15 +70,15 @@ class MediaControllerTest extends TestCase
 
     public function testGetMediumFormatsAction()
     {
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
 
-        $manager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $manager = $this->createMock(MediaManagerInterface::class);
         $manager->expects($this->once())->method('findOneBy')->will($this->returnValue($media));
 
-        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock(MediaProviderInterface::class);
         $provider->expects($this->exactly(2))->method('getHelperProperties')->will($this->returnValue(['foo' => 'bar']));
 
-        $pool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
+        $pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
         $pool->expects($this->any())->method('getProvider')->will($this->returnValue($provider));
         $pool->expects($this->once())->method('getFormatNamesByContext')->will($this->returnValue(['format_name1' => 'value1']));
 
@@ -93,17 +103,17 @@ class MediaControllerTest extends TestCase
 
     public function testGetMediumBinariesAction()
     {
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
 
-        $binaryResponse = $this->getMockBuilder('Symfony\Component\HttpFoundation\BinaryFileResponse')->disableOriginalConstructor()->getMock();
+        $binaryResponse = $this->getMockBuilder(BinaryFileResponse::class)->disableOriginalConstructor()->getMock();
 
-        $manager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $manager = $this->createMock(MediaManagerInterface::class);
         $manager->expects($this->once())->method('findOneBy')->will($this->returnValue($media));
 
-        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock(MediaProviderInterface::class);
         $provider->expects($this->once())->method('getDownloadResponse')->will($this->returnValue($binaryResponse));
 
-        $pool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
+        $pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
         $pool->expects($this->once())->method('getProvider')->will($this->returnValue($provider));
 
         $controller = $this->createMediaController($manager, $pool);
@@ -113,9 +123,9 @@ class MediaControllerTest extends TestCase
 
     public function testDeleteMediumAction()
     {
-        $manager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $manager = $this->createMock(MediaManagerInterface::class);
         $manager->expects($this->once())->method('delete');
-        $manager->expects($this->once())->method('findOneBy')->will($this->returnValue($this->createMock('Sonata\MediaBundle\Model\MediaInterface')));
+        $manager->expects($this->once())->method('findOneBy')->will($this->returnValue($this->createMock(MediaInterface::class)));
 
         $controller = $this->createMediaController($manager);
 
@@ -126,93 +136,93 @@ class MediaControllerTest extends TestCase
 
     public function testPutMediumAction()
     {
-        $medium = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $medium = $this->createMock(MediaInterface::class);
 
-        $manager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $manager = $this->createMock(MediaManagerInterface::class);
         $manager->expects($this->once())->method('findOneBy')->will($this->returnValue($medium));
 
-        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock(MediaProviderInterface::class);
         $provider->expects($this->once())->method('getName');
 
-        $pool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
+        $pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
         $pool->expects($this->once())->method('getProvider')->will($this->returnValue($provider));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($medium));
 
-        $factory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $factory = $this->createMock(FormFactoryInterface::class);
         $factory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $controller = $this->createMediaController($manager, $pool, $factory);
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $controller->putMediumAction(1, new Request()));
+        $this->assertInstanceOf(View::class, $controller->putMediumAction(1, new Request()));
     }
 
     public function testPutMediumInvalidFormAction()
     {
-        $medium = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $medium = $this->createMock(MediaInterface::class);
 
-        $manager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $manager = $this->createMock(MediaManagerInterface::class);
         $manager->expects($this->once())->method('findOneBy')->will($this->returnValue($medium));
 
-        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock(MediaProviderInterface::class);
         $provider->expects($this->once())->method('getName');
 
-        $pool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
+        $pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
         $pool->expects($this->once())->method('getProvider')->will($this->returnValue($provider));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $factory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $factory = $this->createMock(FormFactoryInterface::class);
         $factory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $controller = $this->createMediaController($manager, $pool, $factory);
 
-        $this->assertInstanceOf('Symfony\Component\Form\Form', $controller->putMediumAction(1, new Request()));
+        $this->assertInstanceOf(Form::class, $controller->putMediumAction(1, new Request()));
     }
 
     public function testPostProviderMediumAction()
     {
-        $medium = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $medium = $this->createMock(MediaInterface::class);
         $medium->expects($this->once())->method('setProviderName');
 
-        $manager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $manager = $this->createMock(MediaManagerInterface::class);
         $manager->expects($this->once())->method('create')->will($this->returnValue($medium));
 
-        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock(MediaProviderInterface::class);
         $provider->expects($this->once())->method('getName');
 
-        $pool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
+        $pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
         $pool->expects($this->once())->method('getProvider')->will($this->returnValue($provider));
 
-        $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
+        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($medium));
 
-        $factory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+        $factory = $this->createMock(FormFactoryInterface::class);
         $factory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $controller = $this->createMediaController($manager, $pool, $factory);
 
-        $this->assertInstanceOf('FOS\RestBundle\View\View', $controller->postProviderMediumAction('providerName', new Request()));
+        $this->assertInstanceOf(View::class, $controller->postProviderMediumAction('providerName', new Request()));
     }
 
     public function testPostProviderActionNotFound()
     {
-        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+        $this->expectException(NotFoundHttpException::class);
 
-        $medium = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $medium = $this->createMock(MediaInterface::class);
         $medium->expects($this->once())->method('setProviderName');
 
-        $manager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $manager = $this->createMock(MediaManagerInterface::class);
         $manager->expects($this->once())->method('create')->will($this->returnValue($medium));
 
-        $pool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
+        $pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
         $pool->expects($this->once())->method('getProvider')->will($this->throwException(new \RuntimeException('exception on getProvder')));
 
         $controller = $this->createMediaController($manager, $pool);
@@ -221,13 +231,13 @@ class MediaControllerTest extends TestCase
 
     public function testPutMediumBinaryContentAction()
     {
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
         $media->expects($this->once())->method('setBinaryContent');
 
-        $manager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+        $manager = $this->createMock(MediaManagerInterface::class);
         $manager->expects($this->once())->method('findOneBy')->will($this->returnValue($media));
 
-        $pool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
+        $pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
 
         $controller = $this->createMediaController($manager, $pool);
 
@@ -237,13 +247,13 @@ class MediaControllerTest extends TestCase
     protected function createMediaController($manager = null, $pool = null, $factory = null)
     {
         if (null === $manager) {
-            $manager = $this->createMock('Sonata\MediaBundle\Model\MediaManagerInterface');
+            $manager = $this->createMock(MediaManagerInterface::class);
         }
         if (null === $pool) {
-            $pool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
+            $pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
         }
         if (null === $factory) {
-            $factory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
+            $factory = $this->createMock(FormFactoryInterface::class);
         }
 
         return new MediaController($manager, $pool, $factory);

--- a/tests/Controller/GalleryAdminControllerTest.php
+++ b/tests/Controller/GalleryAdminControllerTest.php
@@ -13,13 +13,24 @@ namespace Sonata\MediaBundle\Tests\Controller;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface;
+use Sonata\AdminBundle\Admin\Pool as AdminPool;
+use Sonata\AdminBundle\Datagrid\DatagridInterface;
+use Sonata\MediaBundle\Admin\BaseMediaAdmin;
 use Sonata\MediaBundle\Controller\GalleryAdminController;
+use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Bridge\Twig\AppVariable;
 use Symfony\Bridge\Twig\Command\DebugCommand;
 use Symfony\Bridge\Twig\Extension\FormExtension;
 use Symfony\Bridge\Twig\Form\TwigRenderer;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormRenderer;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
@@ -32,9 +43,9 @@ class GalleryAdminControllerTest extends TestCase
 
     protected function setUp()
     {
-        $this->container = $this->prophesize('Symfony\Component\DependencyInjection\ContainerInterface');
-        $this->admin = $this->prophesize('Sonata\MediaBundle\Admin\BaseMediaAdmin');
-        $this->request = $this->prophesize('Symfony\Component\HttpFoundation\Request');
+        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->admin = $this->prophesize(BaseMediaAdmin::class);
+        $this->request = $this->prophesize(Request::class);
 
         $this->configureCRUDController();
 
@@ -49,10 +60,10 @@ class GalleryAdminControllerTest extends TestCase
 
     public function testListAction()
     {
-        $datagrid = $this->prophesize('Sonata\AdminBundle\Datagrid\DatagridInterface');
-        $form = $this->prophesize('Symfony\Component\Form\Form');
-        $formView = $this->prophesize('Symfony\Component\Form\FormView');
-        $pool = $this->prophesize('Sonata\MediaBundle\Provider\Pool');
+        $datagrid = $this->prophesize(DatagridInterface::class);
+        $form = $this->prophesize(Form::class);
+        $formView = $this->prophesize(FormView::class);
+        $pool = $this->prophesize(Pool::class);
 
         $this->configureSetFormTheme($formView->reveal(), 'filterTheme');
         $this->configureSetCsrfToken('sonata.batch');
@@ -74,8 +85,8 @@ class GalleryAdminControllerTest extends TestCase
 
     private function configureCRUDController()
     {
-        $pool = $this->prophesize('Sonata\AdminBundle\Admin\Pool');
-        $breadcrumbsBuilder = $this->prophesize('Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface');
+        $pool = $this->prophesize(AdminPool::class);
+        $breadcrumbsBuilder = $this->prophesize(BreadcrumbsBuilderInterface::class);
 
         $this->configureGetCurrentRequest($this->request->reveal());
         $pool->getAdminByAdminCode('admin_code')->willReturn($this->admin->reveal());
@@ -139,9 +150,9 @@ class GalleryAdminControllerTest extends TestCase
 
     private function configureRender($template, $data, $rendered)
     {
-        $templating = $this->prophesize('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');
-        $response = $this->prophesize('Symfony\Component\HttpFoundation\Response');
-        $pool = $this->prophesize('Sonata\MediaBundle\Provider\Pool');
+        $templating = $this->prophesize(EngineInterface::class);
+        $response = $this->prophesize(Response::class);
+        $pool = $this->prophesize(Pool::class);
 
         $this->admin->getPersistentParameters()->willReturn(['param' => 'param']);
         $this->container->has('templating')->willReturn(true);

--- a/tests/DependencyInjection/SonataMediaExtensionTest.php
+++ b/tests/DependencyInjection/SonataMediaExtensionTest.php
@@ -11,8 +11,15 @@
 
 namespace Sonata\MediaBundle\Tests\DependencyInjection;
 
+use Imagine\Gd\Imagine as GdImagine;
+use Imagine\Gmagick\Imagine as GmagicImagine;
+use Imagine\Imagick\Imagine as ImagicImagine;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Sonata\MediaBundle\DependencyInjection\SonataMediaExtension;
+use Sonata\MediaBundle\Model\CategoryManager;
+use Sonata\MediaBundle\Resizer\SimpleResizer;
+use Sonata\MediaBundle\Resizer\SquareResizer;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 
 class SonataMediaExtensionTest extends AbstractExtensionTestCase
@@ -31,7 +38,7 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
     {
         $this->load([
             'class' => [
-                'category' => '\stdClass',
+                'category' => \stdClass::class,
             ],
             'category_manager' => 'dummy.service.name',
         ]);
@@ -43,7 +50,7 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
     {
         $this->load([
             'class' => [
-                'category' => '\stdClass',
+                'category' => \stdClass::class,
             ],
             'category_manager' => 'dummy.service.name',
             'force_disable_category' => true,
@@ -59,7 +66,7 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasAlias('sonata.media.manager.category');
         $this->assertContainerBuilderHasService(
             'sonata.media.manager.category.default',
-            'Sonata\MediaBundle\Model\CategoryManager'
+            CategoryManager::class
         );
     }
 
@@ -76,7 +83,7 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
     {
         $this->load([
             'class' => [
-                'category' => '\stdClass',
+                'category' => \stdClass::class,
             ],
             'category_manager' => 'dummy.service.name',
         ]);
@@ -111,9 +118,9 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
     public function dataAdapter()
     {
         return [
-            ['sonata.media.adapter.image.gd', 'gd', 'Imagine\\Gd\\Imagine'],
-            ['sonata.media.adapter.image.gmagick', 'gmagick', 'Imagine\\Gmagick\\Imagine'],
-            ['sonata.media.adapter.image.imagick', 'imagick', 'Imagine\\Imagick\\Imagine'],
+            ['sonata.media.adapter.image.gd', 'gd', GdImagine::class],
+            ['sonata.media.adapter.image.gmagick', 'gmagick', GmagicImagine::class],
+            ['sonata.media.adapter.image.imagick', 'imagick', ImagicImagine::class],
         ];
     }
 
@@ -125,7 +132,7 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
         if (extension_loaded('gd')) {
             $this->assertContainerBuilderHasService(
                 'sonata.media.resizer.default',
-                'Sonata\\MediaBundle\\Resizer\\SimpleResizer'
+                SimpleResizer::class
             );
         }
     }
@@ -149,8 +156,8 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
     public function dataResizer()
     {
         return [
-            ['sonata.media.resizer.simple', 'Sonata\\MediaBundle\\Resizer\\SimpleResizer'],
-            ['sonata.media.resizer.square', 'Sonata\\MediaBundle\\Resizer\\SquareResizer'],
+            ['sonata.media.resizer.simple', SimpleResizer::class],
+            ['sonata.media.resizer.square', SquareResizer::class],
         ];
     }
 
@@ -166,7 +173,7 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
 
     public function testLoadWithSonataAdminCustomConfiguration()
     {
-        $fakeContainer = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
+        $fakeContainer = $this->getMockBuilder(ContainerBuilder::class)
             ->setMethods(['getParameter', 'getExtensionConfig'])
             ->getMock();
 

--- a/tests/Document/MediaManagerTest.php
+++ b/tests/Document/MediaManagerTest.php
@@ -11,8 +11,11 @@
 
 namespace Sonata\MediaBundle\Tests\Document;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ODM\MongoDB\DocumentManager;
 use PHPUnit\Framework\TestCase;
 use Sonata\MediaBundle\Document\MediaManager;
+use Sonata\MediaBundle\Model\MediaInterface;
 
 /**
  * @group document
@@ -25,7 +28,7 @@ class MediaManagerTest extends TestCase
 
     protected function setUp()
     {
-        $this->manager = new MediaManager('Sonata\MediaBundle\Model\MediaInterface', $this->createRegistryMock());
+        $this->manager = new MediaManager(MediaInterface::class, $this->createRegistryMock());
     }
 
     public function testSave()
@@ -64,11 +67,11 @@ class MediaManagerTest extends TestCase
      */
     protected function createRegistryMock()
     {
-        $dm = $this->getMockBuilder('Doctrine\ODM\MongoDB\DocumentManager')
+        $dm = $this->getMockBuilder(DocumentManager::class)
             ->setMethods(['persist', 'flush'])
             ->disableOriginalConstructor()
             ->getMock();
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
 
         $dm->expects($this->any())->method('persist');
         $dm->expects($this->any())->method('flush');

--- a/tests/Entity/GalleryManagerTest.php
+++ b/tests/Entity/GalleryManagerTest.php
@@ -11,8 +11,10 @@
 
 namespace Sonata\MediaBundle\Test\Entity;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\Test\EntityManagerMockFactory;
+use Sonata\MediaBundle\Entity\BaseGallery;
 use Sonata\MediaBundle\Entity\GalleryManager;
 
 /**
@@ -100,9 +102,9 @@ class GalleryManagerTest extends TestCase
             'enabled',
         ]);
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        return new GalleryManager('Sonata\MediaBundle\Entity\BaseGallery', $registry);
+        return new GalleryManager(BaseGallery::class, $registry);
     }
 }

--- a/tests/Entity/Media.php
+++ b/tests/Entity/Media.php
@@ -11,7 +11,9 @@
 
 namespace Sonata\MediaBundle\Tests\Entity;
 
-class Media extends \Sonata\MediaBundle\Entity\BaseMedia
+use Sonata\MediaBundle\Entity\BaseMedia;
+
+class Media extends BaseMedia
 {
     protected $id;
 

--- a/tests/Entity/MediaManagerTest.php
+++ b/tests/Entity/MediaManagerTest.php
@@ -11,8 +11,10 @@
 
 namespace Sonata\MediaBundle\Test\Entity;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
 use Sonata\CoreBundle\Test\EntityManagerMockFactory;
+use Sonata\MediaBundle\Entity\BaseMedia;
 use Sonata\MediaBundle\Entity\MediaManager;
 
 /**
@@ -101,9 +103,9 @@ class MediaManagerTest extends TestCase
             'enabled',
         ]);
 
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
-        return new MediaManager('Sonata\MediaBundle\Entity\BaseMedia', $registry);
+        return new MediaManager(BaseMedia::class, $registry);
     }
 }

--- a/tests/Entity/MediaTest.php
+++ b/tests/Entity/MediaTest.php
@@ -12,6 +12,8 @@
 namespace Sonata\MediaBundle\Tests\Entity;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\ClassificationBundle\Model\CategoryInterface;
+use Sonata\MediaBundle\Tests\Controller\EntityWithGetId;
 
 class MediaTest extends TestCase
 {
@@ -36,8 +38,8 @@ class MediaTest extends TestCase
     public function testSetGet()
     {
         $category = $this->prophesize();
-        $category->willExtend('Sonata\MediaBundle\Tests\Controller\EntityWithGetId');
-        $category->willImplement('Sonata\ClassificationBundle\Model\CategoryInterface');
+        $category->willExtend(EntityWithGetId::class);
+        $category->willImplement(CategoryInterface::class);
 
         $media = new Media();
         $media->setName('MediaBundle');
@@ -89,7 +91,7 @@ class MediaTest extends TestCase
 
     public function testSetCategoryWithoutAnActualCategory()
     {
-        $this->expectException('\InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
 
         $media = new Media();
 

--- a/tests/Filesystem/ReplicateTest.php
+++ b/tests/Filesystem/ReplicateTest.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\MediaBundle\Tests\Filesystem;
 
+use Gaufrette\Adapter;
 use PHPUnit\Framework\TestCase;
 use Sonata\MediaBundle\Filesystem\Replicate;
 
@@ -18,8 +19,8 @@ class ReplicateTest extends TestCase
 {
     public function testReplicate()
     {
-        $master = $this->createMock('Gaufrette\Adapter');
-        $slave = $this->createMock('Gaufrette\Adapter');
+        $master = $this->createMock(Adapter::class);
+        $slave = $this->createMock(Adapter::class);
         $replicate = new Replicate($master, $slave);
 
         $master->expects($this->once())->method('mtime')->will($this->returnValue('master'));

--- a/tests/Form/DataTransformer/ProviderDataTransformerTest.php
+++ b/tests/Form/DataTransformer/ProviderDataTransformerTest.php
@@ -12,8 +12,10 @@
 namespace Sonata\MediaBundle\Tests\Form\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Sonata\MediaBundle\Form\DataTransformer\ProviderDataTransformer;
 use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
@@ -21,7 +23,7 @@ class ProviderDataTransformerTest extends TestCase
 {
     public function testReverseTransformFakeValue()
     {
-        $pool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
+        $pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
 
         $transformer = new ProviderDataTransformer($pool, 'stdClass');
         $this->assertSame('foo', $transformer->reverseTransform('foo'));
@@ -33,7 +35,7 @@ class ProviderDataTransformerTest extends TestCase
 
         $pool = new Pool('default');
 
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
         $media->expects($this->exactly(3))->method('getProviderName')->will($this->returnValue('unknown'));
         $media->expects($this->any())->method('getId')->will($this->returnValue(1));
         $media->expects($this->any())->method('getBinaryContent')->will($this->returnValue('xcs'));
@@ -46,13 +48,13 @@ class ProviderDataTransformerTest extends TestCase
 
     public function testReverseTransformValidProvider()
     {
-        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock(MediaProviderInterface::class);
         $provider->expects($this->once())->method('transform');
 
         $pool = new Pool('default');
         $pool->addProvider('default', $provider);
 
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
         $media->expects($this->exactly(3))->method('getProviderName')->will($this->returnValue('default'));
         $media->expects($this->any())->method('getId')->will($this->returnValue(1));
         $media->expects($this->any())->method('getBinaryContent')->will($this->returnValue('xcs'));
@@ -65,12 +67,12 @@ class ProviderDataTransformerTest extends TestCase
 
     public function testReverseTransformWithNewMediaAndNoBinaryContent()
     {
-        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock(MediaProviderInterface::class);
 
         $pool = new Pool('default');
         $pool->addProvider('default', $provider);
 
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
         $media->expects($this->any())->method('getId')->will($this->returnValue(null));
         $media->expects($this->any())->method('getBinaryContent')->will($this->returnValue(null));
         $media->expects($this->any())->method('getProviderName')->will($this->returnValue('default'));
@@ -86,12 +88,12 @@ class ProviderDataTransformerTest extends TestCase
 
     public function testReverseTransformWithMediaAndNoBinaryContent()
     {
-        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock(MediaProviderInterface::class);
 
         $pool = new Pool('default');
         $pool->addProvider('default', $provider);
 
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
         $media->expects($this->any())->method('getId')->will($this->returnValue(1));
         $media->expects($this->any())->method('getBinaryContent')->will($this->returnValue(null));
 
@@ -101,12 +103,12 @@ class ProviderDataTransformerTest extends TestCase
 
     public function testReverseTransformWithMediaAndUploadFileInstance()
     {
-        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock(MediaProviderInterface::class);
 
         $pool = new Pool('default');
         $pool->addProvider('default', $provider);
 
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
         $media->expects($this->any())->method('getProviderName')->will($this->returnValue('default'));
         $media->expects($this->any())->method('getId')->will($this->returnValue(1));
         $media->expects($this->any())->method('getBinaryContent')->will($this->returnValue(new UploadedFile(__FILE__, 'ProviderDataTransformerTest')));
@@ -119,13 +121,13 @@ class ProviderDataTransformerTest extends TestCase
 
     public function testReverseTransformWithThrowingProviderNoThrow()
     {
-        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock(MediaProviderInterface::class);
         $provider->expects($this->once())->method('transform')->will($this->throwException(new \Exception()));
 
         $pool = new Pool('default');
         $pool->addProvider('default', $provider);
 
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
         $media->expects($this->exactly(3))->method('getProviderName')->will($this->returnValue('default'));
         $media->expects($this->any())->method('getId')->will($this->returnValue(1));
         $media->expects($this->any())->method('getBinaryContent')->will($this->returnValue(new UploadedFile(__FILE__, 'ProviderDataTransformerTest')));
@@ -138,16 +140,16 @@ class ProviderDataTransformerTest extends TestCase
 
     public function testReverseTransformWithThrowingProviderLogsException()
     {
-        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock(MediaProviderInterface::class);
         $provider->expects($this->once())->method('transform')->will($this->throwException(new \Exception()));
 
         $pool = new Pool('default');
         $pool->addProvider('default', $provider);
 
-        $logger = $this->createMock('Psr\Log\LoggerInterface');
+        $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())->method('error');
 
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
         $media->expects($this->exactly(3))->method('getProviderName')->will($this->returnValue('default'));
         $media->expects($this->any())->method('getId')->will($this->returnValue(1));
         $media->expects($this->any())->method('getBinaryContent')->will($this->returnValue(new UploadedFile(__FILE__, 'ProviderDataTransformerTest')));

--- a/tests/Form/DataTransformer/ServiceProviderDataTransformerTest.php
+++ b/tests/Form/DataTransformer/ServiceProviderDataTransformerTest.php
@@ -13,13 +13,16 @@ namespace Sonata\MediaBundle\Tests\Form\DataTransformer;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Psr\Log\LoggerInterface;
 use Sonata\MediaBundle\Form\DataTransformer\ServiceProviderDataTransformer;
+use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Provider\MediaProviderInterface;
 
 class ServiceProviderDataTransformerTest extends TestCase
 {
     public function testTransformNoop()
     {
-        $provider = $this->prophesize('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->prophesize(MediaProviderInterface::class);
 
         $transformer = new ServiceProviderDataTransformer($provider->reveal());
 
@@ -29,7 +32,7 @@ class ServiceProviderDataTransformerTest extends TestCase
 
     public function testReverseTransformSkipsProviderIfNotMedia()
     {
-        $provider = $this->prophesize('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->prophesize(MediaProviderInterface::class);
         $provider->transform()->shouldNotBeCalled();
 
         $transformer = new ServiceProviderDataTransformer($provider->reveal());
@@ -40,9 +43,9 @@ class ServiceProviderDataTransformerTest extends TestCase
 
     public function testReverseTransformForwardsToProvider()
     {
-        $media = $this->prophesize('Sonata\MediaBundle\Model\MediaInterface')->reveal();
+        $media = $this->prophesize(MediaInterface::class)->reveal();
 
-        $provider = $this->prophesize('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->prophesize(MediaProviderInterface::class);
         $provider->transform(Argument::is($media))->shouldBeCalledTimes(1);
 
         $transformer = new ServiceProviderDataTransformer($provider->reveal());
@@ -51,9 +54,9 @@ class ServiceProviderDataTransformerTest extends TestCase
 
     public function testReverseTransformWithThrowingProviderNoThrow()
     {
-        $media = $this->prophesize('Sonata\MediaBundle\Model\MediaInterface')->reveal();
+        $media = $this->prophesize(MediaInterface::class)->reveal();
 
-        $provider = $this->prophesize('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->prophesize(MediaProviderInterface::class);
         $provider->transform(Argument::is($media))->shouldBeCalled()->willThrow(new \Exception());
 
         $transformer = new ServiceProviderDataTransformer($provider->reveal());
@@ -62,13 +65,13 @@ class ServiceProviderDataTransformerTest extends TestCase
 
     public function testReverseTransformWithThrowingProviderLogsException()
     {
-        $media = $this->prophesize('Sonata\MediaBundle\Model\MediaInterface')->reveal();
+        $media = $this->prophesize(MediaInterface::class)->reveal();
 
         $exception = new \Exception('foo');
-        $provider = $this->prophesize('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->prophesize(MediaProviderInterface::class);
         $provider->transform(Argument::is($media))->shouldBeCalled()->willThrow($exception);
 
-        $logger = $this->prophesize('Psr\Log\LoggerInterface');
+        $logger = $this->prophesize(LoggerInterface::class);
         $logger->error(
             Argument::containingString('Caught Exception Exception: "foo" at'),
             Argument::is(['exception' => $exception])

--- a/tests/Form/Type/AbstractTypeTest.php
+++ b/tests/Form/Type/AbstractTypeTest.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\MediaBundle\Tests\Form\Type;
 
+use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormTypeInterface;
@@ -38,14 +39,14 @@ abstract class AbstractTypeTest extends TypeTestCase
 
     protected function setUp()
     {
-        $provider = $this->getMockBuilder('Sonata\MediaBundle\Provider\MediaProviderInterface')
+        $provider = $this->getMockBuilder(MediaProviderInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->mediaPool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
+        $this->mediaPool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
         $this->mediaPool->expects($this->any())->method('getProvider')->willReturn($provider);
 
-        $this->formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $this->formBuilder = $this->getMockBuilder(FormBuilder::class)->disableOriginalConstructor()->getMock();
         $this->formBuilder
             ->expects($this->any())
             ->method('add')

--- a/tests/Form/Type/ApiMediaTypeTest.php
+++ b/tests/Form/Type/ApiMediaTypeTest.php
@@ -12,6 +12,9 @@
 namespace Sonata\MediaBundle\Tests\Form\Type;
 
 use Sonata\MediaBundle\Form\Type\ApiMediaType;
+use Sonata\MediaBundle\Provider\MediaProviderInterface;
+use Sonata\MediaBundle\Provider\Pool;
+use Symfony\Component\Form\FormBuilder;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -21,14 +24,14 @@ class ApiMediaTypeTest extends AbstractTypeTest
     public function testBuildForm()
     {
         parent::testBuildForm();
-        $provider = $this->getMockBuilder('Sonata\MediaBundle\Provider\MediaProviderInterface')->getMock();
+        $provider = $this->getMockBuilder(MediaProviderInterface::class)->getMock();
 
-        $mediaPool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
+        $mediaPool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
         $mediaPool->expects($this->once())->method('getProvider')->will($this->returnValue($provider));
 
         $type = new ApiMediaType($mediaPool, 'testclass');
 
-        $builder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $builder = $this->getMockBuilder(FormBuilder::class)->disableOriginalConstructor()->getMock();
         $builder->expects($this->once())->method('addModelTransformer');
 
         $type->buildForm($builder, ['provider_name' => 'sonata.media.provider.image']);

--- a/tests/Form/Type/MediaTypeTest.php
+++ b/tests/Form/Type/MediaTypeTest.php
@@ -12,8 +12,10 @@
 namespace Sonata\MediaBundle\Tests\Form\Type;
 
 use Sonata\MediaBundle\Form\Type\MediaType;
+use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Component\Form\Forms;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 
 /**
  * @author Virgile Vivier <virgilevivier@gmail.com>
@@ -32,7 +34,7 @@ class MediaTypeTest extends AbstractTypeTest
     {
         parent::setUp();
 
-        $this->mediaPool = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')->disableOriginalConstructor()->getMock();
+        $this->mediaPool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
         $this->mediaType = new MediaType($this->mediaPool, 'testClass');
 
         $this->factory = Forms::createFormFactoryBuilder()
@@ -52,9 +54,7 @@ class MediaTypeTest extends AbstractTypeTest
             'pic' => [],
         ]));
 
-        $this->expectException(
-            'Symfony\Component\OptionsResolver\Exception\MissingOptionsException'
-        );
+        $this->expectException(MissingOptionsException::class);
         $this->expectExceptionMessage(
             'The required options "context", "provider" are missing.'
         );
@@ -73,7 +73,7 @@ class MediaTypeTest extends AbstractTypeTest
             'pic' => [],
         ]));
 
-        $this->expectException('Symfony\Component\OptionsResolver\Exception\MissingOptionsException');
+        $this->expectException(MissingOptionsException::class);
 
         $this->factory->create($this->getFormType(), null, [
             'provider' => 'provider_a',
@@ -91,7 +91,7 @@ class MediaTypeTest extends AbstractTypeTest
             'pic' => [],
         ]));
 
-        $this->expectException('Symfony\Component\OptionsResolver\Exception\MissingOptionsException');
+        $this->expectException(MissingOptionsException::class);
 
         $this->factory->create($this->getFormType(), null, [
             'context' => 'pic',

--- a/tests/Listener/ORM/MediaEventSubscriberTest.php
+++ b/tests/Listener/ORM/MediaEventSubscriberTest.php
@@ -11,10 +11,14 @@
 
 namespace Sonata\MediaBundle\Tests\Listener\ORM;
 
+use Doctrine\Common\EventArgs;
 use Doctrine\ORM\Events;
 use PHPUnit\Framework\TestCase;
+use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\MediaBundle\Listener\ORM\MediaEventSubscriber;
+use Sonata\MediaBundle\Model\CategoryManagerInterface;
 use Sonata\MediaBundle\Model\Media;
+use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -29,20 +33,20 @@ class MediaEventSubscriberTest extends TestCase
      */
     public function testRefetchCategoriesAfterClear()
     {
-        $provider = $this->createMock('Sonata\\MediaBundle\\Provider\\MediaProviderInterface');
+        $provider = $this->createMock(MediaProviderInterface::class);
 
-        $pool = $this->getMockBuilder('Sonata\\MediaBundle\\Provider\\Pool')
+        $pool = $this->getMockBuilder(Pool::class)
             ->setMethods(['getProvider'])
             ->setConstructorArgs(['default'])
             ->getMock();
 
         $pool->method('getProvider')->will($this->returnValueMap([['provider', $provider]]));
 
-        $category = $this->createMock('Sonata\\ClassificationBundle\\Model\\CategoryInterface');
+        $category = $this->createMock(CategoryInterface::class);
 
-        $catManager = $this->createMock('Sonata\\MediaBundle\\Model\\CategoryManagerInterface');
+        $catManager = $this->createMock(CategoryManagerInterface::class);
 
-        $container = $this->createMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
+        $container = $this->createMock(ContainerInterface::class);
 
         $container->method('get')->will($this->returnValueMap([
             ['sonata.media.pool', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $pool],
@@ -61,13 +65,13 @@ class MediaEventSubscriberTest extends TestCase
 
         $this->assertContains(Events::onClear, $subscriber->getSubscribedEvents());
 
-        $media1 = $this->getMockBuilder('Sonata\\MediaBundle\\Model\\Media')
+        $media1 = $this->getMockBuilder(Media::class)
             ->setMethods(['getId', 'getCategory', 'getProvider', 'getContext'])
             ->getMock();
         $media1->method('getProvider')->willReturn('provider');
         $media1->method('getContext')->willReturn('context');
 
-        $args1 = $this->getMockBuilder('Doctrine\\Common\\EventArgs')
+        $args1 = $this->getMockBuilder(EventArgs::class)
             ->setMethods(['getEntity'])
             ->getMock();
         $args1->method('getEntity')->willReturn($media1);
@@ -76,13 +80,13 @@ class MediaEventSubscriberTest extends TestCase
 
         $subscriber->onClear();
 
-        $media2 = $this->getMockBuilder('Sonata\\MediaBundle\\Model\\Media')
+        $media2 = $this->getMockBuilder(Media::class)
             ->setMethods(['getId', 'getCategory', 'getProvider', 'getContext'])
             ->getMock();
         $media2->method('getProvider')->willReturn('provider');
         $media2->method('getContext')->willReturn('context');
 
-        $args2 = $this->getMockBuilder('Doctrine\\Common\\EventArgs')
+        $args2 = $this->getMockBuilder(EventArgs::class)
             ->setMethods(['getEntity'])
             ->getMock();
         $args2->method('getEntity')->willReturn($media2);

--- a/tests/Metadata/AmazonMetadataBuilderTest.php
+++ b/tests/Metadata/AmazonMetadataBuilderTest.php
@@ -14,12 +14,13 @@ namespace Sonata\MediaBundle\Tests\Metadata;
 use Aws\S3\Enum\Storage;
 use PHPUnit\Framework\TestCase;
 use Sonata\MediaBundle\Metadata\AmazonMetadataBuilder;
+use Sonata\MediaBundle\Model\MediaInterface;
 
 class AmazonMetadataBuilderTest extends TestCase
 {
     public function testAmazon()
     {
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
         $filename = '/test/folder/testfile.png';
 
         foreach ($this->provider() as $provider) {

--- a/tests/Metadata/NoopMetadataBuilderTest.php
+++ b/tests/Metadata/NoopMetadataBuilderTest.php
@@ -13,12 +13,13 @@ namespace Sonata\MediaBundle\Tests\Metadata;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\MediaBundle\Metadata\NoopMetadataBuilder;
+use Sonata\MediaBundle\Model\MediaInterface;
 
 class NoopMetadataBuilderTest extends TestCase
 {
     public function testNoop()
     {
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
         $filename = '/test/folder/testfile.png';
 
         $noopmetadatabuilder = new NoopMetadataBuilder();

--- a/tests/Metadata/ProxyMetadataBuilderTest.php
+++ b/tests/Metadata/ProxyMetadataBuilderTest.php
@@ -13,21 +13,27 @@ namespace Sonata\MediaBundle\Tests\Metadata;
 
 use AmazonS3 as AmazonClient;
 use Gaufrette\Adapter\AmazonS3;
+use Gaufrette\Filesystem;
 use PHPUnit\Framework\TestCase;
 use Sonata\MediaBundle\Filesystem\Local;
 use Sonata\MediaBundle\Filesystem\Replicate;
+use Sonata\MediaBundle\Metadata\AmazonMetadataBuilder;
+use Sonata\MediaBundle\Metadata\NoopMetadataBuilder;
 use Sonata\MediaBundle\Metadata\ProxyMetadataBuilder;
+use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Provider\MediaProviderInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class ProxyMetadataBuilderTest extends TestCase
 {
     public function testProxyAmazon()
     {
-        $amazon = $this->getMockBuilder('Sonata\MediaBundle\Metadata\AmazonMetadataBuilder')->disableOriginalConstructor()->getMock();
+        $amazon = $this->getMockBuilder(AmazonMetadataBuilder::class)->disableOriginalConstructor()->getMock();
         $amazon->expects($this->once())
             ->method('get')
             ->will($this->returnValue(['key' => 'amazon']));
 
-        $noop = $this->createMock('Sonata\MediaBundle\Metadata\NoopMetadataBuilder');
+        $noop = $this->createMock(NoopMetadataBuilder::class);
         $noop->expects($this->never())
             ->method('get')
             ->will($this->returnValue(['key' => 'noop']));
@@ -36,13 +42,13 @@ class ProxyMetadataBuilderTest extends TestCase
         $amazonclient = new AmazonClient(['key' => 'XXXXXXXXXXXX', 'secret' => 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX']);
         $adapter = new AmazonS3($amazonclient, '');
 
-        $filesystem = $this->getMockBuilder('Gaufrette\Filesystem')->disableOriginalConstructor()->getMock();
+        $filesystem = $this->getMockBuilder(Filesystem::class)->disableOriginalConstructor()->getMock();
         $filesystem->expects($this->any())->method('getAdapter')->will($this->returnValue($adapter));
 
-        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock(MediaProviderInterface::class);
         $provider->expects($this->any())->method('getFilesystem')->will($this->returnValue($filesystem));
 
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
         $media->expects($this->any())
             ->method('getProviderName')
             ->will($this->returnValue('sonata.media.provider.image'));
@@ -62,12 +68,12 @@ class ProxyMetadataBuilderTest extends TestCase
 
     public function testProxyLocal()
     {
-        $amazon = $this->getMockBuilder('Sonata\MediaBundle\Metadata\AmazonMetadataBuilder')->disableOriginalConstructor()->getMock();
+        $amazon = $this->getMockBuilder(AmazonMetadataBuilder::class)->disableOriginalConstructor()->getMock();
         $amazon->expects($this->never())
             ->method('get')
             ->will($this->returnValue(['key' => 'amazon']));
 
-        $noop = $this->createMock('Sonata\MediaBundle\Metadata\NoopMetadataBuilder');
+        $noop = $this->createMock(NoopMetadataBuilder::class);
         $noop->expects($this->once())
             ->method('get')
             ->will($this->returnValue(['key' => 'noop']));
@@ -75,13 +81,13 @@ class ProxyMetadataBuilderTest extends TestCase
         //adapter cannot be mocked
         $adapter = new Local('');
 
-        $filesystem = $this->getMockBuilder('Gaufrette\Filesystem')->disableOriginalConstructor()->getMock();
+        $filesystem = $this->getMockBuilder(Filesystem::class)->disableOriginalConstructor()->getMock();
         $filesystem->expects($this->any())->method('getAdapter')->will($this->returnValue($adapter));
 
-        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock(MediaProviderInterface::class);
         $provider->expects($this->any())->method('getFilesystem')->will($this->returnValue($filesystem));
 
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
         $media->expects($this->any())
             ->method('getProviderName')
             ->will($this->returnValue('sonata.media.provider.image'));
@@ -101,12 +107,12 @@ class ProxyMetadataBuilderTest extends TestCase
 
     public function testProxyNoProvider()
     {
-        $amazon = $this->getMockBuilder('Sonata\MediaBundle\Metadata\AmazonMetadataBuilder')->disableOriginalConstructor()->getMock();
+        $amazon = $this->getMockBuilder(AmazonMetadataBuilder::class)->disableOriginalConstructor()->getMock();
         $amazon->expects($this->never())
             ->method('get')
             ->will($this->returnValue(['key' => 'amazon']));
 
-        $noop = $this->createMock('Sonata\MediaBundle\Metadata\NoopMetadataBuilder');
+        $noop = $this->createMock(NoopMetadataBuilder::class);
         $noop->expects($this->never())
             ->method('get')
             ->will($this->returnValue(['key' => 'noop']));
@@ -114,13 +120,13 @@ class ProxyMetadataBuilderTest extends TestCase
         //adapter cannot be mocked
         $adapter = new Local('');
 
-        $filesystem = $this->getMockBuilder('Gaufrette\Filesystem')->disableOriginalConstructor()->getMock();
+        $filesystem = $this->getMockBuilder(Filesystem::class)->disableOriginalConstructor()->getMock();
         $filesystem->expects($this->any())->method('getAdapter')->will($this->returnValue($adapter));
 
-        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock(MediaProviderInterface::class);
         $provider->expects($this->any())->method('getFilesystem')->will($this->returnValue($filesystem));
 
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
         $media->expects($this->any())
             ->method('getProviderName')
             ->will($this->returnValue('wrongprovider'));
@@ -140,12 +146,12 @@ class ProxyMetadataBuilderTest extends TestCase
 
     public function testProxyReplicateWithAmazon()
     {
-        $amazon = $this->getMockBuilder('Sonata\MediaBundle\Metadata\AmazonMetadataBuilder')->disableOriginalConstructor()->getMock();
+        $amazon = $this->getMockBuilder(AmazonMetadataBuilder::class)->disableOriginalConstructor()->getMock();
         $amazon->expects($this->once())
             ->method('get')
             ->will($this->returnValue(['key' => 'amazon']));
 
-        $noop = $this->createMock('Sonata\MediaBundle\Metadata\NoopMetadataBuilder');
+        $noop = $this->createMock(NoopMetadataBuilder::class);
         $noop->expects($this->never())
             ->method('get')
             ->will($this->returnValue(['key' => 'noop']));
@@ -156,13 +162,13 @@ class ProxyMetadataBuilderTest extends TestCase
         $adapter2 = new Local('');
         $adapter = new Replicate($adapter1, $adapter2);
 
-        $filesystem = $this->getMockBuilder('Gaufrette\Filesystem')->disableOriginalConstructor()->getMock();
+        $filesystem = $this->getMockBuilder(Filesystem::class)->disableOriginalConstructor()->getMock();
         $filesystem->expects($this->any())->method('getAdapter')->will($this->returnValue($adapter));
 
-        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock(MediaProviderInterface::class);
         $provider->expects($this->any())->method('getFilesystem')->will($this->returnValue($filesystem));
 
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
         $media->expects($this->any())
             ->method('getProviderName')
             ->will($this->returnValue('sonata.media.provider.image'));
@@ -182,12 +188,12 @@ class ProxyMetadataBuilderTest extends TestCase
 
     public function testProxyReplicateWithoutAmazon()
     {
-        $amazon = $this->getMockBuilder('Sonata\MediaBundle\Metadata\AmazonMetadataBuilder')->disableOriginalConstructor()->getMock();
+        $amazon = $this->getMockBuilder(AmazonMetadataBuilder::class)->disableOriginalConstructor()->getMock();
         $amazon->expects($this->never())
             ->method('get')
             ->will($this->returnValue(['key' => 'amazon']));
 
-        $noop = $this->createMock('Sonata\MediaBundle\Metadata\NoopMetadataBuilder');
+        $noop = $this->createMock(NoopMetadataBuilder::class);
         $noop->expects($this->once())
             ->method('get')
             ->will($this->returnValue(['key' => 'noop']));
@@ -197,13 +203,13 @@ class ProxyMetadataBuilderTest extends TestCase
         $adapter2 = new Local('');
         $adapter = new Replicate($adapter1, $adapter2);
 
-        $filesystem = $this->getMockBuilder('Gaufrette\Filesystem')->disableOriginalConstructor()->getMock();
+        $filesystem = $this->getMockBuilder(Filesystem::class)->disableOriginalConstructor()->getMock();
         $filesystem->expects($this->any())->method('getAdapter')->will($this->returnValue($adapter));
 
-        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock(MediaProviderInterface::class);
         $provider->expects($this->any())->method('getFilesystem')->will($this->returnValue($filesystem));
 
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
         $media->expects($this->any())
             ->method('getProviderName')
             ->will($this->returnValue('sonata.media.provider.image'));
@@ -230,7 +236,7 @@ class ProxyMetadataBuilderTest extends TestCase
      */
     protected function getContainerMock(array $services)
     {
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock(ContainerInterface::class);
         $container
             ->expects($this->any())
             ->method('get')

--- a/tests/Model/MediaTest.php
+++ b/tests/Model/MediaTest.php
@@ -12,6 +12,7 @@
 namespace Sonata\MediaBundle\Tests\Media;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\MediaBundle\Model\Media;
 
 class MediaTest extends TestCase
 {
@@ -64,7 +65,7 @@ class MediaTest extends TestCase
 
     protected function getMediaPropertyReflection($propertyName)
     {
-        $rc = new \ReflectionClass('Sonata\MediaBundle\Model\Media');
+        $rc = new \ReflectionClass(Media::class);
         $property = $rc->getProperty($propertyName);
         $property->setAccessible(true);
 
@@ -73,7 +74,7 @@ class MediaTest extends TestCase
 
     protected function getMedia($id)
     {
-        $media = $this->getMockForAbstractClass('Sonata\MediaBundle\Model\Media');
+        $media = $this->getMockForAbstractClass(Media::class);
         $media->expects($this->any())
             ->method('getId')
             ->will($this->returnValue($id));

--- a/tests/PHPCR/MediaManagerTest.php
+++ b/tests/PHPCR/MediaManagerTest.php
@@ -11,7 +11,10 @@
 
 namespace Sonata\MediaBundle\Tests\PHPCR;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ODM\PHPCR\DocumentManager;
 use PHPUnit\Framework\TestCase;
+use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\PHPCR\MediaManager;
 
 /**
@@ -25,7 +28,7 @@ class MediaManagerTest extends TestCase
 
     protected function setUp()
     {
-        $this->manager = new MediaManager('Sonata\MediaBundle\Model\MediaInterface', $this->createRegistryMock());
+        $this->manager = new MediaManager(MediaInterface::class, $this->createRegistryMock());
     }
 
     public function testSave()
@@ -64,11 +67,11 @@ class MediaManagerTest extends TestCase
      */
     protected function createRegistryMock()
     {
-        $dm = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')
+        $dm = $this->getMockBuilder(DocumentManager::class)
             ->setMethods(['persist', 'flush'])
             ->disableOriginalConstructor()
             ->getMock();
-        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock(ManagerRegistry::class);
 
         $dm->expects($this->any())->method('persist');
         $dm->expects($this->any())->method('flush');

--- a/tests/Provider/AbstractProviderTest.php
+++ b/tests/Provider/AbstractProviderTest.php
@@ -44,7 +44,7 @@ abstract class AbstractProviderTest extends TestCase
 
     protected function setUp()
     {
-        $this->formMapper = $this->getMockBuilder('Sonata\AdminBundle\Form\FormMapper')->disableOriginalConstructor()->getMock();
+        $this->formMapper = $this->getMockBuilder(FormMapper::class)->disableOriginalConstructor()->getMock();
         $this->formMapper
             ->expects($this->any())
             ->method('add')
@@ -54,7 +54,7 @@ abstract class AbstractProviderTest extends TestCase
                 }
             }));
 
-        $this->formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')->disableOriginalConstructor()->getMock();
+        $this->formBuilder = $this->getMockBuilder(FormBuilder::class)->disableOriginalConstructor()->getMock();
         $this->formBuilder
             ->expects($this->any())
             ->method('add')

--- a/tests/Provider/BaseProviderTest.php
+++ b/tests/Provider/BaseProviderTest.php
@@ -11,23 +11,31 @@
 
 namespace Sonata\MediaBundle\Tests\Provider;
 
+use Gaufrette\Adapter;
+use Gaufrette\File;
+use Gaufrette\Filesystem;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\MediaBundle\CDN\CDNInterface;
+use Sonata\MediaBundle\CDN\Server;
+use Sonata\MediaBundle\Generator\DefaultGenerator;
+use Sonata\MediaBundle\Metadata\MetadataBuilderInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Provider\BaseProvider;
 use Sonata\MediaBundle\Tests\Entity\Media;
+use Sonata\MediaBundle\Thumbnail\ThumbnailInterface;
 use Symfony\Component\Form\FormBuilder;
 
 class BaseProviderTest extends AbstractProviderTest
 {
     public function getProvider()
     {
-        $adapter = $this->createMock('Gaufrette\Adapter');
+        $adapter = $this->createMock(Adapter::class);
 
-        $filesystem = $this->getMockBuilder('Gaufrette\Filesystem')
+        $filesystem = $this->getMockBuilder(Filesystem::class)
             ->setMethods(['get'])
             ->setConstructorArgs([$adapter])
             ->getMock();
-        $file = $this->getMockBuilder('Gaufrette\File')
+        $file = $this->getMockBuilder(File::class)
             ->setConstructorArgs(['foo', $filesystem])
             ->getMock();
 
@@ -35,13 +43,13 @@ class BaseProviderTest extends AbstractProviderTest
             ->method('get')
             ->will($this->returnValue($file));
 
-        $cdn = new \Sonata\MediaBundle\CDN\Server('/uploads/media');
+        $cdn = new Server('/uploads/media');
 
-        $generator = new \Sonata\MediaBundle\Generator\DefaultGenerator();
+        $generator = new DefaultGenerator();
 
-        $thumbnail = $this->createMock('Sonata\MediaBundle\Thumbnail\ThumbnailInterface');
+        $thumbnail = $this->createMock(ThumbnailInterface::class);
 
-        $metadata = $this->createMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
+        $metadata = $this->createMock(MetadataBuilderInterface::class);
 
         $provider = new TestProvider('test', $filesystem, $cdn, $generator, $thumbnail, $metadata);
 
@@ -58,13 +66,13 @@ class BaseProviderTest extends AbstractProviderTest
         $this->assertInternalType('array', $provider->getTemplates());
         $this->assertSame('edit.twig', $provider->getTemplate('edit'));
 
-        $this->assertInstanceOf('\Sonata\MediaBundle\CDN\CDNInterface', $provider->getCdn());
+        $this->assertInstanceOf(CDNInterface::class, $provider->getCdn());
 
         $provider->addFormat('small', []);
 
         $this->assertInternalType('array', $provider->getFormat('small'));
 
-        $media = new \Sonata\MediaBundle\Tests\Entity\Media();
+        $media = new Media();
         $media->setContext('test');
 
         $this->assertSame('admin', $provider->getFormatName($media, 'admin'));

--- a/tests/Provider/DailyMotionProviderTest.php
+++ b/tests/Provider/DailyMotionProviderTest.php
@@ -12,9 +12,19 @@
 namespace Sonata\MediaBundle\Tests\Provider;
 
 use Buzz\Browser;
+use Buzz\Message\AbstractMessage;
 use Buzz\Message\Response;
+use Gaufrette\Adapter;
+use Gaufrette\File;
+use Gaufrette\Filesystem;
 use Imagine\Image\Box;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\MediaBundle\CDN\Server;
+use Sonata\MediaBundle\Generator\DefaultGenerator;
+use Sonata\MediaBundle\Metadata\MetadataBuilderInterface;
 use Sonata\MediaBundle\Provider\DailyMotionProvider;
+use Sonata\MediaBundle\Resizer\ResizerInterface;
 use Sonata\MediaBundle\Tests\Entity\Media;
 use Sonata\MediaBundle\Thumbnail\FormatThumbnail;
 
@@ -23,31 +33,31 @@ class DailyMotionProviderTest extends AbstractProviderTest
     public function getProvider(Browser $browser = null)
     {
         if (!$browser) {
-            $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
+            $browser = $this->getMockBuilder(Browser::class)->getMock();
         }
 
-        $resizer = $this->createMock('Sonata\MediaBundle\Resizer\ResizerInterface');
+        $resizer = $this->createMock(ResizerInterface::class);
         $resizer->expects($this->any())->method('resize')->will($this->returnValue(true));
         $resizer->expects($this->any())->method('getBox')->will($this->returnValue(new Box(100, 100)));
 
-        $adapter = $this->createMock('Gaufrette\Adapter');
+        $adapter = $this->createMock(Adapter::class);
 
-        $filesystem = $this->getMockBuilder('Gaufrette\Filesystem')
+        $filesystem = $this->getMockBuilder(Filesystem::class)
             ->setMethods(['get'])
             ->setConstructorArgs([$adapter])
             ->getMock();
-        $file = $this->getMockBuilder('Gaufrette\File')
+        $file = $this->getMockBuilder(File::class)
             ->setConstructorArgs(['foo', $filesystem])
             ->getMock();
         $filesystem->expects($this->any())->method('get')->will($this->returnValue($file));
 
-        $cdn = new \Sonata\MediaBundle\CDN\Server('/uploads/media');
+        $cdn = new Server('/uploads/media');
 
-        $generator = new \Sonata\MediaBundle\Generator\DefaultGenerator();
+        $generator = new DefaultGenerator();
 
         $thumbnail = new FormatThumbnail('jpg');
 
-        $metadata = $this->createMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
+        $metadata = $this->createMock(MetadataBuilderInterface::class);
 
         $provider = new DailyMotionProvider('file', $filesystem, $cdn, $generator, $thumbnail, $browser, $metadata);
         $provider->setResizer($resizer);
@@ -76,10 +86,10 @@ class DailyMotionProviderTest extends AbstractProviderTest
 
     public function testThumbnail()
     {
-        $response = $this->createMock('Buzz\Message\AbstractMessage');
+        $response = $this->createMock(AbstractMessage::class);
         $response->expects($this->once())->method('getContent')->will($this->returnValue('content'));
 
-        $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
+        $browser = $this->getMockBuilder(Browser::class)->getMock();
 
         $browser->expects($this->once())->method('get')->will($this->returnValue($response));
 
@@ -110,7 +120,7 @@ class DailyMotionProviderTest extends AbstractProviderTest
         $response = new Response();
         $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_dailymotion.txt'));
 
-        $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
+        $browser = $this->getMockBuilder(Browser::class)->getMock();
         $browser->expects($this->once())->method('get')->will($this->returnValue($response));
 
         $provider = $this->getProvider($browser);
@@ -133,7 +143,7 @@ class DailyMotionProviderTest extends AbstractProviderTest
         $response = new Response();
         $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_dailymotion.txt'));
 
-        $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
+        $browser = $this->getMockBuilder(Browser::class)->getMock();
         $browser->expects($this->once())->method('get')->will($this->returnValue($response));
 
         $provider = $this->getProvider($browser);
@@ -155,12 +165,12 @@ class DailyMotionProviderTest extends AbstractProviderTest
     {
         $provider = $this->getProvider();
 
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock(AdminInterface::class);
         $admin->expects($this->any())
             ->method('trans')
             ->will($this->returnValue('message'));
 
-        $formMapper = $this->getMockBuilder('Sonata\AdminBundle\Form\FormMapper')
+        $formMapper = $this->getMockBuilder(FormMapper::class)
             ->setMethods(['add', 'getAdmin'])
             ->disableOriginalConstructor()
             ->getMock();

--- a/tests/Provider/ImageProviderTest.php
+++ b/tests/Provider/ImageProviderTest.php
@@ -11,8 +11,18 @@
 
 namespace Sonata\MediaBundle\Tests\Provider;
 
+use Gaufrette\Adapter;
+use Gaufrette\File;
+use Gaufrette\Filesystem;
 use Imagine\Image\Box;
+use Imagine\Image\BoxInterface;
+use Imagine\Image\ImageInterface;
+use Imagine\Image\ImagineInterface;
+use Sonata\MediaBundle\CDN\Server;
+use Sonata\MediaBundle\Generator\DefaultGenerator;
+use Sonata\MediaBundle\Metadata\MetadataBuilderInterface;
 use Sonata\MediaBundle\Provider\ImageProvider;
+use Sonata\MediaBundle\Resizer\ResizerInterface;
 use Sonata\MediaBundle\Tests\Entity\Media;
 use Sonata\MediaBundle\Thumbnail\FormatThumbnail;
 
@@ -20,40 +30,40 @@ class ImageProviderTest extends AbstractProviderTest
 {
     public function getProvider($allowedExtensions = [], $allowedMimeTypes = [], $box = false)
     {
-        $resizer = $this->createMock('Sonata\MediaBundle\Resizer\ResizerInterface');
+        $resizer = $this->createMock(ResizerInterface::class);
         $resizer->expects($this->any())->method('resize')->will($this->returnValue(true));
         if ($box) {
             $resizer->expects($this->any())->method('getBox')->will($box);
         }
 
-        $adapter = $this->createMock('Gaufrette\Adapter');
+        $adapter = $this->createMock(Adapter::class);
 
-        $filesystem = $this->getMockBuilder('Gaufrette\Filesystem')
+        $filesystem = $this->getMockBuilder(Filesystem::class)
             ->setMethods(['get'])
             ->setConstructorArgs([$adapter])
             ->getMock();
-        $file = $this->getMockBuilder('Gaufrette\File')
+        $file = $this->getMockBuilder(File::class)
             ->setConstructorArgs(['foo', $filesystem])
             ->getMock();
         $filesystem->expects($this->any())->method('get')->will($this->returnValue($file));
 
-        $cdn = new \Sonata\MediaBundle\CDN\Server('/uploads/media');
+        $cdn = new Server('/uploads/media');
 
-        $generator = new \Sonata\MediaBundle\Generator\DefaultGenerator();
+        $generator = new DefaultGenerator();
 
         $thumbnail = new FormatThumbnail('jpg');
 
-        $size = $this->createMock('Imagine\Image\BoxInterface');
+        $size = $this->createMock(BoxInterface::class);
         $size->expects($this->any())->method('getWidth')->will($this->returnValue(100));
         $size->expects($this->any())->method('getHeight')->will($this->returnValue(100));
 
-        $image = $this->createMock('Imagine\Image\ImageInterface');
+        $image = $this->createMock(ImageInterface::class);
         $image->expects($this->any())->method('getSize')->will($this->returnValue($size));
 
-        $adapter = $this->createMock('Imagine\Image\ImagineInterface');
+        $adapter = $this->createMock(ImagineInterface::class);
         $adapter->expects($this->any())->method('open')->will($this->returnValue($image));
 
-        $metadata = $this->createMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
+        $metadata = $this->createMock(MetadataBuilderInterface::class);
 
         $provider = new ImageProvider('file', $filesystem, $cdn, $generator, $thumbnail, $allowedExtensions, $allowedMimeTypes, $adapter, $metadata);
         $provider->setResizer($resizer);

--- a/tests/Provider/PoolTest.php
+++ b/tests/Provider/PoolTest.php
@@ -11,8 +11,13 @@
 
 namespace Sonata\MediaBundle\Tests\Provider;
 
+use Gaufrette\Filesystem;
 use PHPUnit\Framework\TestCase;
+use Sonata\MediaBundle\CDN\Server;
+use Sonata\MediaBundle\Generator\DefaultGenerator;
+use Sonata\MediaBundle\Metadata\MetadataBuilderInterface;
 use Sonata\MediaBundle\Provider\FileProvider;
+use Sonata\MediaBundle\Provider\Pool;
 use Sonata\MediaBundle\Thumbnail\FormatThumbnail;
 
 /**
@@ -26,7 +31,7 @@ class PoolTest extends TestCase
         $this->expectExceptionMessage('Provider name cannot be empty, did you forget to call setProviderName() in your Media object?');
 
         $mediaPool = $this
-            ->getMockBuilder('Sonata\MediaBundle\Provider\Pool')
+            ->getMockBuilder(Pool::class)
             ->disableOriginalConstructor()
             ->setMethods(null)
             ->getMock()
@@ -41,7 +46,7 @@ class PoolTest extends TestCase
         $this->expectExceptionMessage('Unable to retrieve provider named "provider_a" since there are no providers configured yet.');
 
         $mediaPool = $this
-            ->getMockBuilder('Sonata\MediaBundle\Provider\Pool')
+            ->getMockBuilder(Pool::class)
             ->disableOriginalConstructor()
             ->setMethods(null)
             ->getMock()
@@ -56,7 +61,7 @@ class PoolTest extends TestCase
         $this->expectExceptionMessage('Unable to retrieve the provider named "provider_c". Available providers are "provider_a", "provider_b".');
 
         $mediaPool = $this
-            ->getMockBuilder('Sonata\MediaBundle\Provider\Pool')
+            ->getMockBuilder(Pool::class)
             ->disableOriginalConstructor()
             ->setMethods(null)
             ->getMock()
@@ -75,11 +80,11 @@ class PoolTest extends TestCase
      */
     protected function createProvider($name)
     {
-        $filesystem = $this->getMockBuilder('Gaufrette\Filesystem')->disableOriginalConstructor()->getMock();
-        $cdn = new \Sonata\MediaBundle\CDN\Server('/uploads/media');
-        $generator = new \Sonata\MediaBundle\Generator\DefaultGenerator();
+        $filesystem = $this->getMockBuilder(Filesystem::class)->disableOriginalConstructor()->getMock();
+        $cdn = new Server('/uploads/media');
+        $generator = new DefaultGenerator();
         $thumbnail = new FormatThumbnail('jpg');
-        $metadata = $this->createMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
+        $metadata = $this->createMock(MetadataBuilderInterface::class);
 
         return new FileProvider($name, $filesystem, $cdn, $generator, $thumbnail, [], [], $metadata);
     }

--- a/tests/Provider/VimeoProviderTest.php
+++ b/tests/Provider/VimeoProviderTest.php
@@ -12,9 +12,19 @@
 namespace Sonata\MediaBundle\Tests\Provider;
 
 use Buzz\Browser;
+use Buzz\Message\AbstractMessage;
 use Buzz\Message\Response;
+use Gaufrette\Adapter;
+use Gaufrette\File;
+use Gaufrette\Filesystem;
 use Imagine\Image\Box;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\MediaBundle\CDN\Server;
+use Sonata\MediaBundle\Generator\DefaultGenerator;
+use Sonata\MediaBundle\Metadata\MetadataBuilderInterface;
 use Sonata\MediaBundle\Provider\VimeoProvider;
+use Sonata\MediaBundle\Resizer\ResizerInterface;
 use Sonata\MediaBundle\Tests\Entity\Media;
 use Sonata\MediaBundle\Thumbnail\FormatThumbnail;
 
@@ -23,31 +33,31 @@ class VimeoProviderTest extends AbstractProviderTest
     public function getProvider(Browser $browser = null)
     {
         if (!$browser) {
-            $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
+            $browser = $this->getMockBuilder(Browser::class)->getMock();
         }
 
-        $resizer = $this->createMock('Sonata\MediaBundle\Resizer\ResizerInterface');
+        $resizer = $this->createMock(ResizerInterface::class);
         $resizer->expects($this->any())->method('resize')->will($this->returnValue(true));
         $resizer->expects($this->any())->method('getBox')->will($this->returnValue(new Box(100, 100)));
 
-        $adapter = $this->createMock('Gaufrette\Adapter');
+        $adapter = $this->createMock(Adapter::class);
 
-        $filesystem = $this->getMockBuilder('Gaufrette\Filesystem')
+        $filesystem = $this->getMockBuilder(Filesystem::class)
             ->setMethods(['get'])
             ->setConstructorArgs([$adapter])
             ->getMock();
-        $file = $this->getMockBuilder('Gaufrette\File')
+        $file = $this->getMockBuilder(File::class)
             ->setConstructorArgs(['foo', $filesystem])
             ->getMock();
         $filesystem->expects($this->any())->method('get')->will($this->returnValue($file));
 
-        $cdn = new \Sonata\MediaBundle\CDN\Server('/uploads/media');
+        $cdn = new Server('/uploads/media');
 
-        $generator = new \Sonata\MediaBundle\Generator\DefaultGenerator();
+        $generator = new DefaultGenerator();
 
         $thumbnail = new FormatThumbnail('jpg');
 
-        $metadata = $this->createMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
+        $metadata = $this->createMock(MetadataBuilderInterface::class);
 
         $provider = new VimeoProvider('file', $filesystem, $cdn, $generator, $thumbnail, $browser, $metadata);
         $provider->setResizer($resizer);
@@ -75,10 +85,10 @@ class VimeoProviderTest extends AbstractProviderTest
 
     public function testThumbnail()
     {
-        $response = $this->createMock('Buzz\Message\AbstractMessage');
+        $response = $this->createMock(AbstractMessage::class);
         $response->expects($this->once())->method('getContent')->will($this->returnValue('content'));
 
-        $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
+        $browser = $this->getMockBuilder(Browser::class)->getMock();
 
         $browser->expects($this->once())->method('get')->will($this->returnValue($response));
 
@@ -109,7 +119,7 @@ class VimeoProviderTest extends AbstractProviderTest
         $response = new Response();
         $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_vimeo.txt'));
 
-        $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
+        $browser = $this->getMockBuilder(Browser::class)->getMock();
         $browser->expects($this->once())->method('get')->will($this->returnValue($response));
 
         $provider = $this->getProvider($browser);
@@ -136,7 +146,7 @@ class VimeoProviderTest extends AbstractProviderTest
         $response = new Response();
         $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_vimeo.txt'));
 
-        $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
+        $browser = $this->getMockBuilder(Browser::class)->getMock();
         $browser->expects($this->once())->method('get')->will($this->returnValue($response));
 
         $provider = $this->getProvider($browser);
@@ -171,12 +181,12 @@ class VimeoProviderTest extends AbstractProviderTest
     {
         $provider = $this->getProvider();
 
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock(AdminInterface::class);
         $admin->expects($this->any())
             ->method('trans')
             ->will($this->returnValue('message'));
 
-        $formMapper = $this->getMockBuilder('Sonata\AdminBundle\Form\FormMapper')
+        $formMapper = $this->getMockBuilder(FormMapper::class)
             ->setMethods(['add', 'getAdmin'])
             ->disableOriginalConstructor()
             ->getMock();

--- a/tests/Provider/YouTubeProviderTest.php
+++ b/tests/Provider/YouTubeProviderTest.php
@@ -12,9 +12,19 @@
 namespace Sonata\MediaBundle\Tests\Provider;
 
 use Buzz\Browser;
+use Buzz\Message\AbstractMessage;
 use Buzz\Message\Response;
+use Gaufrette\Adapter;
+use Gaufrette\File;
+use Gaufrette\Filesystem;
 use Imagine\Image\Box;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\MediaBundle\CDN\Server;
+use Sonata\MediaBundle\Generator\DefaultGenerator;
+use Sonata\MediaBundle\Metadata\MetadataBuilderInterface;
 use Sonata\MediaBundle\Provider\YouTubeProvider;
+use Sonata\MediaBundle\Resizer\ResizerInterface;
 use Sonata\MediaBundle\Tests\Entity\Media;
 use Sonata\MediaBundle\Thumbnail\FormatThumbnail;
 
@@ -23,31 +33,31 @@ class YouTubeProviderTest extends AbstractProviderTest
     public function getProvider(Browser $browser = null)
     {
         if (!$browser) {
-            $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
+            $browser = $this->getMockBuilder(Browser::class)->getMock();
         }
 
-        $resizer = $this->createMock('Sonata\MediaBundle\Resizer\ResizerInterface');
+        $resizer = $this->createMock(ResizerInterface::class);
         $resizer->expects($this->any())->method('resize')->will($this->returnValue(true));
         $resizer->expects($this->any())->method('getBox')->will($this->returnValue(new Box(100, 100)));
 
-        $adapter = $this->createMock('Gaufrette\Adapter');
+        $adapter = $this->createMock(Adapter::class);
 
-        $filesystem = $this->getMockBuilder('Gaufrette\Filesystem')
+        $filesystem = $this->getMockBuilder(Filesystem::class)
             ->setMethods(['get'])
             ->setConstructorArgs([$adapter])
             ->getMock();
-        $file = $this->getMockBuilder('Gaufrette\File')
+        $file = $this->getMockBuilder(File::class)
             ->setConstructorArgs(['foo', $filesystem])
             ->getMock();
         $filesystem->expects($this->any())->method('get')->will($this->returnValue($file));
 
-        $cdn = new \Sonata\MediaBundle\CDN\Server('/uploads/media');
+        $cdn = new Server('/uploads/media');
 
-        $generator = new \Sonata\MediaBundle\Generator\DefaultGenerator();
+        $generator = new DefaultGenerator();
 
         $thumbnail = new FormatThumbnail('jpg');
 
-        $metadata = $this->createMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
+        $metadata = $this->createMock(MetadataBuilderInterface::class);
 
         $provider = new YouTubeProvider('file', $filesystem, $cdn, $generator, $thumbnail, $browser, $metadata);
         $provider->setResizer($resizer);
@@ -76,10 +86,10 @@ class YouTubeProviderTest extends AbstractProviderTest
 
     public function testThumbnail()
     {
-        $response = $this->createMock('Buzz\Message\AbstractMessage');
+        $response = $this->createMock(AbstractMessage::class);
         $response->expects($this->once())->method('getContent')->will($this->returnValue('content'));
 
-        $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
+        $browser = $this->getMockBuilder(Browser::class)->getMock();
 
         $browser->expects($this->once())->method('get')->will($this->returnValue($response));
 
@@ -109,7 +119,7 @@ class YouTubeProviderTest extends AbstractProviderTest
         $response = new Response();
         $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_youtube.txt'));
 
-        $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
+        $browser = $this->getMockBuilder(Browser::class)->getMock();
         $browser->expects($this->once())->method('get')->will($this->returnValue($response));
 
         $provider = $this->getProvider($browser);
@@ -135,7 +145,7 @@ class YouTubeProviderTest extends AbstractProviderTest
         $response = new Response();
         $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_youtube.txt'));
 
-        $browser = $this->getMockBuilder('Buzz\Browser')->getMock();
+        $browser = $this->getMockBuilder(Browser::class)->getMock();
         $browser->expects($this->once())->method('get')->will($this->returnValue($response));
 
         $provider = $this->getProvider($browser);
@@ -174,12 +184,12 @@ class YouTubeProviderTest extends AbstractProviderTest
     {
         $provider = $this->getProvider();
 
-        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock(AdminInterface::class);
         $admin->expects($this->any())
             ->method('trans')
             ->will($this->returnValue('message'));
 
-        $formMapper = $this->getMockBuilder('Sonata\AdminBundle\Form\FormMapper')
+        $formMapper = $this->getMockBuilder(FormMapper::class)
             ->setMethods(['add', 'getAdmin'])
             ->disableOriginalConstructor()
             ->getMock();

--- a/tests/Resizer/SimpleResizerTest.php
+++ b/tests/Resizer/SimpleResizerTest.php
@@ -15,7 +15,11 @@ use Gaufrette\Adapter\InMemory;
 use Gaufrette\File;
 use Gaufrette\Filesystem;
 use Imagine\Image\Box;
+use Imagine\Image\ImageInterface;
+use Imagine\Image\ImagineInterface;
 use PHPUnit\Framework\TestCase;
+use Sonata\MediaBundle\Metadata\MetadataBuilderInterface;
+use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Resizer\SimpleResizer;
 
 class SimpleResizerTest extends TestCase
@@ -24,10 +28,10 @@ class SimpleResizerTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $adapter = $this->createMock('Imagine\Image\ImagineInterface');
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
-        $metadata = $this->createMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
-        $file = $this->getMockBuilder('Gaufrette\File')->disableOriginalConstructor()->getMock();
+        $adapter = $this->createMock(ImagineInterface::class);
+        $media = $this->createMock(MediaInterface::class);
+        $metadata = $this->createMock(MetadataBuilderInterface::class);
+        $file = $this->getMockBuilder(File::class)->disableOriginalConstructor()->getMock();
 
         $resizer = new SimpleResizer($adapter, 'foo', $metadata);
         $resizer->resize($media, $file, $file, 'bar', []);
@@ -35,14 +39,14 @@ class SimpleResizerTest extends TestCase
 
     public function testResize()
     {
-        $image = $this->createMock('Imagine\Image\ImageInterface');
+        $image = $this->createMock(ImageInterface::class);
         $image->expects($this->once())->method('thumbnail')->will($this->returnValue($image));
         $image->expects($this->once())->method('get')->will($this->returnValue(file_get_contents(__DIR__.'/../fixtures/logo.png')));
 
-        $adapter = $this->createMock('Imagine\Image\ImagineInterface');
+        $adapter = $this->createMock(ImagineInterface::class);
         $adapter->expects($this->any())->method('load')->will($this->returnValue($image));
 
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
         $media->expects($this->exactly(2))->method('getBox')->will($this->returnValue(new Box(535, 132)));
 
         $filesystem = new Filesystem(new InMemory());
@@ -51,7 +55,7 @@ class SimpleResizerTest extends TestCase
 
         $out = $filesystem->get('out', true);
 
-        $metadata = $this->createMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
+        $metadata = $this->createMock(MetadataBuilderInterface::class);
         $metadata->expects($this->once())->method('get')->will($this->returnValue([]));
 
         $resizer = new SimpleResizer($adapter, 'outbound', $metadata);
@@ -63,18 +67,18 @@ class SimpleResizerTest extends TestCase
      */
     public function testGetBox($mode, $settings, Box $mediaSize, Box $result)
     {
-        $adapter = $this->createMock('Imagine\Image\ImagineInterface');
+        $adapter = $this->createMock(ImagineInterface::class);
 
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
         $media->expects($this->exactly(2))->method('getBox')->will($this->returnValue($mediaSize));
 
-        $metadata = $this->createMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
+        $metadata = $this->createMock(MetadataBuilderInterface::class);
 
         $resizer = new SimpleResizer($adapter, $mode, $metadata);
 
         $box = $resizer->getBox($media, $settings);
 
-        $this->assertInstanceOf('Imagine\Image\Box', $box);
+        $this->assertInstanceOf(Box::class, $box);
 
         $this->assertSame($result->getWidth(), $box->getWidth());
         $this->assertSame($result->getHeight(), $box->getHeight());

--- a/tests/Resizer/SquareResizerTest.php
+++ b/tests/Resizer/SquareResizerTest.php
@@ -13,7 +13,10 @@ namespace Sonata\MediaBundle\Tests\Resizer;
 
 use Gaufrette\File;
 use Imagine\Image\Box;
+use Imagine\Image\ImagineInterface;
 use PHPUnit\Framework\TestCase;
+use Sonata\MediaBundle\Metadata\MetadataBuilderInterface;
+use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Resizer\SquareResizer;
 
 class SquareResizerTest extends TestCase
@@ -22,10 +25,10 @@ class SquareResizerTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $adapter = $this->createMock('Imagine\Image\ImagineInterface');
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
-        $file = $this->getMockBuilder('Gaufrette\File')->disableOriginalConstructor()->getMock();
-        $metadata = $this->createMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
+        $adapter = $this->createMock(ImagineInterface::class);
+        $media = $this->createMock(MediaInterface::class);
+        $file = $this->getMockBuilder(File::class)->disableOriginalConstructor()->getMock();
+        $metadata = $this->createMock(MetadataBuilderInterface::class);
 
         $resizer = new SquareResizer($adapter, 'foo', $metadata);
         $resizer->resize($media, $file, $file, 'bar', []);
@@ -36,18 +39,18 @@ class SquareResizerTest extends TestCase
      */
     public function testGetBox($settings, Box $mediaSize, Box $expected)
     {
-        $adapter = $this->createMock('Imagine\Image\ImagineInterface');
+        $adapter = $this->createMock(ImagineInterface::class);
 
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
         $media->expects($this->once())->method('getBox')->will($this->returnValue($mediaSize));
 
-        $metadata = $this->createMock('Sonata\MediaBundle\Metadata\MetadataBuilderInterface');
+        $metadata = $this->createMock(MetadataBuilderInterface::class);
 
         $resizer = new SquareResizer($adapter, 'foo', $metadata);
 
         $box = $resizer->getBox($media, $settings);
 
-        $this->assertInstanceOf('Imagine\Image\Box', $box);
+        $this->assertInstanceOf(Box::class, $box);
 
         $this->assertSame($expected->getWidth(), $box->getWidth());
         $this->assertSame($expected->getHeight(), $box->getHeight());

--- a/tests/Security/ForbiddenDownloadStrategyTest.php
+++ b/tests/Security/ForbiddenDownloadStrategyTest.php
@@ -12,15 +12,18 @@
 namespace Sonata\MediaBundle\Tests\Security;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Security\ForbiddenDownloadStrategy;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class ForbiddenDownloadStrategyTest extends TestCase
 {
     public function testIsGranted()
     {
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
-        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
-        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $media = $this->createMock(MediaInterface::class);
+        $request = $this->createMock(Request::class);
+        $translator = $this->createMock(TranslatorInterface::class);
 
         $strategy = new ForbiddenDownloadStrategy($translator);
         $this->assertFalse($strategy->isGranted($media, $request));

--- a/tests/Security/PublicDownloadStrategyTest.php
+++ b/tests/Security/PublicDownloadStrategyTest.php
@@ -12,15 +12,18 @@
 namespace Sonata\MediaBundle\Tests\Security;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Security\PublicDownloadStrategy;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class PublicDownloadStrategyTest extends TestCase
 {
     public function testIsGranted()
     {
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
-        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
-        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $media = $this->createMock(MediaInterface::class);
+        $request = $this->createMock(Request::class);
+        $translator = $this->createMock(TranslatorInterface::class);
 
         $strategy = new PublicDownloadStrategy($translator);
         $this->assertTrue($strategy->isGranted($media, $request));

--- a/tests/Security/RolesDownloadStrategyTest.php
+++ b/tests/Security/RolesDownloadStrategyTest.php
@@ -12,16 +12,19 @@
 namespace Sonata\MediaBundle\Tests\Security;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Security\RolesDownloadStrategy;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class RolesDownloadStrategyTest extends TestCase
 {
     public function testIsGrantedTrue()
     {
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
-        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
-        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $media = $this->createMock(MediaInterface::class);
+        $request = $this->createMock(Request::class);
+        $translator = $this->createMock(TranslatorInterface::class);
         $security = $this->createMock(AuthorizationCheckerInterface::class);
 
         $security->expects($this->any())
@@ -36,9 +39,9 @@ class RolesDownloadStrategyTest extends TestCase
 
     public function testIsGrantedFalse()
     {
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
-        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
-        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $media = $this->createMock(MediaInterface::class);
+        $request = $this->createMock(Request::class);
+        $translator = $this->createMock(TranslatorInterface::class);
         $security = $this->createMock(AuthorizationCheckerInterface::class);
 
         $security->expects($this->any())

--- a/tests/Security/SessionDownloadStrategyTest.php
+++ b/tests/Security/SessionDownloadStrategyTest.php
@@ -12,7 +12,12 @@
 namespace Sonata\MediaBundle\Tests\Security;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Security\SessionDownloadStrategy;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * @author Ahmet Akbana <ahmetakbana@gmail.com>
@@ -21,10 +26,10 @@ final class SessionDownloadStrategyTest extends TestCase
 {
     public function testIsGrantedFalseWithGreaterSessionTime()
     {
-        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
-        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
-        $session = $this->createMock('Symfony\Component\HttpFoundation\Session\Session');
+        $translator = $this->createMock(TranslatorInterface::class);
+        $media = $this->createMock(MediaInterface::class);
+        $request = $this->createMock(Request::class);
+        $session = $this->createMock(Session::class);
 
         $session->expects($this->any())
             ->method('get')
@@ -36,10 +41,10 @@ final class SessionDownloadStrategyTest extends TestCase
 
     public function testIsGrantedTrue()
     {
-        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
-        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
-        $session = $this->createMock('Symfony\Component\HttpFoundation\Session\Session');
+        $translator = $this->createMock(TranslatorInterface::class);
+        $media = $this->createMock(MediaInterface::class);
+        $request = $this->createMock(Request::class);
+        $session = $this->createMock(Session::class);
 
         $session->expects($this->any())
             ->method('get')
@@ -55,12 +60,12 @@ final class SessionDownloadStrategyTest extends TestCase
      */
     public function testIsGrantedTrueWithContainer()
     {
-        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock(ContainerInterface::class);
 
-        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
-        $request = $this->createMock('Symfony\Component\HttpFoundation\Request');
-        $session = $this->createMock('Symfony\Component\HttpFoundation\Session\Session');
+        $translator = $this->createMock(TranslatorInterface::class);
+        $media = $this->createMock(MediaInterface::class);
+        $request = $this->createMock(Request::class);
+        $session = $this->createMock(Session::class);
 
         $session->expects($this->any())
             ->method('get')
@@ -79,7 +84,7 @@ final class SessionDownloadStrategyTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $translator = $this->createMock(TranslatorInterface::class);
 
         new SessionDownloadStrategy($translator, 'foo', 1);
     }

--- a/tests/Thumbnail/ConsumerThumbnailTest.php
+++ b/tests/Thumbnail/ConsumerThumbnailTest.php
@@ -12,18 +12,23 @@
 namespace Sonata\MediaBundle\Tests\Thumbnail;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\MediaBundle\Thumbnail\ConsumerThumbnail;
+use Sonata\MediaBundle\Thumbnail\ThumbnailInterface;
+use Sonata\NotificationBundle\Backend\BackendInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ConsumerThumbnailTest extends TestCase
 {
     public function testGenerateDispatchesEvents()
     {
-        $thumbnail = $this->createMock('Sonata\MediaBundle\Thumbnail\ThumbnailInterface');
-        $backend = $this->createMock('Sonata\NotificationBundle\Backend\BackendInterface');
-        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $thumbnail = $this->createMock(ThumbnailInterface::class);
+        $backend = $this->createMock(BackendInterface::class);
+        $provider = $this->createMock(MediaProviderInterface::class);
+        $media = $this->createMock(MediaInterface::class);
 
-        $dispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
         $dispatcher->expects($this->at(0))
             ->method('addListener')
             ->with($this->equalTo('kernel.finish_request'), $this->anything());

--- a/tests/Thumbnail/FormatThumbnailTest.php
+++ b/tests/Thumbnail/FormatThumbnailTest.php
@@ -15,6 +15,9 @@ use Gaufrette\Adapter\InMemory;
 use Gaufrette\File;
 use Gaufrette\Filesystem;
 use PHPUnit\Framework\TestCase;
+use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Provider\MediaProviderInterface;
+use Sonata\MediaBundle\Resizer\ResizerInterface;
 use Sonata\MediaBundle\Thumbnail\FormatThumbnail;
 
 class FormatThumbnailTest extends TestCase
@@ -32,10 +35,10 @@ class FormatThumbnailTest extends TestCase
            'anothercontext_large' => ['height' => 500, 'width' => 500, 'quality' => 100],
         ];
 
-        $resizer = $this->createMock('Sonata\MediaBundle\Resizer\ResizerInterface');
+        $resizer = $this->createMock(ResizerInterface::class);
         $resizer->expects($this->exactly(2))->method('resize')->will($this->returnValue(true));
 
-        $provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+        $provider = $this->createMock(MediaProviderInterface::class);
         $provider->expects($this->once())->method('requireThumbnails')->will($this->returnValue(true));
         $provider->expects($this->once())->method('getReferenceFile')->will($this->returnValue($referenceFile));
         $provider->expects($this->once())->method('getFormats')->will($this->returnValue($formats));
@@ -43,7 +46,7 @@ class FormatThumbnailTest extends TestCase
         $provider->expects($this->exactly(2))->method('generatePrivateUrl')->will($this->returnValue('/my/private/path'));
         $provider->expects($this->exactly(2))->method('getFilesystem')->will($this->returnValue($filesystem));
 
-        $media = $this->createMock('Sonata\MediaBundle\Model\MediaInterface');
+        $media = $this->createMock(MediaInterface::class);
         $media->expects($this->exactly(6))->method('getContext')->will($this->returnValue('mycontext'));
         $media->expects($this->exactly(2))->method('getExtension')->will($this->returnValue('png'));
 

--- a/tests/Twig/Extension/MediaExtensionTest.php
+++ b/tests/Twig/Extension/MediaExtensionTest.php
@@ -10,7 +10,11 @@
  */
 
 use PHPUnit\Framework\TestCase;
+use Sonata\CoreBundle\Model\ManagerInterface;
+use Sonata\MediaBundle\Model\Media;
 use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Provider\MediaProviderInterface;
+use Sonata\MediaBundle\Provider\Pool;
 use Sonata\MediaBundle\Twig\Extension\MediaExtension;
 
 /**
@@ -75,7 +79,7 @@ class MediaExtensionTest extends TestCase
 
     public function getMediaService()
     {
-        $mediaService = $this->getMockBuilder('Sonata\MediaBundle\Provider\Pool')
+        $mediaService = $this->getMockBuilder(Pool::class)
             ->disableOriginalConstructor()
             ->getMock();
         $mediaService->method('getProvider')->willReturn($this->getProvider());
@@ -85,13 +89,13 @@ class MediaExtensionTest extends TestCase
 
     public function getMediaManager()
     {
-        return $this->createMock('Sonata\CoreBundle\Model\ManagerInterface');
+        return $this->createMock(ManagerInterface::class);
     }
 
     public function getProvider()
     {
         if (null === $this->provider) {
-            $this->provider = $this->createMock('Sonata\MediaBundle\Provider\MediaProviderInterface');
+            $this->provider = $this->createMock(MediaProviderInterface::class);
             $this->provider->method('getFormatName')->will($this->returnArgument(1));
         }
 
@@ -125,7 +129,7 @@ class MediaExtensionTest extends TestCase
     public function getMedia()
     {
         if (null === $this->media) {
-            $this->media = $this->createMock('Sonata\MediaBundle\Model\Media');
+            $this->media = $this->createMock(Media::class);
             $this->media->method('getProviderStatus')->willReturn(MediaInterface::STATUS_OK);
         }
 

--- a/tests/Validator/FormatValidatorTest.php
+++ b/tests/Validator/FormatValidatorTest.php
@@ -12,6 +12,7 @@
 namespace Sonata\MediaBundle\Tests\Validator;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\MediaBundle\Model\GalleryInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Sonata\MediaBundle\Validator\Constraints\ValidMediaFormat;
 use Sonata\MediaBundle\Validator\FormatValidator;
@@ -24,7 +25,7 @@ class FormatValidatorTest extends TestCase
         $pool = new Pool('defaultContext');
         $pool->addContext('test', [], ['format1' => []]);
 
-        $gallery = $this->createMock('Sonata\MediaBundle\Model\GalleryInterface');
+        $gallery = $this->createMock(GalleryInterface::class);
         $gallery->expects($this->once())->method('getDefaultFormat')->will($this->returnValue('format1'));
         $gallery->expects($this->once())->method('getContext')->will($this->returnValue('test'));
 
@@ -42,7 +43,7 @@ class FormatValidatorTest extends TestCase
         $pool = new Pool('defaultContext');
         $pool->addContext('test', [], ['format1' => []]);
 
-        $gallery = $this->createMock('Sonata\MediaBundle\Model\GalleryInterface');
+        $gallery = $this->createMock(GalleryInterface::class);
         $gallery->expects($this->once())->method('getDefaultFormat')->will($this->returnValue('non_existing_format'));
         $gallery->expects($this->once())->method('getContext')->will($this->returnValue('test'));
 
@@ -60,7 +61,7 @@ class FormatValidatorTest extends TestCase
         $pool = new Pool('defaultContext');
         $pool->addContext('test');
 
-        $gallery = $this->createMock('Sonata\MediaBundle\Model\GalleryInterface');
+        $gallery = $this->createMock(GalleryInterface::class);
         $gallery->expects($this->once())->method('getDefaultFormat')->will($this->returnValue('format_that_is_not_reference'));
         $gallery->expects($this->once())->method('getContext')->will($this->returnValue('test'));
 


### PR DESCRIPTION
I am targeting this branch, because it's BC.

## Changelog

```markdown
### Fixed
 - Replaced FQCN strings with `::class` constants
```