### PR TITLE
use Psr7 mimeType guesser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
+        "guzzlehttp/psr7": "^1.0",
         "imagine/imagine": "^0.6 || ^0.7",
         "jms/serializer-bundle": "^0.13 || ^1.0 || ^2.0",
         "knplabs/gaufrette": "^0.1.6 || ^0.2 || ^0.3",

--- a/src/Metadata/AmazonMetadataBuilder.php
+++ b/src/Metadata/AmazonMetadataBuilder.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\MediaBundle\Metadata;
 
-use Guzzle\Http\Mimetypes;
+use GuzzleHttp\Psr7;
 use Sonata\MediaBundle\Model\MediaInterface;
 
 class AmazonMetadataBuilder implements MetadataBuilderInterface
@@ -115,7 +115,7 @@ class AmazonMetadataBuilder implements MetadataBuilderInterface
     protected function getContentType($filename)
     {
         $extension = pathinfo($filename, PATHINFO_EXTENSION);
-        $contentType = Mimetypes::getInstance()->fromExtension($extension);
+        $contentType = Psr7\mimetype_from_extension($extension);
 
         return ['contentType' => $contentType];
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1160 
Closes #1294 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `AmazonMetadataBuilder` now relies on Psr7 mimeType guesser
```

## Subject

<!-- Describe your Pull Request content here -->
Changed old code that relied on a guzzle concrete version by the Psr7 code. It is a small library that is also used by http-plug, so won't conflict with that when we decide to move there.