### PR TITLE
Stop using Sonata\AdminBundle\Controller\CRUDController::render and use renderWithExtraParams

### DIFF
--- a/src/Controller/GalleryAdminController.php
+++ b/src/Controller/GalleryAdminController.php
@@ -35,7 +35,7 @@ class GalleryAdminController extends Controller
         $parameters['media_pool'] = $this->get('sonata.media.pool');
         $parameters['persistent_parameters'] = $this->admin->getPersistentParameters();
 
-        return parent::render($view, $parameters, $response);
+        return parent::renderWithExtraParams($view, $parameters, $response);
     }
 
     /**

--- a/src/Controller/MediaAdminController.php
+++ b/src/Controller/MediaAdminController.php
@@ -52,7 +52,7 @@ class MediaAdminController extends Controller
         $parameters['media_pool'] = $this->get('sonata.media.pool');
         $parameters['persistent_parameters'] = $this->admin->getPersistentParameters();
 
-        return parent::render($view, $parameters, $response);
+        return parent::renderWithExtraParams($view, $parameters, $response);
     }
 
     /**

--- a/tests/Controller/Api/GalleryControllerTest.php
+++ b/tests/Controller/Api/GalleryControllerTest.php
@@ -124,6 +124,9 @@ class GalleryControllerTest extends TestCase
         $this->assertSame([$media], $gController->getGalleryMediasAction(1));
     }
 
+    /**
+     * @group legacy
+     */
     public function testPostGalleryMediaGalleryhasmediaAction()
     {
         $media = $this->createMock(MediaInterface::class);
@@ -184,6 +187,9 @@ class GalleryControllerTest extends TestCase
         $this->assertSame(400, $view->getResponse()->getStatusCode(), 'Should return 400');
     }
 
+    /**
+     * @group legacy
+     */
     public function testPutGalleryMediaGalleryhasmediaAction()
     {
         $media = $this->createMock(MediaInterface::class);


### PR DESCRIPTION
I am targeting this branch, because is Deprecation and BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Make `Sonata\MediaBundle\Controller\MediaAdminController` use `renderWithExtraParams`
instead of the deprecated `render` from `Sonata\AdminBundle\Controller\CRUDController`
- Make `Sonata\MediaBundle\Controller\GalleryAdminController` use `renderWithExtraParams`
instead of the deprecated `render` from `Sonata\AdminBundle\Controller\CRUDController`
```

## Subject

Stop using Sonata\AdminBundle\Controller\CRUDController::render and use renderWithExtraParams