### PR TITLE
 Fixed wrong PHPDoc 

### DIFF
--- a/docs/reference/creating_a_provider_class.rst
+++ b/docs/reference/creating_a_provider_class.rst
@@ -193,8 +193,8 @@ The ``MediaAdmin`` delegates this management to the media provider.
         $media->setContentType('video/x-flv');
         $media->setProviderStatus(Media::STATUS_OK);
 
-        $media->setCreatedAt(new \Datetime());
-        $media->setUpdatedAt(new \Datetime());
+        $media->setCreatedAt(new \DateTime());
+        $media->setUpdatedAt(new \DateTime());
     }
 
 The update method should only update data that cannot be managed by the user.
@@ -217,7 +217,7 @@ The update method should only update data that cannot be managed by the user.
         $media->setWidth($metadata['width']);
         $media->setProviderStatus(Media::STATUS_OK);
 
-        $media->setUpdatedAt(new \Datetime());
+        $media->setUpdatedAt(new \DateTime());
     }
 
 At this point, the ``Media`` object is populated with data from the vimeo's

--- a/src/Model/Gallery.php
+++ b/src/Model/Gallery.php
@@ -36,12 +36,12 @@ abstract class Gallery implements GalleryInterface, GalleryMediaCollectionInterf
     protected $enabled;
 
     /**
-     * @var \Datetime
+     * @var \DateTime|null
      */
     protected $updatedAt;
 
     /**
-     * @var \Datetime
+     * @var \DateTime|null
      */
     protected $createdAt;
 

--- a/src/Model/GalleryHasMedia.php
+++ b/src/Model/GalleryHasMedia.php
@@ -14,12 +14,12 @@ namespace Sonata\MediaBundle\Model;
 abstract class GalleryHasMedia implements GalleryHasMediaInterface
 {
     /**
-     * @var MediaInterface
+     * @var MediaInterface|null
      */
     protected $media;
 
     /**
-     * @var GalleryInterface
+     * @var GalleryInterface|null
      */
     protected $gallery;
 
@@ -29,12 +29,12 @@ abstract class GalleryHasMedia implements GalleryHasMediaInterface
     protected $position = 0;
 
     /**
-     * @var \DateTime
+     * @var \DateTime|null
      */
     protected $updatedAt;
 
     /**
-     * @var \DateTime
+     * @var \DateTime|null
      */
     protected $createdAt;
 

--- a/src/Model/GalleryHasMediaInterface.php
+++ b/src/Model/GalleryHasMediaInterface.php
@@ -29,22 +29,22 @@ interface GalleryHasMediaInterface
     public function getEnabled();
 
     /**
-     * @param GalleryInterface $gallery
+     * @param GalleryInterface|null $gallery
      */
     public function setGallery(GalleryInterface $gallery = null);
 
     /**
-     * @return GalleryInterface
+     * @return GalleryInterface|null
      */
     public function getGallery();
 
     /**
-     * @param MediaInterface $media
+     * @param MediaInterface|null $media
      */
     public function setMedia(MediaInterface $media = null);
 
     /**
-     * @return MediaInterface
+     * @return MediaInterface|null
      */
     public function getMedia();
 
@@ -66,7 +66,7 @@ interface GalleryHasMediaInterface
     public function setUpdatedAt(\DateTime $updatedAt = null);
 
     /**
-     * @return \DateTime
+     * @return \DateTime|null
      */
     public function getUpdatedAt();
 
@@ -76,7 +76,7 @@ interface GalleryHasMediaInterface
     public function setCreatedAt(\DateTime $createdAt = null);
 
     /**
-     * @return \DateTime
+     * @return \DateTime|null
      */
     public function getCreatedAt();
 }

--- a/src/Model/GalleryInterface.php
+++ b/src/Model/GalleryInterface.php
@@ -61,28 +61,28 @@ interface GalleryInterface
     /**
      * Set updated_at.
      *
-     * @param \Datetime $updatedAt
+     * @param \DateTime|null $updatedAt
      */
     public function setUpdatedAt(\DateTime $updatedAt = null);
 
     /**
      * Get updated_at.
      *
-     * @return \Datetime $updatedAt
+     * @return \DateTime|null $updatedAt
      */
     public function getUpdatedAt();
 
     /**
      * Set created_at.
      *
-     * @param \Datetime $createdAt
+     * @param \DateTime|null $createdAt
      */
     public function setCreatedAt(\DateTime $createdAt = null);
 
     /**
      * Get created_at.
      *
-     * @return \Datetime $createdAt
+     * @return \DateTime|null $createdAt
      */
     public function getCreatedAt();
 

--- a/src/Model/MediaInterface.php
+++ b/src/Model/MediaInterface.php
@@ -275,21 +275,21 @@ interface MediaInterface
     /**
      * Set cdn_flush_at.
      *
-     * @param \Datetime $cdnFlushAt
+     * @param \DateTime $cdnFlushAt
      */
     public function setCdnFlushAt(\DateTime $cdnFlushAt = null);
 
     /**
      * Get cdn_flush_at.
      *
-     * @return \Datetime $cdnFlushAt
+     * @return \DateTime $cdnFlushAt
      */
     public function getCdnFlushAt();
 
     /**
      * Set updated_at.
      *
-     * @param \Datetime $updatedAt
+     * @param \DateTime $updatedAt
      */
     public function setUpdatedAt(\DateTime $updatedAt = null);
 
@@ -303,14 +303,14 @@ interface MediaInterface
     /**
      * Set created_at.
      *
-     * @param \Datetime $createdAt
+     * @param \DateTime $createdAt
      */
     public function setCreatedAt(\DateTime $createdAt = null);
 
     /**
      * Get created_at.
      *
-     * @return \Datetime $createdAt
+     * @return \DateTime $createdAt
      */
     public function getCreatedAt();
 

--- a/src/Model/MediaInterface.php
+++ b/src/Model/MediaInterface.php
@@ -277,7 +277,7 @@ interface MediaInterface
      *
      * @param \Datetime $cdnFlushAt
      */
-    public function setCdnFlushAt(\Datetime $cdnFlushAt = null);
+    public function setCdnFlushAt(\DateTime $cdnFlushAt = null);
 
     /**
      * Get cdn_flush_at.
@@ -291,12 +291,12 @@ interface MediaInterface
      *
      * @param \Datetime $updatedAt
      */
-    public function setUpdatedAt(\Datetime $updatedAt = null);
+    public function setUpdatedAt(\DateTime $updatedAt = null);
 
     /**
      * Get updated_at.
      *
-     * @return \Datetime $updatedAt
+     * @return \DateTime $updatedAt
      */
     public function getUpdatedAt();
 
@@ -305,7 +305,7 @@ interface MediaInterface
      *
      * @param \Datetime $createdAt
      */
-    public function setCreatedAt(\Datetime $createdAt = null);
+    public function setCreatedAt(\DateTime $createdAt = null);
 
     /**
      * Get created_at.

--- a/src/Provider/BaseProvider.php
+++ b/src/Provider/BaseProvider.php
@@ -305,8 +305,8 @@ abstract class BaseProvider implements MediaProviderInterface
      */
     public function prePersist(MediaInterface $media)
     {
-        $media->setCreatedAt(new \Datetime());
-        $media->setUpdatedAt(new \Datetime());
+        $media->setCreatedAt(new \DateTime());
+        $media->setUpdatedAt(new \DateTime());
     }
 
     /**
@@ -314,7 +314,7 @@ abstract class BaseProvider implements MediaProviderInterface
      */
     public function preUpdate(MediaInterface $media)
     {
-        $media->setUpdatedAt(new \Datetime());
+        $media->setUpdatedAt(new \DateTime());
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed case typo for \DateTime 
```


## Subject
Some PHPDoc fixes and one typo fix.