### PR TITLE
Use https urls for vimeo api endpoint

### DIFF
--- a/docs/reference/creating_a_provider_class.rst
+++ b/docs/reference/creating_a_provider_class.rst
@@ -50,7 +50,7 @@ Take this video, for example:
 
 * video identifier format : 21216091
 * video player documentation : http://vimeo.com/api/docs/moogaloop
-* metadata : http://vimeo.com/api/oembed.json?url=http://vimeo.com/21216091
+* metadata : https://vimeo.com/api/oembed.json?url=http://vimeo.com/21216091
 
 .. code-block:: json
 
@@ -140,7 +140,7 @@ is going to be used to store ``Media`` information :
             return;
         }
 
-        $url = sprintf('http://vimeo.com/api/oembed.json?url=http://vimeo.com/%s', $media->getBinaryContent());
+        $url = sprintf('https://vimeo.com/api/oembed.json?url=http://vimeo.com/%s', $media->getBinaryContent());
         $metadata = @file_get_contents($url);
 
         if (!$metadata) {

--- a/src/Provider/VimeoProvider.php
+++ b/src/Provider/VimeoProvider.php
@@ -86,7 +86,7 @@ class VimeoProvider extends BaseVideoProvider
      */
     public function updateMetadata(MediaInterface $media, $force = false)
     {
-        $url = sprintf('http://vimeo.com/api/oembed.json?url=%s', $this->getReferenceUrl($media));
+        $url = sprintf('https://vimeo.com/api/oembed.json?url=%s', $this->getReferenceUrl($media));
 
         try {
             $metadata = $this->getMetadata($media, $url);
@@ -130,7 +130,7 @@ class VimeoProvider extends BaseVideoProvider
      */
     public function getReferenceUrl(MediaInterface $media)
     {
-        return sprintf('http://vimeo.com/%s', $media->getProviderReference());
+        return sprintf('https://vimeo.com/%s', $media->getProviderReference());
     }
 
     /**

--- a/tests/Provider/VimeoProviderTest.php
+++ b/tests/Provider/VimeoProviderTest.php
@@ -164,11 +164,11 @@ class VimeoProviderTest extends AbstractProviderTest
     public function getTransformWithUrlMedia()
     {
         $mediaWebsite = new Media();
-        $mediaWebsite->setBinaryContent('http://vimeo.com/012341231');
+        $mediaWebsite->setBinaryContent('https://vimeo.com/012341231');
         $mediaWebsite->setId(1023456);
 
         $mediaPlayer = new Media();
-        $mediaPlayer->setBinaryContent('http://player.vimeo.com/video/012341231');
+        $mediaPlayer->setBinaryContent('https://player.vimeo.com/video/012341231');
         $mediaPlayer->setId(1023456);
 
         return [
@@ -222,6 +222,6 @@ class VimeoProviderTest extends AbstractProviderTest
     {
         $media = new Media();
         $media->setProviderReference('123456');
-        $this->assertEquals('http://vimeo.com/123456', $this->getProvider()->getReferenceUrl($media));
+        $this->assertEquals('https://vimeo.com/123456', $this->getProvider()->getReferenceUrl($media));
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it doesn't break anything.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes: no issue created

## Changelog

```markdown

### Changed

- Changed Vimeo endpoint to https
```

- [x] Update the tests
- [x] Update the documentation
- [x] Add an upgrade note

## Subject

Use https endpoint for Vimeo because of security reasons.
