### PR TITLE
NotificationBundle is an optional dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
         "sonata-project/core-bundle": "^3.9",
         "sonata-project/doctrine-extensions": "^1.0",
         "sonata-project/easy-extends-bundle": "^2.5",
-        "sonata-project/notification-bundle": "^3.3",
         "symfony/config": "^2.8 || ^3.2 || ^4.0",
         "symfony/console": "^2.8 || ^3.2 || ^4.0",
         "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",
@@ -63,6 +62,7 @@
         "sonata-project/block-bundle": "<3.11 || >=4.0",
         "sonata-project/classification-bundle": "<3.0 || >= 5.0",
         "sonata-project/formatter-bundle": "<3.2",
+        "sonata-project/notification-bundle": "<3.3",
         "sonata-project/seo-bundle": "<2.1 || >=3.0",
         "symfony/monolog-bundle": "<2.4"
     },
@@ -78,6 +78,7 @@
         "sonata-project/datagrid-bundle": "^2.3",
         "sonata-project/doctrine-orm-admin-bundle": "^3.4",
         "sonata-project/formatter-bundle": "^3.4",
+        "sonata-project/notification-bundle": "^3.3",
         "sonata-project/seo-bundle": "^2.5",
         "symfony/phpunit-bridge": "^4.0",
         "symfony/security-csrf": "^2.8 || ^3.2 || ^4.0"
@@ -87,6 +88,7 @@
         "rackspace/php-opencloud": "^1.6",
         "sonata-project/classification-bundle": "If you want to categorize your media items.",
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
+        "sonata-project/notification-bundle": "If you want to generate thumbnails asynchronously.",
         "sonata-project/seo-bundle": "^2.1",
         "symfony/monolog-bundle": "If you want to log exceptions produced when dealing with images.",
         "tilleuls/ckeditor-sonata-media-bundle": "^1.0"


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Removed `SonataNotificationBundle` as a required dependency
```

## Subject

<!-- Describe your Pull Request content here -->
It was added here (on composer.json and code): 

PR: https://github.com/sonata-project/SonataMediaBundle/pull/151/files
Commit: https://github.com/sonata-project/SonataMediaBundle/commit/fa34e9e9c93c2a3ea6a7aab02463eae78c5c7f82

It was always made optional (not loaded if bundle is not present), so no need to make it a hard requirement on composer
 