### PR TITLE
fix deleting previousProviderReference on edit for not new_on_update …

### DIFF
--- a/src/Form/DataTransformer/ProviderDataTransformer.php
+++ b/src/Form/DataTransformer/ProviderDataTransformer.php
@@ -87,9 +87,11 @@ class ProviderDataTransformer implements DataTransformerInterface, LoggerAwareIn
         // create a new media to avoid erasing other media or not ...
         $newMedia = $this->options['new_on_update'] ? new $this->class() : $media;
 
-        $newMedia->setProviderName($media->getProviderName());
-        $newMedia->setContext($media->getContext());
-        $newMedia->setBinaryContent($binaryContent);
+        if ($this->options['new_on_update']) {
+            $newMedia->setProviderName($media->getProviderName());
+            $newMedia->setContext($media->getContext());
+            $newMedia->setBinaryContent($binaryContent);
+        }
 
         if (!$newMedia->getProviderName() && $this->options['provider']) {
             $newMedia->setProviderName($this->options['provider']);

--- a/tests/Form/DataTransformer/ProviderDataTransformerTest.php
+++ b/tests/Form/DataTransformer/ProviderDataTransformerTest.php
@@ -36,7 +36,7 @@ class ProviderDataTransformerTest extends TestCase
         $pool = new Pool('default');
 
         $media = $this->createMock(MediaInterface::class);
-        $media->expects($this->exactly(3))->method('getProviderName')->will($this->returnValue('unknown'));
+        $media->expects($this->exactly(2))->method('getProviderName')->will($this->returnValue('unknown'));
         $media->expects($this->any())->method('getId')->will($this->returnValue(1));
         $media->expects($this->any())->method('getBinaryContent')->will($this->returnValue('xcs'));
 
@@ -55,7 +55,7 @@ class ProviderDataTransformerTest extends TestCase
         $pool->addProvider('default', $provider);
 
         $media = $this->createMock(MediaInterface::class);
-        $media->expects($this->exactly(3))->method('getProviderName')->will($this->returnValue('default'));
+        $media->expects($this->exactly(2))->method('getProviderName')->will($this->returnValue('default'));
         $media->expects($this->any())->method('getId')->will($this->returnValue(1));
         $media->expects($this->any())->method('getBinaryContent')->will($this->returnValue('xcs'));
 
@@ -128,7 +128,7 @@ class ProviderDataTransformerTest extends TestCase
         $pool->addProvider('default', $provider);
 
         $media = $this->createMock(MediaInterface::class);
-        $media->expects($this->exactly(3))->method('getProviderName')->will($this->returnValue('default'));
+        $media->expects($this->exactly(2))->method('getProviderName')->will($this->returnValue('default'));
         $media->expects($this->any())->method('getId')->will($this->returnValue(1));
         $media->expects($this->any())->method('getBinaryContent')->will($this->returnValue(new UploadedFile(__FILE__, 'ProviderDataTransformerTest')));
 
@@ -150,7 +150,7 @@ class ProviderDataTransformerTest extends TestCase
         $logger->expects($this->once())->method('error');
 
         $media = $this->createMock(MediaInterface::class);
-        $media->expects($this->exactly(3))->method('getProviderName')->will($this->returnValue('default'));
+        $media->expects($this->exactly(2))->method('getProviderName')->will($this->returnValue('default'));
         $media->expects($this->any())->method('getId')->will($this->returnValue(1));
         $media->expects($this->any())->method('getBinaryContent')->will($this->returnValue(new UploadedFile(__FILE__, 'ProviderDataTransformerTest')));
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this fixes a bug when on editing media old files are not deleting.

In case of bug fix, `3.x` **MUST** be targeted.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed  
Deleting old media file for update using option `new_on_update` as false
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

<!-- Describe your Pull Request content here -->
Using `new_on_update` option in `ProviderDataTransformer` as false, prevent to delete files, cause `previousProviderReference` will be set to nul. However thumbnails still are not deleting.