### PR TITLE
Use createMock in test files where it's possible

### DIFF
--- a/tests/Block/GalleryListBlockServiceTest.php
+++ b/tests/Block/GalleryListBlockServiceTest.php
@@ -36,13 +36,13 @@ class GalleryListBlockServiceTest extends AbstractBlockServiceTestCase
     {
         parent::setUp();
 
-        $this->galleryManager = $this->getMockBuilder(GalleryManagerInterface::class)->getMock();
-        $this->pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
+        $this->galleryManager = $this->createMock(GalleryManagerInterface::class);
+        $this->pool = $this->createMock(Pool::class);
     }
 
     public function testExecute()
     {
-        $pager = $this->getMockBuilder(PagerInterface::class)->getMock();
+        $pager = $this->createMock(PagerInterface::class);
         $this->galleryManager->expects($this->once())->method('getPager')->will($this->returnValue($pager));
 
         $block = new Block();

--- a/tests/Command/CleanMediaCommandTest.php
+++ b/tests/Command/CleanMediaCommandTest.php
@@ -71,7 +71,7 @@ class CleanMediaCommandTest extends FilesystemTestCase
     {
         parent::setUp();
 
-        $this->container = $this->getMockBuilder(ContainerInterface::class)->getMock();
+        $this->container = $this->createMock(ContainerInterface::class);
 
         $this->command = new CleanMediaCommand();
         $this->command->setContainer($this->container);
@@ -81,11 +81,11 @@ class CleanMediaCommandTest extends FilesystemTestCase
 
         $this->tester = new CommandTester($this->application->find('sonata:media:clean-uploads'));
 
-        $this->pool = $pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
+        $this->pool = $pool = $this->createMock(Pool::class);
 
-        $this->mediaManager = $mediaManager = $this->getMockBuilder(MediaManagerInterface::class)->getMock();
+        $this->mediaManager = $mediaManager = $this->createMock(MediaManagerInterface::class);
 
-        $this->fileSystemLocal = $fileSystemLocal = $this->getMockBuilder(Local::class)->disableOriginalConstructor()->getMock();
+        $this->fileSystemLocal = $fileSystemLocal = $this->createMock(Local::class);
         $this->fileSystemLocal->expects($this->once())->method('getDirectory')->will($this->returnValue($this->workspace));
 
         $this->container->expects($this->any())
@@ -150,13 +150,13 @@ class CleanMediaCommandTest extends FilesystemTestCase
             'download' => [],
         ];
 
-        $provider = $this->getMockBuilder(FileProvider::class)->disableOriginalConstructor()->getMock();
+        $provider = $this->createMock(FileProvider::class);
         $provider->expects($this->any())->method('getName')->will($this->returnValue('fooprovider'));
 
         $this->pool->expects($this->any())->method('getContexts')->will($this->returnValue(['foo' => $context]));
         $this->pool->expects($this->any())->method('getProviders')->will($this->returnValue([$provider]));
 
-        $media = $this->getMockBuilder(MediaInterface::class)->getMock();
+        $media = $this->createMock(MediaInterface::class);
 
         $this->mediaManager->expects($this->once())->method('findOneBy')
             ->with($this->equalTo(['id' => 1, 'context' => 'foo']))
@@ -184,13 +184,13 @@ class CleanMediaCommandTest extends FilesystemTestCase
             'download' => [],
         ];
 
-        $provider = $this->getMockBuilder(FileProvider::class)->disableOriginalConstructor()->getMock();
+        $provider = $this->createMock(FileProvider::class);
         $provider->expects($this->any())->method('getName')->will($this->returnValue('fooprovider'));
 
         $this->pool->expects($this->any())->method('getContexts')->will($this->returnValue(['foo' => $context]));
         $this->pool->expects($this->any())->method('getProviders')->will($this->returnValue([$provider]));
 
-        $media = $this->getMockBuilder(MediaInterface::class)->getMock();
+        $media = $this->createMock(MediaInterface::class);
 
         $this->mediaManager->expects($this->once())->method('findOneBy')
             ->with($this->equalTo(['id' => 1, 'context' => 'foo']))
@@ -227,7 +227,7 @@ class CleanMediaCommandTest extends FilesystemTestCase
             'download' => [],
         ];
 
-        $provider = $this->getMockBuilder(FileProvider::class)->disableOriginalConstructor()->getMock();
+        $provider = $this->createMock(FileProvider::class);
         $provider->expects($this->any())->method('getName')->will($this->returnValue('fooprovider'));
 
         $this->pool->expects($this->any())->method('getContexts')->will($this->returnValue(['foo' => $context]));
@@ -265,7 +265,7 @@ class CleanMediaCommandTest extends FilesystemTestCase
             'download' => [],
         ];
 
-        $provider = $this->getMockBuilder(FileProvider::class)->disableOriginalConstructor()->getMock();
+        $provider = $this->createMock(FileProvider::class);
         $provider->expects($this->any())->method('getName')->will($this->returnValue('fooprovider'));
 
         $this->pool->expects($this->any())->method('getContexts')->will($this->returnValue(['foo' => $context]));

--- a/tests/Command/FixMediaContextCommandTest.php
+++ b/tests/Command/FixMediaContextCommandTest.php
@@ -64,7 +64,7 @@ class FixMediaContextCommandTest extends TestCase
      */
     protected function setUp()
     {
-        $this->container = $this->getMockBuilder(ContainerInterface::class)->getMock();
+        $this->container = $this->createMock(ContainerInterface::class);
 
         $this->command = new FixMediaContextCommand();
         $this->command->setContainer($this->container);
@@ -74,9 +74,9 @@ class FixMediaContextCommandTest extends TestCase
 
         $this->tester = new CommandTester($this->application->find('sonata:media:fix-media-context'));
 
-        $this->pool = $pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
+        $this->pool = $pool = $this->createMock(Pool::class);
 
-        $this->contextManger = $contextManger = $this->getMockBuilder(ContextManagerInterface::class)->getMock();
+        $this->contextManger = $contextManger = $this->createMock(ContextManagerInterface::class);
 
         $this->categoryManger = $categoryManger = $this->createMock(CategoryManagerInterface::class);
 
@@ -117,11 +117,11 @@ class FixMediaContextCommandTest extends TestCase
 
         $this->pool->expects($this->any())->method('getContexts')->will($this->returnValue(['foo' => $context]));
 
-        $contextModel = $this->getMockBuilder(ContextInterface::class)->getMock();
+        $contextModel = $this->createMock(ContextInterface::class);
 
         $this->contextManger->expects($this->once())->method('findOneBy')->with($this->equalTo(['id' => 'foo']))->will($this->returnValue($contextModel));
 
-        $category = $this->getMockBuilder(CategoryInterface::class)->getMock();
+        $category = $this->createMock(CategoryInterface::class);
 
         $this->categoryManger->expects($this->once())->method('getRootCategory')->with($this->equalTo($contextModel))->will($this->returnValue($category));
 
@@ -145,11 +145,11 @@ class FixMediaContextCommandTest extends TestCase
 
         $this->pool->expects($this->any())->method('getContexts')->will($this->returnValue(['foo' => $context]));
 
-        $contextModel = $this->getMockBuilder(ContextInterface::class)->getMock();
+        $contextModel = $this->createMock(ContextInterface::class);
 
         $this->contextManger->expects($this->once())->method('findOneBy')->with($this->equalTo(['id' => 'foo']))->will($this->returnValue($contextModel));
 
-        $category = $this->getMockBuilder(CategoryInterface::class)->getMock();
+        $category = $this->createMock(CategoryInterface::class);
 
         $this->categoryManger->expects($this->once())->method('getRootCategory')->with($this->equalTo($contextModel))->will($this->returnValue(null));
         $this->categoryManger->expects($this->once())->method('create')->will($this->returnValue($category));
@@ -175,13 +175,13 @@ class FixMediaContextCommandTest extends TestCase
 
         $this->pool->expects($this->any())->method('getContexts')->will($this->returnValue(['foo' => $context]));
 
-        $contextModel = $this->getMockBuilder(ContextInterface::class)->getMock();
+        $contextModel = $this->createMock(ContextInterface::class);
 
         $this->contextManger->expects($this->once())->method('findOneBy')->with($this->equalTo(['id' => 'foo']))->will($this->returnValue(null));
         $this->contextManger->expects($this->once())->method('create')->will($this->returnValue($contextModel));
         $this->contextManger->expects($this->once())->method('save')->with($this->equalTo($contextModel));
 
-        $category = $this->getMockBuilder(CategoryInterface::class)->getMock();
+        $category = $this->createMock(CategoryInterface::class);
 
         $this->categoryManger->expects($this->once())->method('getRootCategory')->with($this->equalTo($contextModel))->will($this->returnValue(null));
         $this->categoryManger->expects($this->once())->method('create')->will($this->returnValue($category));

--- a/tests/Controller/Api/GalleryControllerTest.php
+++ b/tests/Controller/Api/GalleryControllerTest.php
@@ -47,9 +47,7 @@ class GalleryControllerTest extends TestCase
 
         $gController = new GalleryController($gManager, $mediaManager, $formFactory, 'test');
 
-        $paramFetcher = $this->getMockBuilder(ParamFetcher::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $paramFetcher = $this->createMock(ParamFetcher::class);
         $paramFetcher->expects($this->exactly(3))->method('get');
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue([]));
 
@@ -145,7 +143,7 @@ class GalleryControllerTest extends TestCase
         $mediaManager = $this->createMock(MediaManagerInterface::class);
         $mediaManager->expects($this->once())->method('findOneBy')->will($this->returnValue($media));
 
-        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($galleryHasMedia));
@@ -203,7 +201,7 @@ class GalleryControllerTest extends TestCase
         $mediaManager = $this->createMock(MediaManagerInterface::class);
         $mediaManager->expects($this->once())->method('findOneBy')->will($this->returnValue($media));
 
-        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($galleryHasMedia));
@@ -235,7 +233,7 @@ class GalleryControllerTest extends TestCase
         $mediaManager = $this->createMock(MediaManagerInterface::class);
         $mediaManager->expects($this->once())->method('findOneBy')->will($this->returnValue($media));
 
-        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 

--- a/tests/Controller/Api/MediaControllerTest.php
+++ b/tests/Controller/Api/MediaControllerTest.php
@@ -39,9 +39,7 @@ class MediaControllerTest extends TestCase
 
         $mController = $this->createMediaController($mManager);
 
-        $paramFetcher = $this->getMockBuilder(ParamFetcher::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $paramFetcher = $this->createMock(ParamFetcher::class);
         $paramFetcher->expects($this->exactly(3))->method('get');
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue([]));
 
@@ -78,7 +76,7 @@ class MediaControllerTest extends TestCase
         $provider = $this->createMock(MediaProviderInterface::class);
         $provider->expects($this->exactly(2))->method('getHelperProperties')->will($this->returnValue(['foo' => 'bar']));
 
-        $pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
+        $pool = $this->createMock(Pool::class);
         $pool->expects($this->any())->method('getProvider')->will($this->returnValue($provider));
         $pool->expects($this->once())->method('getFormatNamesByContext')->will($this->returnValue(['format_name1' => 'value1']));
 
@@ -105,7 +103,7 @@ class MediaControllerTest extends TestCase
     {
         $media = $this->createMock(MediaInterface::class);
 
-        $binaryResponse = $this->getMockBuilder(BinaryFileResponse::class)->disableOriginalConstructor()->getMock();
+        $binaryResponse = $this->createMock(BinaryFileResponse::class);
 
         $manager = $this->createMock(MediaManagerInterface::class);
         $manager->expects($this->once())->method('findOneBy')->will($this->returnValue($media));
@@ -113,7 +111,7 @@ class MediaControllerTest extends TestCase
         $provider = $this->createMock(MediaProviderInterface::class);
         $provider->expects($this->once())->method('getDownloadResponse')->will($this->returnValue($binaryResponse));
 
-        $pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
+        $pool = $this->createMock(Pool::class);
         $pool->expects($this->once())->method('getProvider')->will($this->returnValue($provider));
 
         $controller = $this->createMediaController($manager, $pool);
@@ -144,10 +142,10 @@ class MediaControllerTest extends TestCase
         $provider = $this->createMock(MediaProviderInterface::class);
         $provider->expects($this->once())->method('getName');
 
-        $pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
+        $pool = $this->createMock(Pool::class);
         $pool->expects($this->once())->method('getProvider')->will($this->returnValue($provider));
 
-        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($medium));
@@ -170,10 +168,10 @@ class MediaControllerTest extends TestCase
         $provider = $this->createMock(MediaProviderInterface::class);
         $provider->expects($this->once())->method('getName');
 
-        $pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
+        $pool = $this->createMock(Pool::class);
         $pool->expects($this->once())->method('getProvider')->will($this->returnValue($provider));
 
-        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
@@ -196,10 +194,10 @@ class MediaControllerTest extends TestCase
         $provider = $this->createMock(MediaProviderInterface::class);
         $provider->expects($this->once())->method('getName');
 
-        $pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
+        $pool = $this->createMock(Pool::class);
         $pool->expects($this->once())->method('getProvider')->will($this->returnValue($provider));
 
-        $form = $this->getMockBuilder(Form::class)->disableOriginalConstructor()->getMock();
+        $form = $this->createMock(Form::class);
         $form->expects($this->once())->method('handleRequest');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($medium));
@@ -222,7 +220,7 @@ class MediaControllerTest extends TestCase
         $manager = $this->createMock(MediaManagerInterface::class);
         $manager->expects($this->once())->method('create')->will($this->returnValue($medium));
 
-        $pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
+        $pool = $this->createMock(Pool::class);
         $pool->expects($this->once())->method('getProvider')->will($this->throwException(new \RuntimeException('exception on getProvder')));
 
         $controller = $this->createMediaController($manager, $pool);
@@ -237,7 +235,7 @@ class MediaControllerTest extends TestCase
         $manager = $this->createMock(MediaManagerInterface::class);
         $manager->expects($this->once())->method('findOneBy')->will($this->returnValue($media));
 
-        $pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
+        $pool = $this->createMock(Pool::class);
 
         $controller = $this->createMediaController($manager, $pool);
 
@@ -250,7 +248,7 @@ class MediaControllerTest extends TestCase
             $manager = $this->createMock(MediaManagerInterface::class);
         }
         if (null === $pool) {
-            $pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
+            $pool = $this->createMock(Pool::class);
         }
         if (null === $factory) {
             $factory = $this->createMock(FormFactoryInterface::class);

--- a/tests/Form/DataTransformer/ProviderDataTransformerTest.php
+++ b/tests/Form/DataTransformer/ProviderDataTransformerTest.php
@@ -23,7 +23,7 @@ class ProviderDataTransformerTest extends TestCase
 {
     public function testReverseTransformFakeValue()
     {
-        $pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
+        $pool = $this->createMock(Pool::class);
 
         $transformer = new ProviderDataTransformer($pool, 'stdClass');
         $this->assertSame('foo', $transformer->reverseTransform('foo'));

--- a/tests/Form/Type/AbstractTypeTest.php
+++ b/tests/Form/Type/AbstractTypeTest.php
@@ -43,10 +43,10 @@ abstract class AbstractTypeTest extends TypeTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->mediaPool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
+        $this->mediaPool = $this->createMock(Pool::class);
         $this->mediaPool->expects($this->any())->method('getProvider')->willReturn($provider);
 
-        $this->formBuilder = $this->getMockBuilder(FormBuilder::class)->disableOriginalConstructor()->getMock();
+        $this->formBuilder = $this->createMock(FormBuilder::class);
         $this->formBuilder
             ->expects($this->any())
             ->method('add')

--- a/tests/Form/Type/ApiMediaTypeTest.php
+++ b/tests/Form/Type/ApiMediaTypeTest.php
@@ -24,14 +24,14 @@ class ApiMediaTypeTest extends AbstractTypeTest
     public function testBuildForm()
     {
         parent::testBuildForm();
-        $provider = $this->getMockBuilder(MediaProviderInterface::class)->getMock();
+        $provider = $this->createMock(MediaProviderInterface::class);
 
-        $mediaPool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
+        $mediaPool = $this->createMock(Pool::class);
         $mediaPool->expects($this->once())->method('getProvider')->will($this->returnValue($provider));
 
         $type = new ApiMediaType($mediaPool, 'testclass');
 
-        $builder = $this->getMockBuilder(FormBuilder::class)->disableOriginalConstructor()->getMock();
+        $builder = $this->createMock(FormBuilder::class);
         $builder->expects($this->once())->method('addModelTransformer');
 
         $type->buildForm($builder, ['provider_name' => 'sonata.media.provider.image']);

--- a/tests/Form/Type/MediaTypeTest.php
+++ b/tests/Form/Type/MediaTypeTest.php
@@ -34,7 +34,7 @@ class MediaTypeTest extends AbstractTypeTest
     {
         parent::setUp();
 
-        $this->mediaPool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
+        $this->mediaPool = $this->createMock(Pool::class);
         $this->mediaType = new MediaType($this->mediaPool, 'testClass');
 
         $this->factory = Forms::createFormFactoryBuilder()

--- a/tests/Metadata/ProxyMetadataBuilderTest.php
+++ b/tests/Metadata/ProxyMetadataBuilderTest.php
@@ -28,7 +28,7 @@ class ProxyMetadataBuilderTest extends TestCase
 {
     public function testProxyAmazon()
     {
-        $amazon = $this->getMockBuilder(AmazonMetadataBuilder::class)->disableOriginalConstructor()->getMock();
+        $amazon = $this->createMock(AmazonMetadataBuilder::class);
         $amazon->expects($this->once())
             ->method('get')
             ->will($this->returnValue(['key' => 'amazon']));
@@ -42,7 +42,7 @@ class ProxyMetadataBuilderTest extends TestCase
         $amazonclient = new AmazonClient(['key' => 'XXXXXXXXXXXX', 'secret' => 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX']);
         $adapter = new AmazonS3($amazonclient, '');
 
-        $filesystem = $this->getMockBuilder(Filesystem::class)->disableOriginalConstructor()->getMock();
+        $filesystem = $this->createMock(Filesystem::class);
         $filesystem->expects($this->any())->method('getAdapter')->will($this->returnValue($adapter));
 
         $provider = $this->createMock(MediaProviderInterface::class);
@@ -68,7 +68,7 @@ class ProxyMetadataBuilderTest extends TestCase
 
     public function testProxyLocal()
     {
-        $amazon = $this->getMockBuilder(AmazonMetadataBuilder::class)->disableOriginalConstructor()->getMock();
+        $amazon = $this->createMock(AmazonMetadataBuilder::class);
         $amazon->expects($this->never())
             ->method('get')
             ->will($this->returnValue(['key' => 'amazon']));
@@ -81,7 +81,7 @@ class ProxyMetadataBuilderTest extends TestCase
         //adapter cannot be mocked
         $adapter = new Local('');
 
-        $filesystem = $this->getMockBuilder(Filesystem::class)->disableOriginalConstructor()->getMock();
+        $filesystem = $this->createMock(Filesystem::class);
         $filesystem->expects($this->any())->method('getAdapter')->will($this->returnValue($adapter));
 
         $provider = $this->createMock(MediaProviderInterface::class);
@@ -107,7 +107,7 @@ class ProxyMetadataBuilderTest extends TestCase
 
     public function testProxyNoProvider()
     {
-        $amazon = $this->getMockBuilder(AmazonMetadataBuilder::class)->disableOriginalConstructor()->getMock();
+        $amazon = $this->createMock(AmazonMetadataBuilder::class);
         $amazon->expects($this->never())
             ->method('get')
             ->will($this->returnValue(['key' => 'amazon']));
@@ -120,7 +120,7 @@ class ProxyMetadataBuilderTest extends TestCase
         //adapter cannot be mocked
         $adapter = new Local('');
 
-        $filesystem = $this->getMockBuilder(Filesystem::class)->disableOriginalConstructor()->getMock();
+        $filesystem = $this->createMock(Filesystem::class);
         $filesystem->expects($this->any())->method('getAdapter')->will($this->returnValue($adapter));
 
         $provider = $this->createMock(MediaProviderInterface::class);
@@ -146,7 +146,7 @@ class ProxyMetadataBuilderTest extends TestCase
 
     public function testProxyReplicateWithAmazon()
     {
-        $amazon = $this->getMockBuilder(AmazonMetadataBuilder::class)->disableOriginalConstructor()->getMock();
+        $amazon = $this->createMock(AmazonMetadataBuilder::class);
         $amazon->expects($this->once())
             ->method('get')
             ->will($this->returnValue(['key' => 'amazon']));
@@ -162,7 +162,7 @@ class ProxyMetadataBuilderTest extends TestCase
         $adapter2 = new Local('');
         $adapter = new Replicate($adapter1, $adapter2);
 
-        $filesystem = $this->getMockBuilder(Filesystem::class)->disableOriginalConstructor()->getMock();
+        $filesystem = $this->createMock(Filesystem::class);
         $filesystem->expects($this->any())->method('getAdapter')->will($this->returnValue($adapter));
 
         $provider = $this->createMock(MediaProviderInterface::class);
@@ -188,7 +188,7 @@ class ProxyMetadataBuilderTest extends TestCase
 
     public function testProxyReplicateWithoutAmazon()
     {
-        $amazon = $this->getMockBuilder(AmazonMetadataBuilder::class)->disableOriginalConstructor()->getMock();
+        $amazon = $this->createMock(AmazonMetadataBuilder::class);
         $amazon->expects($this->never())
             ->method('get')
             ->will($this->returnValue(['key' => 'amazon']));
@@ -203,7 +203,7 @@ class ProxyMetadataBuilderTest extends TestCase
         $adapter2 = new Local('');
         $adapter = new Replicate($adapter1, $adapter2);
 
-        $filesystem = $this->getMockBuilder(Filesystem::class)->disableOriginalConstructor()->getMock();
+        $filesystem = $this->createMock(Filesystem::class);
         $filesystem->expects($this->any())->method('getAdapter')->will($this->returnValue($adapter));
 
         $provider = $this->createMock(MediaProviderInterface::class);

--- a/tests/Provider/AbstractProviderTest.php
+++ b/tests/Provider/AbstractProviderTest.php
@@ -44,7 +44,7 @@ abstract class AbstractProviderTest extends TestCase
 
     protected function setUp()
     {
-        $this->formMapper = $this->getMockBuilder(FormMapper::class)->disableOriginalConstructor()->getMock();
+        $this->formMapper = $this->createMock(FormMapper::class);
         $this->formMapper
             ->expects($this->any())
             ->method('add')
@@ -54,7 +54,7 @@ abstract class AbstractProviderTest extends TestCase
                 }
             }));
 
-        $this->formBuilder = $this->getMockBuilder(FormBuilder::class)->disableOriginalConstructor()->getMock();
+        $this->formBuilder = $this->createMock(FormBuilder::class);
         $this->formBuilder
             ->expects($this->any())
             ->method('add')

--- a/tests/Provider/DailyMotionProviderTest.php
+++ b/tests/Provider/DailyMotionProviderTest.php
@@ -33,7 +33,7 @@ class DailyMotionProviderTest extends AbstractProviderTest
     public function getProvider(Browser $browser = null)
     {
         if (!$browser) {
-            $browser = $this->getMockBuilder(Browser::class)->getMock();
+            $browser = $this->createMock(Browser::class);
         }
 
         $resizer = $this->createMock(ResizerInterface::class);
@@ -89,7 +89,7 @@ class DailyMotionProviderTest extends AbstractProviderTest
         $response = $this->createMock(AbstractMessage::class);
         $response->expects($this->once())->method('getContent')->will($this->returnValue('content'));
 
-        $browser = $this->getMockBuilder(Browser::class)->getMock();
+        $browser = $this->createMock(Browser::class);
 
         $browser->expects($this->once())->method('get')->will($this->returnValue($response));
 
@@ -120,7 +120,7 @@ class DailyMotionProviderTest extends AbstractProviderTest
         $response = new Response();
         $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_dailymotion.txt'));
 
-        $browser = $this->getMockBuilder(Browser::class)->getMock();
+        $browser = $this->createMock(Browser::class);
         $browser->expects($this->once())->method('get')->will($this->returnValue($response));
 
         $provider = $this->getProvider($browser);
@@ -143,7 +143,7 @@ class DailyMotionProviderTest extends AbstractProviderTest
         $response = new Response();
         $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_dailymotion.txt'));
 
-        $browser = $this->getMockBuilder(Browser::class)->getMock();
+        $browser = $this->createMock(Browser::class);
         $browser->expects($this->once())->method('get')->will($this->returnValue($response));
 
         $provider = $this->getProvider($browser);

--- a/tests/Provider/FileProviderTest.php
+++ b/tests/Provider/FileProviderTest.php
@@ -37,7 +37,7 @@ class FileProviderTest extends AbstractProviderTest
         $resizer = $this->createMock(ResizerInterface::class);
         $resizer->expects($this->any())->method('resize')->will($this->returnValue(true));
 
-        $adapter = $this->getMockBuilder(Local::class)->disableOriginalConstructor()->getMock();
+        $adapter = $this->createMock(Local::class);
         $adapter->expects($this->any())->method('getDirectory')->will($this->returnValue(realpath(__DIR__).'/../fixtures'));
 
         $filesystem = $this->getMockBuilder(Filesystem::class)

--- a/tests/Provider/PoolTest.php
+++ b/tests/Provider/PoolTest.php
@@ -80,7 +80,7 @@ class PoolTest extends TestCase
      */
     protected function createProvider($name)
     {
-        $filesystem = $this->getMockBuilder(Filesystem::class)->disableOriginalConstructor()->getMock();
+        $filesystem = $this->createMock(Filesystem::class);
         $cdn = new Server('/uploads/media');
         $generator = new DefaultGenerator();
         $thumbnail = new FormatThumbnail('jpg');

--- a/tests/Provider/VimeoProviderTest.php
+++ b/tests/Provider/VimeoProviderTest.php
@@ -33,7 +33,7 @@ class VimeoProviderTest extends AbstractProviderTest
     public function getProvider(Browser $browser = null)
     {
         if (!$browser) {
-            $browser = $this->getMockBuilder(Browser::class)->getMock();
+            $browser = $this->createMock(Browser::class);
         }
 
         $resizer = $this->createMock(ResizerInterface::class);
@@ -88,7 +88,7 @@ class VimeoProviderTest extends AbstractProviderTest
         $response = $this->createMock(AbstractMessage::class);
         $response->expects($this->once())->method('getContent')->will($this->returnValue('content'));
 
-        $browser = $this->getMockBuilder(Browser::class)->getMock();
+        $browser = $this->createMock(Browser::class);
 
         $browser->expects($this->once())->method('get')->will($this->returnValue($response));
 
@@ -119,7 +119,7 @@ class VimeoProviderTest extends AbstractProviderTest
         $response = new Response();
         $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_vimeo.txt'));
 
-        $browser = $this->getMockBuilder(Browser::class)->getMock();
+        $browser = $this->createMock(Browser::class);
         $browser->expects($this->once())->method('get')->will($this->returnValue($response));
 
         $provider = $this->getProvider($browser);
@@ -146,7 +146,7 @@ class VimeoProviderTest extends AbstractProviderTest
         $response = new Response();
         $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_vimeo.txt'));
 
-        $browser = $this->getMockBuilder(Browser::class)->getMock();
+        $browser = $this->createMock(Browser::class);
         $browser->expects($this->once())->method('get')->will($this->returnValue($response));
 
         $provider = $this->getProvider($browser);

--- a/tests/Provider/YouTubeProviderTest.php
+++ b/tests/Provider/YouTubeProviderTest.php
@@ -33,7 +33,7 @@ class YouTubeProviderTest extends AbstractProviderTest
     public function getProvider(Browser $browser = null)
     {
         if (!$browser) {
-            $browser = $this->getMockBuilder(Browser::class)->getMock();
+            $browser = $this->createMock(Browser::class);
         }
 
         $resizer = $this->createMock(ResizerInterface::class);
@@ -89,7 +89,7 @@ class YouTubeProviderTest extends AbstractProviderTest
         $response = $this->createMock(AbstractMessage::class);
         $response->expects($this->once())->method('getContent')->will($this->returnValue('content'));
 
-        $browser = $this->getMockBuilder(Browser::class)->getMock();
+        $browser = $this->createMock(Browser::class);
 
         $browser->expects($this->once())->method('get')->will($this->returnValue($response));
 
@@ -119,7 +119,7 @@ class YouTubeProviderTest extends AbstractProviderTest
         $response = new Response();
         $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_youtube.txt'));
 
-        $browser = $this->getMockBuilder(Browser::class)->getMock();
+        $browser = $this->createMock(Browser::class);
         $browser->expects($this->once())->method('get')->will($this->returnValue($response));
 
         $provider = $this->getProvider($browser);
@@ -145,7 +145,7 @@ class YouTubeProviderTest extends AbstractProviderTest
         $response = new Response();
         $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_youtube.txt'));
 
-        $browser = $this->getMockBuilder(Browser::class)->getMock();
+        $browser = $this->createMock(Browser::class);
         $browser->expects($this->once())->method('get')->will($this->returnValue($response));
 
         $provider = $this->getProvider($browser);

--- a/tests/Resizer/SimpleResizerTest.php
+++ b/tests/Resizer/SimpleResizerTest.php
@@ -31,7 +31,7 @@ class SimpleResizerTest extends TestCase
         $adapter = $this->createMock(ImagineInterface::class);
         $media = $this->createMock(MediaInterface::class);
         $metadata = $this->createMock(MetadataBuilderInterface::class);
-        $file = $this->getMockBuilder(File::class)->disableOriginalConstructor()->getMock();
+        $file = $this->createMock(File::class);
 
         $resizer = new SimpleResizer($adapter, 'foo', $metadata);
         $resizer->resize($media, $file, $file, 'bar', []);

--- a/tests/Resizer/SquareResizerTest.php
+++ b/tests/Resizer/SquareResizerTest.php
@@ -27,7 +27,7 @@ class SquareResizerTest extends TestCase
 
         $adapter = $this->createMock(ImagineInterface::class);
         $media = $this->createMock(MediaInterface::class);
-        $file = $this->getMockBuilder(File::class)->disableOriginalConstructor()->getMock();
+        $file = $this->createMock(File::class);
         $metadata = $this->createMock(MetadataBuilderInterface::class);
 
         $resizer = new SquareResizer($adapter, 'foo', $metadata);


### PR DESCRIPTION
I am targeting this branch, because it's BC.

## Changelog
```markdown
### Fixed
- Replaced `getMockBuilder` with `createMock` where it was possible
```