### PR TITLE
Remove compatibility with FOSRest < 2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "twig/twig": "^1.35 || ^2.0"
     },
     "conflict": {
-        "friendsofsymfony/rest-bundle": "<1.7.4 || >=3.0",
+        "friendsofsymfony/rest-bundle": "<2.1 || >=3.0",
         "jms/serializer": "<0.13",
         "liip/imagine-bundle": "<1.9",
         "sonata-project/block-bundle": "<3.11 || >=4.0",
@@ -68,7 +68,7 @@
     },
     "require-dev": {
         "aws/aws-sdk-php": "^2.8",
-        "friendsofsymfony/rest-bundle": "^1.7.4 || ^2.0",
+        "friendsofsymfony/rest-bundle": "^2.1",
         "jackalope/jackalope-doctrine-dbal": "^1.1",
         "liip/imagine-bundle": "^1.9",
         "matthiasnoback/symfony-dependency-injection-test": "^1.0",

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -26,9 +26,11 @@ Here's the configuration we used, you may adapt it to your needs:
             validate: true
 
     sensio_framework_extra:
-        view:    { annotations: false }
         router:  { annotations: true }
         request: { converters: true }
+        format_listener:
+            rules:
+                - { path: '^/', priorities: ['json'], fallback_format: json, prefer_extension: false }
 
     twig:
         exception_controller: 'FOS\RestBundle\Controller\ExceptionController::showAction'


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Removed compatibility with older versions of FOSRestBundle (<2.1)
```

## Subject

<!-- Describe your Pull Request content here -->
Since dropping a dependency is not a BC break, this is a good start, because we are doing a lot of code just to keep compat with FOSRest 1.

Those are the PR adding this code, to check if I did correctly or not: https://github.com/sonata-project/SonataMediaBundle/pull/1071 https://github.com/sonata-project/SonataMediaBundle/pull/1155 https://github.com/sonata-project/SonataMediaBundle/pull/1339 