### PR TITLE
fix category not saved on media admin creation

### DIFF
--- a/src/Admin/BaseMediaAdmin.php
+++ b/src/Admin/BaseMediaAdmin.php
@@ -186,8 +186,8 @@ abstract class BaseMediaAdmin extends AbstractAdmin
         $formMapper->add('providerName', HiddenType::class);
 
         $formMapper->getFormBuilder()->addModelTransformer(
-            new ProviderDataTransformer($this->pool, $this->getClass(), array(), $this->categoryManager),
-            true);
+           new ProviderDataTransformer($this->pool, $this->getClass(), array(), $this->categoryManager),
+           true);
 
         $provider = $this->pool->getProvider($media->getProviderName());
 

--- a/src/Admin/BaseMediaAdmin.php
+++ b/src/Admin/BaseMediaAdmin.php
@@ -87,7 +87,9 @@ abstract class BaseMediaAdmin extends AbstractAdmin
             $this->getRequest()->query->set('provider', $provider);
         }
 
-        $categoryId = $this->getRequest()->get('category');
+        $uniqueId = $this->getRequest()->get('uniqid');
+        $formParams =  $this->getRequest()->get($uniqueId);
+        $categoryId = $formParams && array_key_exists('category', $formParams) ? $formParams['category'] : $this->getRequest()->get('category');
 
         if (null !== $this->categoryManager && !$categoryId) {
             $categoryId = $this->categoryManager->getRootCategory($context)->getId();
@@ -183,7 +185,7 @@ abstract class BaseMediaAdmin extends AbstractAdmin
 
         $formMapper->add('providerName', HiddenType::class);
 
-        $formMapper->getFormBuilder()->addModelTransformer(new ProviderDataTransformer($this->pool, $this->getClass()), true);
+        $formMapper->getFormBuilder()->addModelTransformer(new ProviderDataTransformer($this->pool, $this->getClass(), array(), $this->categoryManager), true);
 
         $provider = $this->pool->getProvider($media->getProviderName());
 

--- a/src/Admin/BaseMediaAdmin.php
+++ b/src/Admin/BaseMediaAdmin.php
@@ -35,10 +35,10 @@ abstract class BaseMediaAdmin extends AbstractAdmin
     protected $categoryManager;
 
     /**
-     * @param string                   $code
-     * @param string                   $class
-     * @param string                   $baseControllerName
-     * @param Pool                     $pool
+     * @param string $code
+     * @param string $class
+     * @param string $baseControllerName
+     * @param Pool $pool
      * @param CategoryManagerInterface $categoryManager
      */
     public function __construct($code, $class, $baseControllerName, Pool $pool, CategoryManagerInterface $categoryManager = null)
@@ -88,8 +88,9 @@ abstract class BaseMediaAdmin extends AbstractAdmin
         }
 
         $uniqueId = $this->getRequest()->get('uniqid');
-        $formParams =  $this->getRequest()->get($uniqueId);
-        $categoryId = $formParams && array_key_exists('category', $formParams) ? $formParams['category'] : $this->getRequest()->get('category');
+        $formParams = $this->getRequest()->get($uniqueId);
+        $categoryId = $formParams && array_key_exists('category', $formParams) ?
+            $formParams['category'] : $this->getRequest()->get('category');
 
         if (null !== $this->categoryManager && !$categoryId) {
             $categoryId = $this->categoryManager->getRootCategory($context)->getId();
@@ -98,7 +99,7 @@ abstract class BaseMediaAdmin extends AbstractAdmin
         return array_merge($parameters, [
             'context' => $context,
             'category' => $categoryId,
-            'hide_context' => (bool) $this->getRequest()->get('hide_context'),
+            'hide_context' => (bool)$this->getRequest()->get('hide_context'),
         ]);
     }
 
@@ -164,8 +165,7 @@ abstract class BaseMediaAdmin extends AbstractAdmin
             ->addIdentifier('name')
             ->add('description')
             ->add('enabled')
-            ->add('size')
-        ;
+            ->add('size');
     }
 
     /**
@@ -185,7 +185,9 @@ abstract class BaseMediaAdmin extends AbstractAdmin
 
         $formMapper->add('providerName', HiddenType::class);
 
-        $formMapper->getFormBuilder()->addModelTransformer(new ProviderDataTransformer($this->pool, $this->getClass(), array(), $this->categoryManager), true);
+        $formMapper->getFormBuilder()->addModelTransformer(
+            new ProviderDataTransformer($this->pool, $this->getClass(), array(), $this->categoryManager),
+            true);
 
         $provider = $this->pool->getProvider($media->getProviderName());
 

--- a/src/Form/DataTransformer/ProviderDataTransformer.php
+++ b/src/Form/DataTransformer/ProviderDataTransformer.php
@@ -17,6 +17,7 @@ use Psr\Log\NullLogger;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Component\Form\DataTransformerInterface;
+use Sonata\MediaBundle\Model\CategoryManagerInterface;
 
 class ProviderDataTransformer implements DataTransformerInterface, LoggerAwareInterface
 {
@@ -33,11 +34,17 @@ class ProviderDataTransformer implements DataTransformerInterface, LoggerAwareIn
     protected $options;
 
     /**
-     * @param Pool   $pool
-     * @param string $class
-     * @param array  $options
+     * @var CategoryManagerInterface
      */
-    public function __construct(Pool $pool, $class, array $options = [])
+    protected $categoryManager;
+
+    /**
+     * @param Pool $pool
+     * @param string $class
+     * @param array $options
+     * @param CategoryManagerInterface|null $categoryManager
+     */
+    public function __construct(Pool $pool, $class, array $options = array(), CategoryManagerInterface $categoryManager = null)
     {
         $this->pool = $pool;
         $this->options = $this->getOptions($options);
@@ -97,6 +104,10 @@ class ProviderDataTransformer implements DataTransformerInterface, LoggerAwareIn
 
         if (!$newMedia->getContext() && $this->options['context']) {
             $newMedia->setContext($this->options['context']);
+        }
+
+        if (null !== $this->categoryManager) {
+            $newMedia->setCategory($media->getCategory());
         }
 
         $provider = $this->pool->getProvider($newMedia->getProviderName());

--- a/src/Form/DataTransformer/ProviderDataTransformer.php
+++ b/src/Form/DataTransformer/ProviderDataTransformer.php
@@ -36,13 +36,11 @@ class ProviderDataTransformer implements DataTransformerInterface, LoggerAwareIn
     /**
      * @var CategoryManagerInterface
      */
-    protected $categoryManager;
+    private $categoryManager;
 
     /**
      * @param Pool $pool
      * @param string $class
-     * @param array $options
-     * @param CategoryManagerInterface|null $categoryManager
      */
     public function __construct(Pool $pool, $class, array $options = array(), CategoryManagerInterface $categoryManager = null)
     {


### PR DESCRIPTION
I am targeting this branch, because it is a bug fix.

Closes #1287 

## Changelog

```markdown
### Changed
- Injected `CategoryManager` in `ProviderDataTransformer` to check whether to set the category in the transformed media.
```

## Subject

Category was not saved when persisting a new media from the Admin class.

