### PR TITLE
Connection to S3 without credentials but with IAM role

### DIFF
--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -458,16 +458,22 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
             ;
 
             if (3 === $config['filesystem']['s3']['sdk_version']) {
-                $container->getDefinition('sonata.media.adapter.service.s3')
-                ->replaceArgument(0, [
-                    'credentials' => [
-                        'secret' => $config['filesystem']['s3']['secretKey'],
-                        'key' => $config['filesystem']['s3']['accessKey'],
-                    ],
+                $arguments = [
+                    'credentials' => false,
                     'region' => $config['filesystem']['s3']['region'],
                     'version' => $config['filesystem']['s3']['version'],
-                ])
-            ;
+                ];
+
+                if (isset($config['filesystem']['s3']['secretKey'], $config['filesystem']['s3']['accessKey'])) {
+                    $arguments['credentials'] = [
+                        'secret' => $config['filesystem']['s3']['secretKey'],
+                        'key' => $config['filesystem']['s3']['accessKey'],
+                    ];
+                }
+
+                $container->getDefinition('sonata.media.adapter.service.s3')
+                    ->replaceArgument(0, $arguments)
+                ;
             } else {
                 $container->getDefinition('sonata.media.adapter.service.s3')
                     ->replaceArgument(0, [

--- a/tests/DependencyInjection/SonataMediaExtensionTest.php
+++ b/tests/DependencyInjection/SonataMediaExtensionTest.php
@@ -207,6 +207,69 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
         );
     }
 
+    /**
+     * @param $configs
+     * @param $args
+     *
+     * @dataProvider dataFilesystemConfiguration
+     */
+    public function testLoadWithFilesystemConfiguration($configs, $args)
+    {
+        $this->load($configs);
+
+        $this->assertEquals(
+            $this->container->getDefinition('sonata.media.adapter.service.s3')->getArgument(0),
+            $args
+        );
+    }
+
+    public function dataFilesystemConfiguration()
+    {
+        return [
+            [
+                [
+                    'filesystem' => [
+                        's3' => [
+                            'bucket' => 'bucket_name',
+                            'sdk_version' => 3,
+                            'region' => 'region',
+                            'version' => 'version',
+                            'secretKey' => null,
+                            'accessKey' => 'null',
+                        ],
+                    ],
+                ],
+                [
+                    'credentials' => false,
+                    'region' => 'region',
+                    'version' => 'version',
+                ],
+            ],
+            [
+                [
+                    'filesystem' => [
+                        's3' => [
+                            'bucket' => 'bucket_name',
+                            'sdk_version' => 3,
+                            'region' => 'region',
+                            'version' => 'version',
+                            'secretKey' => 'secret',
+                            'accessKey' => 'access',
+                        ],
+                    ],
+                ],
+                [
+                    'credentials' => [
+                        'secret' => 'secret',
+                        'key' => 'access',
+                    ],
+                    'region' => 'region',
+                    'version' => 'version',
+                ],
+            ],
+        ];
+    }
+
     protected function getMinimalConfiguration()
     {
         return [


### PR DESCRIPTION
I am targeting this branch  3.x, because it used for backward compatible PRs.

## Changelog
```Markdown
### Added
- S3 Connection without use of credentials (access and secret keys) but with IAM roles (Amazon instances must have been configured with it). 
```

## Subject

To connect to an Amazon S3, you can use IAM role (cf. https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials.html#instance-profile-credentials). But sonata media always set credentials has an array with secret and acces keys.
Sonata admin could send a credential set at `false` if  `filesystem.s3.accessKey` and `filesystem.s3.secretKey` are `null` in sonata_media configuration. So aws_sdk set an empty Credentials object (cf. https://github.com/aws/aws-sdk-php/blob/master/src/ClientResolver.php#L405)  and use IAM roles.