### PR TITLE
Fixed Bug that would clear a Gallery

### DIFF
--- a/src/Model/Gallery.php
+++ b/src/Model/Gallery.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Model;
 
-use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 
 abstract class Gallery implements GalleryInterface
@@ -49,7 +49,7 @@ abstract class Gallery implements GalleryInterface
     protected $defaultFormat = MediaProviderInterface::FORMAT_REFERENCE;
 
     /**
-     * @var GalleryItemInterface[]
+     * @var Collection
      */
     protected $galleryItems;
 
@@ -146,8 +146,6 @@ abstract class Gallery implements GalleryInterface
      */
     public function setGalleryItems($galleryItems): void
     {
-        $this->galleryItems = new ArrayCollection();
-
         foreach ($galleryItems as $galleryItem) {
             $this->addGalleryItem($galleryItem);
         }
@@ -168,7 +166,9 @@ abstract class Gallery implements GalleryInterface
     {
         $galleryItem->setGallery($this);
 
-        $this->galleryItems[] = $galleryItem;
+        if (!$this->galleryItems->contains($galleryItem)) {
+            $this->galleryItems->add($galleryItem);
+        }
     }
 
     /**


### PR DESCRIPTION
I am targeting this branch, because ~~gregoire asked me to apply this to 'master' as well, since in 'master' some things have been renamed~~ some things have been renamed in master, so the 3.x branch won't merge automatically.

## Changelog

```markdown
### Fixed
- Fixed Bug that would clear a Galery
- Selected gallery context remained untranslated in dropdown
```


## Subject

When saving an existing gallery, all assigned images were removed:

DELETE FROM media__gallery_media WHERE gallery_id = 1;

This was due to replacing the PersistentCollection with a fresh new ArrayCollection, probably without proper cascade=persist on Doctrine level.
