### PR TITLE
SyncThumbsCommand PHPCR, ODM manager fix

### DIFF
--- a/src/Command/SyncThumbsCommand.php
+++ b/src/Command/SyncThumbsCommand.php
@@ -141,7 +141,7 @@ class SyncThumbsCommand extends BaseCommand
             }
 
             //clear entity manager for saving memory
-            $this->getMediaManager()->getEntityManager()->clear();
+            $this->getMediaManager()->getObjectManager()->clear();
 
             if ($batchesLimit > 0 && $batchCounter == $batchesLimit) {
                 break;


### PR DESCRIPTION
## The problem

The following error occurred when i ran the sonata:media:sync-thumbnails command with PHPCR or ODM document mapper.

`Error thrown while running command "sonata:media:sync-thumbnails". Message: "Call to undefined method Sonata\MediaBundle\PHPCR\MediaManager::getEntityManager()"`

https://github.com/sonata-project/SonataMediaBundle/blob/8ca7f8447f439d79d8b42aaa1d25683c769cf5b1/src/Command/SyncThumbsCommand.php#L144

If you use PHPCR then $this->getMediaManager() is Sonata\CoreBundle\Model\BasePHPCRManager and this class does not have getEntityManager() method.
Same as in the Sonata\CoreBundle\Model\BaseDocumentManager class when you use ODM.

But the ORM, ODM and the PHPCR manager class extends same Sonata\CoreBundle\Model\BaseManager class, which has getObjectManager() method.

## The solution
Changing
`$this->getMediaManager()->getEntityManager()->clear();`
to
`$this->getMediaManager()->getObjectManager()->clear();`
in the Sonata\MediaBundle\Command\SyncThumbsCommand on line 144.

## Changelog

```
### Fixed
- `sonata:media:sync-thumbnails` command when running this command with PHPCR or ODM  document mapper.
