### PR TITLE
Remove all thumbnails before removing media

### DIFF
--- a/src/Provider/BaseProvider.php
+++ b/src/Provider/BaseProvider.php
@@ -187,6 +187,9 @@ abstract class BaseProvider implements MediaProviderInterface
      */
     public function preRemove(MediaInterface $media)
     {
+        if ($this->requireThumbnails()) {
+            $this->thumbnail->delete($this, $media);
+        }
     }
 
     /**
@@ -198,10 +201,6 @@ abstract class BaseProvider implements MediaProviderInterface
 
         if ($this->getFilesystem()->has($path)) {
             $this->getFilesystem()->delete($path);
-        }
-
-        if ($this->requireThumbnails()) {
-            $this->thumbnail->delete($this, $media);
         }
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because the resized images was not deleted when the origine image was deleted.

## Changelog

- Remove all resized images when the origine image was deleted.

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed

- Moved a code block from BaseProvider::postRemove to BaseProvider::preRemove

```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

## Subject

<!-- Describe your Pull Request content here -->

We should delete all resized images when the original image has been removed, but sonata media just to clear the original image and keep the other resized images in the upload folder. So this pull request will fix this problem by changing some codes in the class BaseProvider.