### PR TITLE
Decouple from Templating Component, Stage 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
     "conflict": {
         "friendsofsymfony/rest-bundle": "<1.7.4 || >=3.0",
         "jms/serializer": "<0.13",
-        "sonata-project/block-bundle": "<3.1.1 || >=4.0",
+        "sonata-project/block-bundle": "<3.11 || >=4.0",
         "sonata-project/classification-bundle": "<3.0 || >= 5.0",
         "sonata-project/formatter-bundle": "<3.2",
         "sonata-project/seo-bundle": "<2.1 || >=3.0",
@@ -70,7 +70,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^0.7 || ^1.0",
         "nelmio/api-doc-bundle": "^2.11",
         "sonata-project/admin-bundle": "^3.11",
-        "sonata-project/block-bundle": "^3.2",
+        "sonata-project/block-bundle": "^3.11",
         "sonata-project/datagrid-bundle": "^2.2.1",
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
         "sonata-project/formatter-bundle": "^3.2",

--- a/docs/reference/creating_a_provider_class.rst
+++ b/docs/reference/creating_a_provider_class.rst
@@ -295,8 +295,8 @@ added to the provider pool.
         <argument type="service" id="sonata.media.metadata.proxy" />
         <call method="setTemplates">
             <argument type="collection">
-                <argument key='helper_thumbnail'>SonataMediaBundle:Provider:thumbnail.html.twig</argument>
-                <argument key='helper_view'>SonataMediaBundle:Provider:view_vimeo.html.twig</argument>
+                <argument key='helper_thumbnail'>@SonataMedia/Provider/thumbnail.html.twig</argument>
+                <argument key='helper_view'>@SonataMedia/Provider/view_vimeo.html.twig</argument>
             </argument>
         </call>
         <call method="setResizer">

--- a/docs/reference/extra.rst
+++ b/docs/reference/extra.rst
@@ -187,8 +187,8 @@ Second step is optional but you can also define some custom browsing and upload 
   sonata_formatter:
       ckeditor:
           templates:
-              browser: 'SonataFormatterBundle:Ckeditor:browser.html.twig'
-              upload: 'SonataFormatterBundle:Ckeditor:upload.html.twig'
+              browser: '@SonataFormatter/Ckeditor/browser.html.twig'
+              upload: '@SonataFormatter/Ckeditor/upload.html.twig'
 
 Last step takes place in your admin class, you just have to specify the ``ckeditor_context`` parameter.
 

--- a/docs/reference/form.rst
+++ b/docs/reference/form.rst
@@ -52,4 +52,4 @@ You also need to add a new template for the form component:
         form:
             resources:
                 # other files
-                - 'SonataMediaBundle:Form:media_widgets.html.twig'
+                - '@SonataMedia/Form/media_widgets.html.twig'

--- a/src/Block/FeatureMediaBlockService.php
+++ b/src/Block/FeatureMediaBlockService.php
@@ -38,7 +38,7 @@ class FeatureMediaBlockService extends MediaBlockService
             'context' => false,
             'mediaId' => null,
             'format' => false,
-            'template' => 'SonataMediaBundle:Block:block_feature_media.html.twig',
+            'template' => '@SonataMedia/Block/block_feature_media.html.twig',
         ]);
     }
 

--- a/src/Block/GalleryBlockService.php
+++ b/src/Block/GalleryBlockService.php
@@ -95,7 +95,7 @@ class GalleryBlockService extends AbstractAdminBlockService
             'pauseTime' => 3000,
             'startPaused' => false,
             'wrap' => true,
-            'template' => 'SonataMediaBundle:Block:block_gallery.html.twig',
+            'template' => '@SonataMedia/Block/block_gallery.html.twig',
             'galleryId' => null,
         ]);
     }

--- a/src/Block/GalleryListBlockService.php
+++ b/src/Block/GalleryListBlockService.php
@@ -146,7 +146,7 @@ class GalleryListBlockService extends AbstractAdminBlockService
             'sort' => 'desc',
             'context' => false,
             'title' => 'Gallery List',
-            'template' => 'SonataMediaBundle:Block:block_gallery_list.html.twig',
+            'template' => '@SonataMedia/Block/block_gallery_list.html.twig',
         ]);
     }
 

--- a/src/Block/MediaBlockService.php
+++ b/src/Block/MediaBlockService.php
@@ -91,7 +91,7 @@ class MediaBlockService extends AbstractAdminBlockService
             'context' => false,
             'mediaId' => null,
             'format' => false,
-            'template' => 'SonataMediaBundle:Block:block_media.html.twig',
+            'template' => '@SonataMedia/Block/block_media.html.twig',
         ]);
     }
 

--- a/src/Controller/GalleryController.php
+++ b/src/Controller/GalleryController.php
@@ -26,7 +26,7 @@ class GalleryController extends Controller
             'enabled' => true,
         ]);
 
-        return $this->render('SonataMediaBundle:Gallery:index.html.twig', [
+        return $this->render('@SonataMedia/Gallery/index.html.twig', [
             'galleries' => $galleries,
         ]);
     }
@@ -49,7 +49,7 @@ class GalleryController extends Controller
             throw new NotFoundHttpException('unable to find the gallery with the id');
         }
 
-        return $this->render('SonataMediaBundle:Gallery:view.html.twig', [
+        return $this->render('@SonataMedia/Gallery/view.html.twig', [
             'gallery' => $gallery,
         ]);
     }

--- a/src/Controller/MediaAdminController.php
+++ b/src/Controller/MediaAdminController.php
@@ -33,7 +33,7 @@ class MediaAdminController extends Controller
         if (!$request->get('provider') && $request->isMethod('get')) {
             $pool = $this->get('sonata.media.pool');
 
-            return $this->render('SonataMediaBundle:MediaAdmin:select_provider.html.twig', [
+            return $this->render('@SonataMedia/MediaAdmin/select_provider.html.twig', [
                 'providers' => $pool->getProvidersByContext(
                     $request->get('context', $pool->getDefaultContext())
                 ),

--- a/src/Controller/MediaController.php
+++ b/src/Controller/MediaController.php
@@ -91,7 +91,7 @@ class MediaController extends Controller
             throw new AccessDeniedException();
         }
 
-        return $this->render('SonataMediaBundle:Media:view.html.twig', [
+        return $this->render('@SonataMedia/Media/view.html.twig', [
             'media' => $media,
             'formats' => $this->get('sonata.media.pool')->getFormatNamesByContext($media->getContext()),
             'format' => $format,

--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -55,7 +55,6 @@ use Sonata\MediaBundle\Security\ForbiddenDownloadStrategy;
 use Sonata\MediaBundle\Security\PublicDownloadStrategy;
 use Sonata\MediaBundle\Security\RolesDownloadStrategy;
 use Sonata\MediaBundle\Security\SessionDownloadStrategy;
-use Sonata\MediaBundle\Templating\Helper\MediaHelper;
 use Sonata\MediaBundle\Thumbnail\ConsumerThumbnail;
 use Sonata\MediaBundle\Thumbnail\FormatThumbnail;
 use Sonata\MediaBundle\Thumbnail\ThumbnailInterface;
@@ -596,7 +595,6 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
             PublicDownloadStrategy::class,
             RolesDownloadStrategy::class,
             SessionDownloadStrategy::class,
-            MediaHelper::class,
             ConsumerThumbnail::class,
             FormatThumbnail::class,
             ThumbnailInterface::class,

--- a/src/Extra/Pixlr.php
+++ b/src/Extra/Pixlr.php
@@ -142,7 +142,7 @@ class Pixlr
 
         $this->checkMedia($hash, $media);
 
-        return new Response($this->templating->render('SonataMediaBundle:Extra:pixlr_exit.html.twig'));
+        return new Response($this->templating->render('@SonataMedia/Extra/pixlr_exit.html.twig'));
     }
 
     /**
@@ -175,7 +175,7 @@ class Pixlr
 
         $this->mediaManager->save($media);
 
-        return new Response($this->templating->render('SonataMediaBundle:Extra:pixlr_exit.html.twig'));
+        return new Response($this->templating->render('@SonataMedia/Extra/pixlr_exit.html.twig'));
     }
 
     /**
@@ -207,7 +207,7 @@ class Pixlr
             throw new NotFoundHttpException('The media is not editable');
         }
 
-        return new Response($this->templating->render('SonataMediaBundle:Extra:pixlr_editor.html.twig', [
+        return new Response($this->templating->render('@SonataMedia/Extra/pixlr_editor.html.twig', [
             'media' => $media,
             'admin_pool' => $this->container->get('sonata.admin.pool'),
         ]));

--- a/src/Resources/config/block.xml
+++ b/src/Resources/config/block.xml
@@ -10,28 +10,28 @@
         <service id="sonata.media.block.media" class="%sonata.media.block.media.class%">
             <tag name="sonata.block"/>
             <argument>sonata.media.block.media</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
             <argument type="service" id="service_container"/>
             <argument type="service" id="sonata.media.manager.media"/>
         </service>
         <service id="sonata.media.block.feature_media" class="%sonata.media.block.feature_media.class%">
             <tag name="sonata.block"/>
             <argument>sonata.media.block.feature_media</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
             <argument type="service" id="service_container"/>
             <argument type="service" id="sonata.media.manager.media"/>
         </service>
         <service id="sonata.media.block.gallery" class="%sonata.media.block.gallery.class%">
             <tag name="sonata.block"/>
             <argument>sonata.media.block.gallery</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
             <argument type="service" id="service_container"/>
             <argument type="service" id="sonata.media.manager.gallery"/>
         </service>
         <service id="sonata.media.block.gallery_list" class="%sonata.media.block.gallery_list.class%">
             <tag name="sonata.block"/>
             <argument>sonata.media.block.gallery_list</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
             <argument type="service" id="sonata.media.manager.gallery"/>
             <argument type="service" id="sonata.media.pool"/>
         </service>

--- a/src/Resources/config/doctrine_mongodb_admin.xml
+++ b/src/Resources/config/doctrine_mongodb_admin.xml
@@ -33,10 +33,10 @@
             </call>
             <call method="setTemplates">
                 <argument type="collection">
-                    <argument key="inner_list_row">SonataMediaBundle:MediaAdmin:inner_row_media.html.twig</argument>
-                    <argument key="base_list_field">SonataAdminBundle:CRUD:base_list_flat_field.html.twig</argument>
-                    <argument key="list">SonataMediaBundle:MediaAdmin:list.html.twig</argument>
-                    <argument key="edit">SonataMediaBundle:MediaAdmin:edit.html.twig</argument>
+                    <argument key="inner_list_row">@SonataMedia/MediaAdmin/inner_row_media.html.twig</argument>
+                    <argument key="base_list_field">@SonataAdmin/CRUD/base_list_flat_field.html.twig</argument>
+                    <argument key="list">@SonataMedia/MediaAdmin/list.html.twig</argument>
+                    <argument key="edit">@SonataMedia/MediaAdmin/edit.html.twig</argument>
                 </argument>
             </call>
         </service>
@@ -54,7 +54,7 @@
             </call>
             <call method="setTemplates">
                 <argument type="collection">
-                    <argument key="list">SonataMediaBundle:GalleryAdmin:list.html.twig</argument>
+                    <argument key="list">@SonataMedia/GalleryAdmin/list.html.twig</argument>
                 </argument>
             </call>
         </service>

--- a/src/Resources/config/doctrine_orm_admin.xml
+++ b/src/Resources/config/doctrine_orm_admin.xml
@@ -33,11 +33,11 @@
             </call>
             <call method="setTemplates">
                 <argument type="collection">
-                    <argument key="inner_list_row">SonataMediaBundle:MediaAdmin:inner_row_media.html.twig</argument>
-                    <argument key="outer_list_rows_mosaic">SonataMediaBundle:MediaAdmin:list_outer_rows_mosaic.html.twig</argument>
-                    <argument key="base_list_field">SonataAdminBundle:CRUD:base_list_flat_field.html.twig</argument>
-                    <argument key="list">SonataMediaBundle:MediaAdmin:list.html.twig</argument>
-                    <argument key="edit">SonataMediaBundle:MediaAdmin:edit.html.twig</argument>
+                    <argument key="inner_list_row">@SonataMedia/MediaAdmin/inner_row_media.html.twig</argument>
+                    <argument key="outer_list_rows_mosaic">@SonataMedia/MediaAdmin/list_outer_rows_mosaic.html.twig</argument>
+                    <argument key="base_list_field">@SonataAdmin/CRUD/base_list_flat_field.html.twig</argument>
+                    <argument key="list">@SonataMedia/MediaAdmin/list.html.twig</argument>
+                    <argument key="edit">@SonataMedia/MediaAdmin/edit.html.twig</argument>
                 </argument>
             </call>
         </service>
@@ -55,7 +55,7 @@
             </call>
             <call method="setTemplates">
                 <argument type="collection">
-                    <argument key="list">SonataMediaBundle:GalleryAdmin:list.html.twig</argument>
+                    <argument key="list">@SonataMedia/GalleryAdmin/list.html.twig</argument>
                 </argument>
             </call>
         </service>

--- a/src/Resources/config/doctrine_phpcr_admin.xml
+++ b/src/Resources/config/doctrine_phpcr_admin.xml
@@ -31,10 +31,10 @@
             </call>
             <call method="setTemplates">
                 <argument type="collection">
-                    <argument key="inner_list_row">SonataMediaBundle:MediaAdmin:inner_row_media.html.twig</argument>
-                    <argument key="base_list_field">SonataAdminBundle:CRUD:base_list_flat_field.html.twig</argument>
-                    <argument key="list">SonataMediaBundle:MediaAdmin:list.html.twig</argument>
-                    <argument key="edit">SonataMediaBundle:MediaAdmin:edit.html.twig</argument>
+                    <argument key="inner_list_row">@SonataMedia/MediaAdmin/inner_row_media.html.twig</argument>
+                    <argument key="base_list_field">@SonataAdmin/CRUD/base_list_flat_field.html.twig</argument>
+                    <argument key="list">@SonataMedia/MediaAdmin/list.html.twig</argument>
+                    <argument key="edit">@SonataMedia/MediaAdmin/edit.html.twig</argument>
                 </argument>
             </call>
             <call method="setRouteBuilder">
@@ -52,7 +52,7 @@
             </call>
             <call method="setTemplates">
                 <argument type="collection">
-                    <argument key="list">SonataMediaBundle:GalleryAdmin:list.html.twig</argument>
+                    <argument key="list">@SonataMedia/GalleryAdmin/list.html.twig</argument>
                 </argument>
             </call>
             <call method="setRouteBuilder">

--- a/src/Resources/config/extra.xml
+++ b/src/Resources/config/extra.xml
@@ -7,7 +7,7 @@
             <argument type="service" id="sonata.media.pool"/>
             <argument type="service" id="sonata.media.manager.media"/>
             <argument type="service" id="router"/>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
             <argument type="service" id="service_container"/>
         </service>
     </services>

--- a/src/Resources/config/provider.xml
+++ b/src/Resources/config/provider.xml
@@ -34,8 +34,8 @@
             <argument type="service" id="sonata.media.metadata.proxy"/>
             <call method="setTemplates">
                 <argument type="collection">
-                    <argument key="helper_thumbnail">SonataMediaBundle:Provider:thumbnail.html.twig</argument>
-                    <argument key="helper_view">SonataMediaBundle:Provider:view_image.html.twig</argument>
+                    <argument key="helper_thumbnail">@SonataMedia/Provider/thumbnail.html.twig</argument>
+                    <argument key="helper_view">@SonataMedia/Provider/view_image.html.twig</argument>
                 </argument>
             </call>
         </service>
@@ -51,8 +51,8 @@
             <argument type="service" id="sonata.media.metadata.proxy"/>
             <call method="setTemplates">
                 <argument type="collection">
-                    <argument key="helper_thumbnail">SonataMediaBundle:Provider:thumbnail.html.twig</argument>
-                    <argument key="helper_view">SonataMediaBundle:Provider:view_file.html.twig</argument>
+                    <argument key="helper_thumbnail">@SonataMedia/Provider/thumbnail.html.twig</argument>
+                    <argument key="helper_view">@SonataMedia/Provider/view_file.html.twig</argument>
                 </argument>
             </call>
         </service>
@@ -68,8 +68,8 @@
             <argument/>
             <call method="setTemplates">
                 <argument type="collection">
-                    <argument key="helper_thumbnail">SonataMediaBundle:Provider:thumbnail.html.twig</argument>
-                    <argument key="helper_view">SonataMediaBundle:Provider:view_youtube.html.twig</argument>
+                    <argument key="helper_thumbnail">@SonataMedia/Provider/thumbnail.html.twig</argument>
+                    <argument key="helper_view">@SonataMedia/Provider/view_youtube.html.twig</argument>
                 </argument>
             </call>
         </service>
@@ -84,8 +84,8 @@
             <argument type="service" id="sonata.media.metadata.proxy"/>
             <call method="setTemplates">
                 <argument type="collection">
-                    <argument key="helper_thumbnail">SonataMediaBundle:Provider:thumbnail.html.twig</argument>
-                    <argument key="helper_view">SonataMediaBundle:Provider:view_dailymotion.html.twig</argument>
+                    <argument key="helper_thumbnail">@SonataMedia/Provider/thumbnail.html.twig</argument>
+                    <argument key="helper_view">@SonataMedia/Provider/view_dailymotion.html.twig</argument>
                 </argument>
             </call>
         </service>
@@ -100,8 +100,8 @@
             <argument type="service" id="sonata.media.metadata.proxy"/>
             <call method="setTemplates">
                 <argument type="collection">
-                    <argument key="helper_thumbnail">SonataMediaBundle:Provider:thumbnail.html.twig</argument>
-                    <argument key="helper_view">SonataMediaBundle:Provider:view_vimeo.html.twig</argument>
+                    <argument key="helper_thumbnail">@SonataMedia/Provider/thumbnail.html.twig</argument>
+                    <argument key="helper_view">@SonataMedia/Provider/view_vimeo.html.twig</argument>
                 </argument>
             </call>
         </service>

--- a/src/Resources/config/seo_block.xml
+++ b/src/Resources/config/seo_block.xml
@@ -11,7 +11,7 @@
             <tag name="sonata.breadcrumb"/>
             <argument>gallery_view</argument>
             <argument>sonata.media.block.breadcrumb_view</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
             <argument type="service" id="knp_menu.menu_provider"/>
             <argument type="service" id="knp_menu.factory"/>
         </service>
@@ -20,7 +20,7 @@
             <tag name="sonata.breadcrumb"/>
             <argument>gallery_index</argument>
             <argument>sonata.media.block.breadcrumb_view</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
             <argument type="service" id="knp_menu.menu_provider"/>
             <argument type="service" id="knp_menu.factory"/>
         </service>
@@ -29,7 +29,7 @@
             <tag name="sonata.breadcrumb"/>
             <argument>media_view</argument>
             <argument>sonata.media.block.breadcrumb_view_media</argument>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
             <argument type="service" id="knp_menu.menu_provider"/>
             <argument type="service" id="knp_menu.factory"/>
         </service>

--- a/src/Resources/views/Block/block_gallery.html.twig
+++ b/src/Resources/views/Block/block_gallery.html.twig
@@ -8,7 +8,7 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
-{% extends 'SonataBlockBundle:Block:block_base.html.twig' %}
+{% extends '@SonataBlock/Block/block_base.html.twig' %}
 
 {% block block %}
     {% if settings.format %}

--- a/src/Resources/views/Extra/pixlr_editor.html.twig
+++ b/src/Resources/views/Extra/pixlr_editor.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends "SonataAdminBundle::empty_layout.html.twig" %}
+{% extends "@SonataAdmin/empty_layout.html.twig" %}
 
 
 {% block title %}Pixlr Editor{% endblock title %}

--- a/src/Resources/views/GalleryAdmin/list.html.twig
+++ b/src/Resources/views/GalleryAdmin/list.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_list.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_list.html.twig' %}
 
 {% block preview %}
     <div class="box box-primary">

--- a/src/Resources/views/MediaAdmin/edit.html.twig
+++ b/src/Resources/views/MediaAdmin/edit.html.twig
@@ -26,7 +26,7 @@ file that was distributed with this source code.
 {% endspaceless %}
 {% endmacro %}
 
-{% extends 'SonataAdminBundle:CRUD:base_edit.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_edit.html.twig' %}
 
 {% block stylesheets %}
     {{ parent() }}

--- a/src/Resources/views/MediaAdmin/inner_row_media.html.twig
+++ b/src/Resources/views/MediaAdmin/inner_row_media.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_list_flat_inner_row.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_list_flat_inner_row.html.twig' %}
 
 {% block row %}
 

--- a/src/Resources/views/MediaAdmin/list.html.twig
+++ b/src/Resources/views/MediaAdmin/list.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_list.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_list.html.twig' %}
 
 {% import _self as tree %}
 

--- a/src/Resources/views/MediaAdmin/list_image.html.twig
+++ b/src/Resources/views/MediaAdmin/list_image.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_list_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_list_field.html.twig' %}
 
 {% block field%}
     <a href="{{ admin.generateUrl('edit', {'id' : object|sonata_urlsafeid }) }}">{% thumbnail attribute(object, field_description.name ), 'admin' with {'width': 75, 'height': 60} %}</a>

--- a/src/Resources/views/MediaAdmin/list_outer_rows_mosaic.html.twig
+++ b/src/Resources/views/MediaAdmin/list_outer_rows_mosaic.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:list_outer_rows_mosaic.html.twig' %}
+{% extends '@SonataAdmin/CRUD/list_outer_rows_mosaic.html.twig' %}
 
 {% block sonata_mosaic_default_view %}
     <span class="mosaic-box-label label label-primary pull-right">{{ object.providerName|trans({}, 'SonataMediaBundle') }}</span>

--- a/src/Resources/views/MediaAdmin/select_provider.html.twig
+++ b/src/Resources/views/MediaAdmin/select_provider.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:action.html.twig' %}
+{% extends '@SonataAdmin/CRUD/action.html.twig' %}
 
 {% block title %}{{ 'title_select_provider'|trans({}, 'SonataMediaBundle') }}{% endblock %}
 

--- a/src/Templating/Helper/MediaHelper.php
+++ b/src/Templating/Helper/MediaHelper.php
@@ -21,6 +21,9 @@ use Symfony\Component\Templating\Helper\Helper;
  * MediaHelper manages action inclusions.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * @deprecated Since version 3.10, will be removed in 4.0.
+ * NEXT_MAJOR : remove this class
  */
 class MediaHelper extends Helper
 {

--- a/tests/Block/FeatureMediaBlockServiceTest.php
+++ b/tests/Block/FeatureMediaBlockServiceTest.php
@@ -50,7 +50,7 @@ class FeatureMediaBlockServiceTest extends AbstractBlockServiceTestCase
             'media' => false,
             'mediaId' => null,
             'orientation' => 'left',
-            'template' => 'SonataMediaBundle:Block:block_feature_media.html.twig',
+            'template' => '@SonataMedia/Block/block_feature_media.html.twig',
             'title' => false,
             'ttl' => 0,
             'use_cache' => true,

--- a/tests/Block/GalleryBlockServiceTest.php
+++ b/tests/Block/GalleryBlockServiceTest.php
@@ -74,7 +74,7 @@ class GalleryBlockServiceTest extends AbstractBlockServiceTestCase
             'galleryId' => null,
             'pauseTime' => 3000,
             'startPaused' => false,
-            'template' => 'SonataMediaBundle:Block:block_gallery.html.twig',
+            'template' => '@SonataMedia/Block/block_gallery.html.twig',
             'title' => false,
             'ttl' => 0,
             'use_cache' => true,

--- a/tests/Block/GalleryListBlockServiceTest.php
+++ b/tests/Block/GalleryListBlockServiceTest.php
@@ -54,13 +54,13 @@ class GalleryListBlockServiceTest extends AbstractBlockServiceTestCase
             'sort' => 'desc',
             'context' => false,
             'title' => 'Gallery List',
-            'template' => 'SonataMediaBundle:Block:block_gallery_list.html.twig',
+            'template' => '@SonataMedia/Block/block_gallery_list.html.twig',
         ]);
 
         $blockService = new GalleryListBlockService('block.service', $this->templating, $this->galleryManager, $this->pool);
         $blockService->execute($blockContext);
 
-        $this->assertSame('SonataMediaBundle:Block:block_gallery_list.html.twig', $this->templating->view);
+        $this->assertSame('@SonataMedia/Block/block_gallery_list.html.twig', $this->templating->view);
 
         $this->assertSame($blockContext, $this->templating->parameters['context']);
         $this->assertInternalType('array', $this->templating->parameters['settings']);
@@ -80,7 +80,7 @@ class GalleryListBlockServiceTest extends AbstractBlockServiceTestCase
             'sort' => 'desc',
             'context' => false,
             'title' => 'Gallery List',
-            'template' => 'SonataMediaBundle:Block:block_gallery_list.html.twig',
+            'template' => '@SonataMedia/Block/block_gallery_list.html.twig',
         ], $blockContext);
     }
 }

--- a/tests/Block/MediaBlockServiceTest.php
+++ b/tests/Block/MediaBlockServiceTest.php
@@ -76,7 +76,7 @@ class MediaBlockServiceTest extends AbstractBlockServiceTestCase
             'format' => false,
             'media' => false,
             'mediaId' => null,
-            'template' => 'SonataMediaBundle:Block:block_media.html.twig',
+            'template' => '@SonataMedia/Block/block_media.html.twig',
             'title' => false,
             'ttl' => 0,
             'use_cache' => true,

--- a/tests/Controller/MediaAdminControllerTest.php
+++ b/tests/Controller/MediaAdminControllerTest.php
@@ -68,7 +68,7 @@ class MediaAdminControllerTest extends TestCase
         $pool = $this->prophesize(Pool::class);
 
         $this->configureRender(
-            'SonataMediaBundle:MediaAdmin:select_provider.html.twig',
+            '@SonataMedia/MediaAdmin/select_provider.html.twig',
             Argument::type('array'),
             'renderResponse'
         );

--- a/tests/Controller/MediaControllerTest.php
+++ b/tests/Controller/MediaControllerTest.php
@@ -121,7 +121,7 @@ class MediaControllerTest extends TestCase
         $this->configureGetMedia(1, $media->reveal());
         $this->configureGetCurrentRequest($request->reveal());
         $this->configureDownloadSecurity($pool, $media->reveal(), $request->reveal(), true);
-        $this->configureRender('SonataMediaBundle:Media:view.html.twig', [
+        $this->configureRender('@SonataMedia/Media/view.html.twig', [
             'media' => $media->reveal(),
             'formats' => ['format'],
             'format' => 'format',


### PR DESCRIPTION
I am targeting this branch, because this is a patch.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Switch all templates references to Twig namespaced syntax
- Switch from templating service to sonata.templating

### Deprecated
- Deprecated Sonata\MediaBundle\Templating\Helper\MediaHelper
```

## To do

- [X] Switch all templates references to Twig namespaced syntax. Update docs, src and tests
- [X] Deprecate Sonata\MediaBundle\Templating\Helper\MediaHelper
- [x] Add `sonata-project/block-bundle` to composer.json
- [x] Switch from `templating` service to `sonata.templating`

## Subject

This PR is a part of a big plan of decoupling sonata-project bundles from Templating Component. See sonata-project/dev-kit#380 for details

Aso found, that [`Sonata\MediaBundle\Templating\Helper\MediaHelper`](https://github.com/sonata-project/SonataMediaBundle/blob/3.x/src/Templating/Helper/MediaHelper.php) is not used anywhere, so i marked this class as deprecated