### PR TITLE
Bugfix - galleryHasMedia collection is removed on Gallery update

### DIFF
--- a/src/Admin/GalleryAdmin.php
+++ b/src/Admin/GalleryAdmin.php
@@ -47,18 +47,6 @@ class GalleryAdmin extends AbstractAdmin
         $parameters = $this->getPersistentParameters();
 
         $gallery->setContext($parameters['context']);
-
-        // fix weird bug with setter object not being call
-        $gallery->setGalleryHasMedias($gallery->getGalleryHasMedias());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function preUpdate($gallery)
-    {
-        // fix weird bug with setter object not being call
-        $gallery->setGalleryHasMedias($gallery->getGalleryHasMedias());
     }
 
     /**
@@ -128,7 +116,7 @@ class GalleryAdmin extends AbstractAdmin
                 ->ifEnd()
             ->end()
             ->with('Gallery')
-                ->add('galleryHasMedias', CollectionType::class, [], [
+                ->add('galleryHasMedias', CollectionType::class, ['by_reference' => false], [
                     'edit' => 'inline',
                     'inline' => 'table',
                     'sortable' => 'position',

--- a/src/Controller/Api/GalleryController.php
+++ b/src/Controller/Api/GalleryController.php
@@ -417,7 +417,7 @@ class GalleryController
             $galleryHasMedia = $form->getData();
             $galleryHasMedia->setMedia($media);
 
-            $gallery->addGalleryHasMedias($galleryHasMedia);
+            $gallery->addGalleryHasMedia($galleryHasMedia);
             $this->galleryManager->save($gallery);
 
             $context = new Context();

--- a/src/Controller/Api/GalleryController.php
+++ b/src/Controller/Api/GalleryController.php
@@ -21,6 +21,7 @@ use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\MediaBundle\Model\GalleryHasMediaInterface;
 use Sonata\MediaBundle\Model\GalleryInterface;
 use Sonata\MediaBundle\Model\GalleryManagerInterface;
+use Sonata\MediaBundle\Model\GalleryMediaCollectionInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -417,7 +418,12 @@ class GalleryController
             $galleryHasMedia = $form->getData();
             $galleryHasMedia->setMedia($media);
 
-            $gallery->addGalleryHasMedia($galleryHasMedia);
+            // NEXT_MAJOR: remove this if/else block. Just call `$gallery->addGalleryHasMedia($galleryHasMedia);`
+            if ($gallery instanceof GalleryMediaCollectionInterface) {
+                $gallery->addGalleryHasMedia($galleryHasMedia);
+            } else {
+                $gallery->addGalleryHasMedias($galleryHasMedia);
+            }
             $this->galleryManager->save($gallery);
 
             $context = new Context();

--- a/src/Model/Gallery.php
+++ b/src/Model/Gallery.php
@@ -15,7 +15,11 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 
-abstract class Gallery implements GalleryInterface
+
+/**
+ * NEXT_MAJOR: remove GalleryMediaCollectionInterface interface. Move its content into GalleryInterface
+ */
+abstract class Gallery implements GalleryInterface, GalleryMediaCollectionInterface
 {
     /**
      * @var string
@@ -179,10 +183,9 @@ abstract class Gallery implements GalleryInterface
     }
 
     /**
+     * {@inheritdoc}
      * @deprecated use addGalleryHasMedia method instead
      * NEXT_MAJOR: remove this method with the next major release
-     *
-     * @param GalleryHasMediaInterface $galleryHasMedia
      */
     public function addGalleryHasMedias(GalleryHasMediaInterface $galleryHasMedia)
     {

--- a/src/Model/Gallery.php
+++ b/src/Model/Gallery.php
@@ -187,7 +187,8 @@ abstract class Gallery implements GalleryInterface
     public function addGalleryHasMedias(GalleryHasMediaInterface $galleryHasMedia)
     {
         @trigger_error(
-            'The '.__METHOD__.' is deprecated and will be removed with next major release. Use `addGalleryHasMedia` method instead.',
+            'The '.__METHOD__.' is deprecated and will be removed with next major release.'
+            .'Use `addGalleryHasMedia` method instead.',
             E_USER_DEPRECATED
         );
         $this->addGalleryHasMedia($galleryHasMedia);

--- a/src/Model/Gallery.php
+++ b/src/Model/Gallery.php
@@ -147,7 +147,7 @@ abstract class Gallery implements GalleryInterface
         $this->galleryHasMedias = new ArrayCollection();
 
         foreach ($galleryHasMedias as $galleryHasMedia) {
-            $this->addGalleryHasMedias($galleryHasMedia);
+            $this->addGalleryHasMedia($galleryHasMedia);
         }
     }
 

--- a/src/Model/Gallery.php
+++ b/src/Model/Gallery.php
@@ -12,6 +12,7 @@
 namespace Sonata\MediaBundle\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 
 abstract class Gallery implements GalleryInterface
@@ -47,7 +48,7 @@ abstract class Gallery implements GalleryInterface
     protected $defaultFormat = MediaProviderInterface::FORMAT_REFERENCE;
 
     /**
-     * @var GalleryHasMediaInterface[]
+     * @var GalleryHasMediaInterface[]|Collection
      */
     protected $galleryHasMedias;
 
@@ -174,9 +175,7 @@ abstract class Gallery implements GalleryInterface
      */
     public function removeGalleryHasMedia(GalleryHasMediaInterface $galleryHasMedia)
     {
-        $galleryHasMedia->setGallery($this);
-
-        $this->galleryHasMedias[] = $galleryHasMedia;
+        $this->galleryHasMedias->removeElement($galleryHasMedia);
     }
 
     /**

--- a/src/Model/Gallery.php
+++ b/src/Model/Gallery.php
@@ -162,7 +162,17 @@ abstract class Gallery implements GalleryInterface
     /**
      * {@inheritdoc}
      */
-    public function addGalleryHasMedias(GalleryHasMediaInterface $galleryHasMedia)
+    public function addGalleryHasMedia(GalleryHasMediaInterface $galleryHasMedia)
+    {
+        $galleryHasMedia->setGallery($this);
+
+        $this->galleryHasMedias[] = $galleryHasMedia;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeGalleryHasMedia(GalleryHasMediaInterface $galleryHasMedia)
     {
         $galleryHasMedia->setGallery($this);
 

--- a/src/Model/Gallery.php
+++ b/src/Model/Gallery.php
@@ -15,9 +15,8 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 
-
 /**
- * NEXT_MAJOR: remove GalleryMediaCollectionInterface interface. Move its content into GalleryInterface
+ * NEXT_MAJOR: remove GalleryMediaCollectionInterface interface. Move its content into GalleryInterface.
  */
 abstract class Gallery implements GalleryInterface, GalleryMediaCollectionInterface
 {
@@ -184,6 +183,7 @@ abstract class Gallery implements GalleryInterface, GalleryMediaCollectionInterf
 
     /**
      * {@inheritdoc}
+     *
      * @deprecated use addGalleryHasMedia method instead
      * NEXT_MAJOR: remove this method with the next major release
      */

--- a/src/Model/Gallery.php
+++ b/src/Model/Gallery.php
@@ -180,6 +180,21 @@ abstract class Gallery implements GalleryInterface
     }
 
     /**
+     * @deprecated use addGalleryHasMedia method instead
+     * NEXT_MAJOR: remove this method with the next major release
+     *
+     * @param GalleryHasMediaInterface $galleryHasMedia
+     */
+    public function addGalleryHasMedias(GalleryHasMediaInterface $galleryHasMedia)
+    {
+        @trigger_error(
+            'The '.__METHOD__.' is deprecated and will be removed with next major release. Use `addGalleryHasMedia` method instead.',
+            E_USER_DEPRECATED
+        );
+        $this->addGalleryHasMedia($galleryHasMedia);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function setContext($context)

--- a/src/Model/GalleryInterface.php
+++ b/src/Model/GalleryInterface.php
@@ -108,6 +108,7 @@ interface GalleryInterface
 
     /**
      * @param GalleryHasMediaInterface $galleryHasMedia
+     *
      * @deprecated implement addGalleryHasMedia method instead, it will be provided with the next major release
      * NEXT_MAJOR: remove this method
      */

--- a/src/Model/GalleryInterface.php
+++ b/src/Model/GalleryInterface.php
@@ -109,5 +109,10 @@ interface GalleryInterface
     /**
      * @param GalleryHasMediaInterface $galleryHasMedia
      */
-    public function addGalleryHasMedias(GalleryHasMediaInterface $galleryHasMedia);
+    public function addGalleryHasMedia(GalleryHasMediaInterface $galleryHasMedia);
+
+    /**
+     * @param GalleryHasMediaInterface $galleryHasMedia
+     */
+    public function removeGalleryHasMedia(GalleryHasMediaInterface $galleryHasMedia);
 }

--- a/src/Model/GalleryInterface.php
+++ b/src/Model/GalleryInterface.php
@@ -108,11 +108,8 @@ interface GalleryInterface
 
     /**
      * @param GalleryHasMediaInterface $galleryHasMedia
+     * @deprecated implement addGalleryHasMedia method instead, it will be provided with the next major release
+     * NEXT_MAJOR: remove this method
      */
-    public function addGalleryHasMedia(GalleryHasMediaInterface $galleryHasMedia);
-
-    /**
-     * @param GalleryHasMediaInterface $galleryHasMedia
-     */
-    public function removeGalleryHasMedia(GalleryHasMediaInterface $galleryHasMedia);
+    public function addGalleryHasMedias(GalleryHasMediaInterface $galleryHasMedia);
 }

--- a/src/Model/GalleryMediaCollectionInterface.php
+++ b/src/Model/GalleryMediaCollectionInterface.php
@@ -17,13 +17,7 @@ namespace Sonata\MediaBundle\Model;
  */
 interface GalleryMediaCollectionInterface
 {
-    /**
-     * @param GalleryHasMediaInterface $galleryHasMedia
-     */
     public function addGalleryHasMedia(GalleryHasMediaInterface $galleryHasMedia);
 
-    /**
-     * @param GalleryHasMediaInterface $galleryHasMedia
-     */
     public function removeGalleryHasMedia(GalleryHasMediaInterface $galleryHasMedia);
 }

--- a/src/Model/GalleryMediaCollectionInterface.php
+++ b/src/Model/GalleryMediaCollectionInterface.php
@@ -13,7 +13,7 @@ namespace Sonata\MediaBundle\Model;
 
 /**
  * This a workaround to maintain BC within SonataMediaBundle v3.
- * NEXT_MAJOR: remove this interface, move all methods into GalleryInterface
+ * NEXT_MAJOR: remove this interface, move all methods into GalleryInterface.
  */
 interface GalleryMediaCollectionInterface
 {

--- a/src/Model/GalleryMediaCollectionInterface.php
+++ b/src/Model/GalleryMediaCollectionInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Model;
+
+/**
+ * This a workaround to maintain BC within SonataMediaBundle v3.
+ * NEXT_MAJOR: remove this interface, move all methods into GalleryInterface
+ */
+interface GalleryMediaCollectionInterface
+{
+    /**
+     * @param GalleryHasMediaInterface $galleryHasMedia
+     */
+    public function addGalleryHasMedia(GalleryHasMediaInterface $galleryHasMedia);
+
+    /**
+     * @param GalleryHasMediaInterface $galleryHasMedia
+     */
+    public function removeGalleryHasMedia(GalleryHasMediaInterface $galleryHasMedia);
+}

--- a/src/PHPCR/BaseGallery.php
+++ b/src/PHPCR/BaseGallery.php
@@ -46,7 +46,7 @@ abstract class BaseGallery extends Gallery
     /**
      * {@inheritdoc}
      */
-    public function addGalleryHasMedias(GalleryHasMediaInterface $galleryHasMedia)
+    public function addGalleryHasMedia(GalleryHasMediaInterface $galleryHasMedia)
     {
         $galleryHasMedia->setGallery($this);
 


### PR DESCRIPTION
I am targeting this branch, because this is a bugfix.

Fixes #1396, closes #1394, and closes #1370

## Changelog

```markdown
### Added
- Added `Sonata\MediaBundle\Model\Gallery::addGalleryHasMedia` and `Sonata\MediaBundle\Model\Gallery::removeGalleryHasMedia` to properly manage collections.

### Deprecated
- Deprecated `Sonata\MediaBundle\Model\Gallery::addGalleryHasMedias` because adder must use singular naming.

### Removed
- Removed old hacks in GalleryAdmin setting galleryHasMedia collection.

### Fixed
```
## Subject

Unlike PRs #1394 and #1370 this is a proper fix which eliminates the core reason of that collection behavior and removes hacks which were added into GalleryAdmin. It also maintains backwards compatibility by keeping an old addGalleryHasMedias method which is marked as deprecated.

#### Why having both - adder and remover is so important and why they should use singular naming:
If you look into `Symfony\Component\PropertyAccess\PropertyAccessor::writeProperty()` method, you'll see that it first detects ways to gain write access to a property being written. We want it to use `writeCollection()` method to correctly write our `galleryHasMedias` collection, but in order to do that, PropertyAccessor needs to find both adder and remover methods first. 

So `getWriteAccessInfo()` method is called to get write access modes.
At some this method calls `Inflector::singularize($camelized)` to get singular name of the property. 
Then `findAdderAndRemover()` method is called with singular names. It returns adder and remover only if both methods are found which allows PropertyAccessor to use `ACCESS_TYPE_ADDER_AND_REMOVER` write mode to write the collection.

#### by_reference => false in GalleryAdmin
Now when we have all methods properly set up and hacks removed, we need to add this form option. It should be false for ArrayCollections in order for adder/remover to be called (see Symfony docs).

#### Case with by_reference => false and missing adder or remover
Now let's see what happens if we have by_reference => false, as it must be for collections, but no adder or remover. BTW this option was there a long time ago, but was wrongly blamed for causing this bug and removed.
In this case setter is used. And what do we have in setter?
`$this->galleryHasMedias = new ArrayCollection();` - new collection is created. Old collection is gone!
So we populate new collection in a `foreach`, it kind of contains all necessary items - old and new ones, doesn't it? Yes, it does, so what can go wrong?
Llets go much further - into UnitOfWork. It still remembers original collection, which was overwritten in the setter. So it persists all items from a new collection, but since we have `orphanRemoval = true` on Gallery - GalleryHasMedia relation, it processes an old collection as orphaned and removes all items which belong to it.