### PR TITLE
Make a db_driver configuration parameter optional with no_driver default value

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -39,6 +39,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('db_driver')
                     ->defaultValue('no_driver')
+                    ->info('Choose persistence mechanism driver from the following list: "doctrine_orm", "doctrine_mongodb", "doctrine_phpcr"')
                     ->validate()
                         ->ifNotInArray(self::DB_DRIVERS)
                         ->thenInvalid('SonataMediaBundle - Invalid db driver %s.')

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -23,6 +23,11 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 class Configuration implements ConfigurationInterface
 {
     /**
+     * NEXT_MAJOR: make constant protected/private.
+     */
+    const DB_DRIVERS = ['doctrine_orm', 'doctrine_mongodb', 'doctrine_phpcr', 'no_driver'];
+
+    /**
      * {@inheritdoc}
      */
     public function getConfigTreeBuilder()
@@ -32,7 +37,13 @@ class Configuration implements ConfigurationInterface
 
         $node
             ->children()
-                ->scalarNode('db_driver')->defaultValue('no_driver')->end()
+                ->scalarNode('db_driver')
+                    ->defaultValue('no_driver')
+                    ->validate()
+                        ->ifNotInArray(self::DB_DRIVERS)
+                        ->thenInvalid('SonataMediaBundle - Invalid db driver %s.')
+                    ->end()
+                ->end()
                 ->scalarNode('default_context')->isRequired()->end()
                 ->scalarNode('category_manager')
                     ->defaultValue('sonata.media.manager.category.default')

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -32,7 +32,7 @@ class Configuration implements ConfigurationInterface
 
         $node
             ->children()
-                ->scalarNode('db_driver')->isRequired()->end()
+                ->scalarNode('db_driver')->defaultValue('no_driver')->end()
                 ->scalarNode('default_context')->isRequired()->end()
                 ->scalarNode('category_manager')
                     ->defaultValue('sonata.media.manager.category.default')

--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -99,10 +99,6 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
         $loader->load('serializer.xml');
         $loader->load('command.xml');
 
-        if (!in_array(strtolower($config['db_driver']), ['doctrine_orm', 'doctrine_mongodb', 'doctrine_phpcr', 'no_driver'])) {
-            throw new \InvalidArgumentException(sprintf('SonataMediaBundle - Invalid db driver "%s".', $config['db_driver']));
-        }
-
         $bundles = $container->getParameter('kernel.bundles');
 
         if (isset($bundles['FOSRestBundle'], $bundles['NelmioApiDocBundle'])) {

--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -99,7 +99,7 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
         $loader->load('serializer.xml');
         $loader->load('command.xml');
 
-        if (!in_array(strtolower($config['db_driver']), ['doctrine_orm', 'doctrine_mongodb', 'doctrine_phpcr'])) {
+        if (!in_array(strtolower($config['db_driver']), ['doctrine_orm', 'doctrine_mongodb', 'doctrine_phpcr', 'no_driver'])) {
             throw new \InvalidArgumentException(sprintf('SonataMediaBundle - Invalid db driver "%s".', $config['db_driver']));
         }
 

--- a/src/Exception/NoDriverException.php
+++ b/src/Exception/NoDriverException.php
@@ -19,7 +19,7 @@ final class NoDriverException extends \RuntimeException
     public function __construct($message = null, $code = 0, \Exception $previous = null)
     {
         parent::__construct(
-            $message ?? 'The child node "db_driver" at path "sonata_media" must be configured.',
+            null === $message ? 'The child node "db_driver" at path "sonata_media" must be configured.' : $message,
             $code,
             $previous
         );

--- a/src/Exception/NoDriverException.php
+++ b/src/Exception/NoDriverException.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Exception;
+
+/**
+ * @author Andrey F. Mindubaev <covex.mobile@gmail.com>
+ */
+class NoDriverException extends \RuntimeException
+{
+    const DEFAULT_MESSAGE = 'The child node "db_driver" at path "sonata_media" must be configured.';
+
+    public function __construct($message = self::DEFAULT_MESSAGE, $code = 0, \Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Exception/NoDriverException.php
+++ b/src/Exception/NoDriverException.php
@@ -14,12 +14,14 @@ namespace Sonata\MediaBundle\Exception;
 /**
  * @author Andrey F. Mindubaev <covex.mobile@gmail.com>
  */
-class NoDriverException extends \RuntimeException
+final class NoDriverException extends \RuntimeException
 {
-    const DEFAULT_MESSAGE = 'The child node "db_driver" at path "sonata_media" must be configured.';
-
-    public function __construct($message = self::DEFAULT_MESSAGE, $code = 0, \Throwable $previous = null)
+    public function __construct($message = null, $code = 0, \Exception $previous = null)
     {
-        parent::__construct($message, $code, $previous);
+        parent::__construct(
+            $message ?? 'The child node "db_driver" at path "sonata_media" must be configured.',
+            $code,
+            $previous
+        );
     }
 }

--- a/src/Generator/NoDriverGenerator.php
+++ b/src/Generator/NoDriverGenerator.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Generator;
+
+use Sonata\MediaBundle\Exception\NoDriverException;
+use Sonata\MediaBundle\Model\MediaInterface;
+
+/**
+ * @internal
+ *
+ * @author Andrey F. Mindubaev <covex.mobile@gmail.com>
+ */
+class NoDriverGenerator implements GeneratorInterface
+{
+    public function generatePath(MediaInterface $media)
+    {
+        throw new NoDriverException();
+    }
+}

--- a/src/Generator/NoDriverGenerator.php
+++ b/src/Generator/NoDriverGenerator.php
@@ -19,7 +19,7 @@ use Sonata\MediaBundle\Model\MediaInterface;
  *
  * @author Andrey F. Mindubaev <covex.mobile@gmail.com>
  */
-class NoDriverGenerator implements GeneratorInterface
+final class NoDriverGenerator implements GeneratorInterface
 {
     public function generatePath(MediaInterface $media)
     {

--- a/src/Model/NoDriverManager.php
+++ b/src/Model/NoDriverManager.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Model;
+
+use Sonata\CoreBundle\Model\ManagerInterface;
+use Sonata\MediaBundle\Exception\NoDriverException;
+
+/**
+ * @internal
+ *
+ * @author Andrey F. Mindubaev <covex.mobile@gmail.com>
+ */
+class NoDriverManager implements ManagerInterface
+{
+    public function getClass()
+    {
+        throw new NoDriverException();
+    }
+
+    public function findAll()
+    {
+        throw new NoDriverException();
+    }
+
+    /**
+     * @param int|null $limit
+     * @param int|null $offset
+     */
+    public function findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+    {
+        throw new NoDriverException();
+    }
+
+    public function findOneBy(array $criteria, array $orderBy = null)
+    {
+        throw new NoDriverException();
+    }
+
+    /**
+     * @param mixed $id
+     */
+    public function find($id)
+    {
+        throw new NoDriverException();
+    }
+
+    public function create()
+    {
+        throw new NoDriverException();
+    }
+
+    /**
+     * @param object $entity
+     * @param bool   $andFlush
+     */
+    public function save($entity, $andFlush = true)
+    {
+        throw new NoDriverException();
+    }
+
+    /**
+     * @param object $entity
+     * @param bool   $andFlush
+     */
+    public function delete($entity, $andFlush = true)
+    {
+        throw new NoDriverException();
+    }
+
+    public function getTableName()
+    {
+        throw new NoDriverException();
+    }
+
+    public function getConnection()
+    {
+        throw new NoDriverException();
+    }
+}

--- a/src/Model/NoDriverManager.php
+++ b/src/Model/NoDriverManager.php
@@ -19,7 +19,7 @@ use Sonata\MediaBundle\Exception\NoDriverException;
  *
  * @author Andrey F. Mindubaev <covex.mobile@gmail.com>
  */
-class NoDriverManager implements ManagerInterface
+final class NoDriverManager implements ManagerInterface
 {
     public function getClass()
     {

--- a/src/Resources/config/no_driver.xml
+++ b/src/Resources/config/no_driver.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sonata.media.manager.media" class="Sonata\MediaBundle\Model\NoDriverManager"/>
-        <service id="sonata.media.manager.gallery" class="Sonata\MediaBundle\Model\NoDriverManager"/>
+        <service id="sonata.media.manager.media" class="Sonata\MediaBundle\Model\NoDriverManager" public="true"/>
+        <service id="sonata.media.manager.gallery" class="Sonata\MediaBundle\Model\NoDriverManager" public="true"/>
         <service id="sonata.media.generator.default" class="Sonata\MediaBundle\Generator\NoDriverGenerator"/>
     </services>
 </container>

--- a/src/Resources/config/no_driver.xml
+++ b/src/Resources/config/no_driver.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sonata.media.manager.media" class="Sonata\MediaBundle\Model\NoDriverManager"/>
+        <service id="sonata.media.manager.gallery" class="Sonata\MediaBundle\Model\NoDriverManager"/>
+        <service id="sonata.media.generator.default" class="Sonata\MediaBundle\Generator\NoDriverGenerator"/>
+    </services>
+</container>

--- a/src/Resources/config/no_driver_admin.xml
+++ b/src/Resources/config/no_driver_admin.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+</container>

--- a/src/Resources/config/no_driver_admin.xml
+++ b/src/Resources/config/no_driver_admin.xml
@@ -1,3 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <!--
+     This file will be loaded when SonataAdminBundle is enabled and db_driver has its default value, not corresponding
+     to real persistence mechanism.
+     -->
 </container>

--- a/tests/Generator/NoDriverGeneratorTest.php
+++ b/tests/Generator/NoDriverGeneratorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\Generator;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\MediaBundle\Exception\NoDriverException;
+use Sonata\MediaBundle\Generator\NoDriverGenerator;
+use Sonata\MediaBundle\Model\MediaInterface;
+
+class NoDriverGeneratorTest extends TestCase
+{
+    public function testException()
+    {
+        $this->expectException(NoDriverException::class);
+
+        $manager = new NoDriverGenerator();
+        $manager->generatePath($this->createMock(MediaInterface::class));
+    }
+}

--- a/tests/Model/NoDriverManagerTest.php
+++ b/tests/Model/NoDriverManagerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\Model;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\MediaBundle\Exception\NoDriverException;
+use Sonata\MediaBundle\Model\NoDriverManager;
+
+class NoDriverManagerTest extends TestCase
+{
+    /**
+     * @dataProvider providerMethods
+     */
+    public function testException($method, array $arguments)
+    {
+        $this->expectException(NoDriverException::class);
+
+        call_user_func_array([new NoDriverManager(), $method], $arguments);
+    }
+
+    public function providerMethods()
+    {
+        return [
+            ['getClass', []],
+            ['findAll', []],
+            ['findBy', [[]]],
+            ['findOneBy', [[]]],
+            ['find', [1]],
+            ['create', []],
+            ['save', [null]],
+            ['delete', [null]],
+            ['getTableName', []],
+            ['getConnection', []],
+        ];
+    }
+}


### PR DESCRIPTION
I am targeting this branch, because this is BC.

Closes #1419

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- A db_driver configuration parameter is optional now with 'no_driver' default value
```

## To do

- [x] Add tests

## Subject

To create a recipe for Symfony Flex, it should be possible to create a default configuration, that allows to run `cache:clear` without errors (see https://github.com/sonata-project/dev-kit/issues/409) A default value for `db_driver` configuration parameter will allow this.

If this PR will be accepted, a default configuration, i.e. a recipe for `sonata-media/media-bundle` could be like this (please fix me, it there something wrong here; may be `providers` or `formats` sections should be changed to more commonly used?):

```yaml
sonata_media:
    default_context: default
    contexts:
        default:
            providers:
                - sonata.media.provider.dailymotion
                - sonata.media.provider.youtube
                - sonata.media.provider.image
                - sonata.media.provider.file
                - sonata.media.provider.vimeo

            formats:
                small: { width: 100 , quality: 70}
                big:   { width: 500 , quality: 70}

    cdn:
        server:
            path: /upload/media

    filesystem:
        local:
            directory: "%kernel.project_dir%/public/upload/media"
            create: false
```

Additional configuration, i.e. a recipe for a new package `sonata-project/media-orm-pack` could be like this (i created a [gist](https://gist.github.com/covex-nn/76795ddb85fb3656d716e462a748156c) with entity classes):

```yaml
sonata_media:
    class:
        media: App\Entity\SonataMediaMedia
        gallery: App\Entity\SonataMediaGallery
        gallery_has_media: App\Entity\SonataMediaGalleryHasMedia
    db_driver: doctrine_orm
```
