### PR TITLE
Commands as services

### DIFF
--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -97,6 +97,7 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
         $loader->load('gaufrette.xml');
         $loader->load('validators.xml');
         $loader->load('serializer.xml');
+        $loader->load('command.xml');
 
         if (!in_array(strtolower($config['db_driver']), ['doctrine_orm', 'doctrine_mongodb', 'doctrine_phpcr'])) {
             throw new \InvalidArgumentException(sprintf('SonataMediaBundle - Invalid db driver "%s".', $config['db_driver']));

--- a/src/Resources/config/command.xml
+++ b/src/Resources/config/command.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="Sonata\MediaBundle\Command\AddMassMediaCommand" class="Sonata\MediaBundle\Command\AddMassMediaCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+        <service id="Sonata\MediaBundle\Command\AddMediaCommand" class="Sonata\MediaBundle\Command\AddMediaCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+        <service id="Sonata\MediaBundle\Command\CleanMediaCommand" class="Sonata\MediaBundle\Command\CleanMediaCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+        <service id="Sonata\MediaBundle\Command\FixMediaContextCommand" class="Sonata\MediaBundle\Command\FixMediaContextCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+        <service id="Sonata\MediaBundle\Command\MigrateToJsonTypeCommand" class="Sonata\MediaBundle\Command\MigrateToJsonTypeCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+        <service id="Sonata\MediaBundle\Command\RefreshMetadataCommand" class="Sonata\MediaBundle\Command\RefreshMetadataCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+        <service id="Sonata\MediaBundle\Command\RemoveThumbsCommand" class="Sonata\MediaBundle\Command\RemoveThumbsCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+        <service id="Sonata\MediaBundle\Command\SyncThumbsCommand" class="Sonata\MediaBundle\Command\SyncThumbsCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+        <service id="Sonata\MediaBundle\Command\UpdateCdnStatusCommand" class="Sonata\MediaBundle\Command\UpdateCdnStatusCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a BC fix.


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Commands not working on symfony4
```

## Subject

On symfony4 commands are not working as they are not registered as a services, this fixes it.