### PR TITLE
Make services public

### DIFF
--- a/src/Resources/config/doctrine_orm.xml
+++ b/src/Resources/config/doctrine_orm.xml
@@ -5,7 +5,7 @@
         <parameter key="sonata.media.manager.gallery.class">Sonata\MediaBundle\Entity\GalleryManager</parameter>
     </parameters>
     <services>
-        <service id="sonata.media.manager.media" class="%sonata.media.manager.media.class%">
+        <service id="sonata.media.manager.media" class="%sonata.media.manager.media.class%" public="true">
             <argument>%sonata.media.media.class%</argument>
             <argument type="service" id="doctrine"/>
         </service>

--- a/src/Resources/config/provider.xml
+++ b/src/Resources/config/provider.xml
@@ -12,7 +12,7 @@
         <parameter key="sonata.media.pool.class">Sonata\MediaBundle\Provider\Pool</parameter>
     </parameters>
     <services>
-        <service id="sonata.media.pool" class="%sonata.media.pool.class%">
+        <service id="sonata.media.pool" class="%sonata.media.pool.class%" public="true">
             <argument/>
         </service>
         <service id="sonata.media.thumbnail.format" class="%sonata.media.thumbnail.format%">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1364

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Make services public
```


## Subject

While I was fixing the documentation I encountered an error:

> The "sonata.media.pool" service or alias has been removed or inlined when the container was compiled.

Making `sonata.media.pool` public fixed the problem, I saw there is a similar issue with the same problem (#1364) so I made that service also public.