### PR TITLE
Fix widget template for MediaType as a child form type

### DIFF
--- a/src/Resources/views/Form/media_widgets.html.twig
+++ b/src/Resources/views/Form/media_widgets.html.twig
@@ -2,7 +2,7 @@
     <div class="row">
         <div class="col-md-4 pull-left">
             {% if value is not empty and value.providerReference %}
-                {% if sonata_admin_enabled is defined and sonata_admin_enabled %}
+                {% if sonata_admin_enabled is defined and sonata_admin_enabled and sonata_admin.admin is not same as(false) %}
                     <a href="{{ sonata_admin.admin.getConfigurationPool().adminByAdminCode('sonata.media.admin.media').generateObjectUrl('edit', value) }}">
                         <strong>{{ value.name }}</strong>
                     </a>


### PR DESCRIPTION
I am targeting this branch, because this is a patch.

Closes #1369 

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed widget template for MediaType as a child form type
```

## Subject

When `Sonata\MediaBundle\Form\Type\MediaType` is a child of some other form type, `Sonata\AdminBundle\Form\Extension\Field\Type\FormTypeFieldExtension` [sets](https://github.com/sonata-project/SonataAdminBundle/blob/3.x/src/Form/Extension/Field/Type/FormTypeFieldExtension.php#L78) `$view->vars['sonata_admin_enabled'] = true;` and at the same time `$view->vars['sonata_admin']['admin']` is false!

This PR adds one additional check `... and sonata_admin.admin is not same as(false)` to widget template for MediaType.