### PR TITLE
Fix outdated twig docs

### DIFF
--- a/docs/reference/form.rst
+++ b/docs/reference/form.rst
@@ -41,7 +41,7 @@ And optionals parameters:
     }
 
 
-You also need to add a new template for the form component:
+You also need to add a new form theme template to twig configuration:
 
 .. code-block:: yaml
 
@@ -49,7 +49,5 @@ You also need to add a new template for the form component:
         debug:            "%kernel.debug%"
         strict_variables: "%kernel.debug%"
 
-        form:
-            resources:
-                # other files
-                - '@SonataMedia/Form/media_widgets.html.twig'
+        form_themes:
+            - '@SonataMedia/Form/media_widgets.html.twig'


### PR DESCRIPTION
I am targeting this branch, because this is docs.

## Subject

`@SonataMedia/Form/media_widgets.html.twig` template must be added to `twig.form_themes`, not to `twig.form.resources`