### PR TITLE
Force use existing translation strings for Media and Gallery

### DIFF
--- a/src/Admin/BaseMediaAdmin.php
+++ b/src/Admin/BaseMediaAdmin.php
@@ -34,6 +34,8 @@ abstract class BaseMediaAdmin extends AbstractAdmin
      */
     protected $categoryManager;
 
+    protected $classnameLabel = 'Media';
+
     /**
      * @param string                   $code
      * @param string                   $class

--- a/src/Admin/GalleryAdmin.php
+++ b/src/Admin/GalleryAdmin.php
@@ -26,6 +26,8 @@ class GalleryAdmin extends AbstractAdmin
      */
     protected $pool;
 
+    protected $classnameLabel = 'Gallery';
+
     /**
      * @param string $code
      * @param string $class


### PR DESCRIPTION
I am targeting this branch, because this is BC patch.

See https://github.com/sonata-project/media-orm-pack/issues/3

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Force use existing translation strings for Media/Gallery breadcrumbs in Admin panel
```

## Subject

If a last part of Media/Gallery class name differs from `Media` or `Gallery`, then `Admin` will try to use non-existing translation strings for breadcrumbs instead of `breadcrumb.link_media_list` or `breadcrumb.link_gallery_create`, i.e. it will use `breadcrumb.link_sonata_media_media_list` for `SonataMediaMedia` and `breadcrumb.link_sonata_media_gallery_create` for `SonataMediaGallery` classes.

With this PR `Admin` will be forced to use existing translation strings.