### PR TITLE
Add getters to FileProvider

### DIFF
--- a/src/Provider/FileProvider.php
+++ b/src/Provider/FileProvider.php
@@ -89,7 +89,7 @@ class FileProvider extends BaseProvider
     }
 
     /**
-     * @return array
+     * @return string[]
      */
     public function getAllowedExtensions()
     {
@@ -97,7 +97,7 @@ class FileProvider extends BaseProvider
     }
 
     /**
-     * @return array
+     * @return string[]
      */
     public function getAllowedMimeTypes()
     {

--- a/src/Provider/FileProvider.php
+++ b/src/Provider/FileProvider.php
@@ -89,6 +89,22 @@ class FileProvider extends BaseProvider
     }
 
     /**
+     * @return array
+     */
+    public function getAllowedExtensions()
+    {
+        return $this->allowedExtensions;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAllowedMimeTypes()
+    {
+        return $this->allowedMimeTypes;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function buildEditForm(FormMapper $formMapper)


### PR DESCRIPTION
I am targeting this branch, because it adds helpful getters to FileProvider class.

## Changelog

```markdown
### Added
- Added getters for `allowedExtensions` and  `allowedMimeTypes` properties
```

Useful when we inject the provider in twig.