### PR TITLE
Make providers, metadata, and managers services public

### DIFF
--- a/src/Resources/config/category.xml
+++ b/src/Resources/config/category.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sonata.media.manager.category.default" class="Sonata\MediaBundle\Model\CategoryManager">
+        <service id="sonata.media.manager.category.default" class="Sonata\MediaBundle\Model\CategoryManager" public="true">
             <argument type="service" id="sonata.classification.manager.category" on-invalid="null"/>
         </service>
     </services>

--- a/src/Resources/config/doctrine_mongodb.xml
+++ b/src/Resources/config/doctrine_mongodb.xml
@@ -6,11 +6,11 @@
     </parameters>
     <services>
         <service id="sonata.media.document_manager" alias="doctrine_mongodb.odm.document_manager"/>
-        <service id="sonata.media.manager.media" class="%sonata.media.manager.media.class%">
+        <service id="sonata.media.manager.media" class="%sonata.media.manager.media.class%" public="true">
             <argument>%sonata.media.media.class%</argument>
             <argument type="service" id="doctrine_mongodb"/>
         </service>
-        <service id="sonata.media.manager.gallery" class="%sonata.media.manager.gallery.class%">
+        <service id="sonata.media.manager.gallery" class="%sonata.media.manager.gallery.class%" public="true">
             <argument>%sonata.media.gallery.class%</argument>
             <argument type="service" id="doctrine_mongodb"/>
         </service>

--- a/src/Resources/config/doctrine_orm.xml
+++ b/src/Resources/config/doctrine_orm.xml
@@ -9,7 +9,7 @@
             <argument>%sonata.media.media.class%</argument>
             <argument type="service" id="doctrine"/>
         </service>
-        <service id="sonata.media.manager.gallery" class="%sonata.media.manager.gallery.class%">
+        <service id="sonata.media.manager.gallery" class="%sonata.media.manager.gallery.class%" public="true">
             <argument>%sonata.media.gallery.class%</argument>
             <argument type="service" id="doctrine"/>
         </service>

--- a/src/Resources/config/doctrine_phpcr.xml
+++ b/src/Resources/config/doctrine_phpcr.xml
@@ -5,11 +5,11 @@
         <parameter key="sonata.media.manager.gallery.class">Sonata\MediaBundle\PHPCR\GalleryManager</parameter>
     </parameters>
     <services>
-        <service id="sonata.media.manager.media" class="%sonata.media.manager.media.class%">
+        <service id="sonata.media.manager.media" class="%sonata.media.manager.media.class%" public="true">
             <argument>%sonata.media.media.class%</argument>
             <argument type="service" id="doctrine_phpcr"/>
         </service>
-        <service id="sonata.media.manager.gallery" class="%sonata.media.manager.gallery.class%">
+        <service id="sonata.media.manager.gallery" class="%sonata.media.manager.gallery.class%" public="true">
             <argument>%sonata.media.gallery.class%</argument>
             <argument type="service" id="doctrine_phpcr"/>
         </service>

--- a/src/Resources/config/gaufrette.xml
+++ b/src/Resources/config/gaufrette.xml
@@ -56,12 +56,12 @@
         <service id="sonata.media.filesystem.replicate" class="Gaufrette\Filesystem">
             <argument type="service" id="sonata.media.adapter.filesystem.replicate"/>
         </service>
-        <service id="sonata.media.metadata.proxy" class="%sonata.media.metadata.proxy.class%">
+        <service id="sonata.media.metadata.proxy" class="%sonata.media.metadata.proxy.class%" public="true">
             <argument type="service" id="service_container"/>
         </service>
-        <service id="sonata.media.metadata.amazon" class="%sonata.media.metadata.amazon.class%">
+        <service id="sonata.media.metadata.amazon" class="%sonata.media.metadata.amazon.class%" public="true">
         </service>
-        <service id="sonata.media.metadata.noop" class="%sonata.media.metadata.noop.class%">
+        <service id="sonata.media.metadata.noop" class="%sonata.media.metadata.noop.class%" public="true">
         </service>
     </services>
 </container>

--- a/src/Resources/config/provider.xml
+++ b/src/Resources/config/provider.xml
@@ -21,7 +21,7 @@
         <service id="sonata.media.thumbnail.liip_imagine" class="%sonata.media.thumbnail.liip_imagine%">
             <argument type="service" id="liip_imagine.cache.manager" on-invalid="null"/>
         </service>
-        <service id="sonata.media.provider.image" class="%sonata.media.provider.image.class%">
+        <service id="sonata.media.provider.image" class="%sonata.media.provider.image.class%" public="true">
             <tag name="sonata.media.provider"/>
             <argument>sonata.media.provider.image</argument>
             <argument/>
@@ -39,7 +39,7 @@
                 </argument>
             </call>
         </service>
-        <service id="sonata.media.provider.file" class="%sonata.media.provider.file.class%">
+        <service id="sonata.media.provider.file" class="%sonata.media.provider.file.class%" public="true">
             <tag name="sonata.media.provider"/>
             <argument>sonata.media.provider.file</argument>
             <argument/>
@@ -56,7 +56,7 @@
                 </argument>
             </call>
         </service>
-        <service id="sonata.media.provider.youtube" class="%sonata.media.provider.youtube.class%">
+        <service id="sonata.media.provider.youtube" class="%sonata.media.provider.youtube.class%" public="true">
             <tag name="sonata.media.provider"/>
             <argument>sonata.media.provider.youtube</argument>
             <argument/>
@@ -73,7 +73,7 @@
                 </argument>
             </call>
         </service>
-        <service id="sonata.media.provider.dailymotion" class="%sonata.media.provider.dailymotion.class%">
+        <service id="sonata.media.provider.dailymotion" class="%sonata.media.provider.dailymotion.class%" public="true">
             <tag name="sonata.media.provider"/>
             <argument>sonata.media.provider.dailymotion</argument>
             <argument/>
@@ -89,7 +89,7 @@
                 </argument>
             </call>
         </service>
-        <service id="sonata.media.provider.vimeo" class="%sonata.media.provider.vimeo.class%">
+        <service id="sonata.media.provider.vimeo" class="%sonata.media.provider.vimeo.class%" public="true">
             <tag name="sonata.media.provider"/>
             <argument>sonata.media.provider.vimeo</argument>
             <argument/>


### PR DESCRIPTION
I am targeting this branch, because is a patch and backwards compatible.

Closes #1379

## Changelog

```markdown
### Fixed
- `sonata.media.manager.media` is now `public`
- `sonata.media.manager.gallery` is now `public`
- `sonata.media.metadata.proxy` is now `public`
- `sonata.media.metadata.amazon` is now `public`
- `sonata.media.metadata.noop` is now `public`
- `sonata.media.provider.image` is now `public`
- `sonata.media.provider.file` is now `public`
- `sonata.media.provider.youtube` is now `public`
- `sonata.media.provider.dailymotion` is now `public`
- `sonata.media.provider.vimeo` is now `public`
```

## Subject

Set providers, metadata and manager services public so applications using SonataMediaBundle can upgrade to Symfony 4.0.