### PR TITLE
Allow usage of AWS default credential provider chain for S3

### DIFF
--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -459,7 +459,6 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
 
             if (3 === $config['filesystem']['s3']['sdk_version']) {
                 $arguments = [
-                    'credentials' => false,
                     'region' => $config['filesystem']['s3']['region'],
                     'version' => $config['filesystem']['s3']['version'],
                 ];

--- a/tests/DependencyInjection/SonataMediaExtensionTest.php
+++ b/tests/DependencyInjection/SonataMediaExtensionTest.php
@@ -235,12 +235,11 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
                             'region' => 'region',
                             'version' => 'version',
                             'secretKey' => null,
-                            'accessKey' => 'null',
+                            'accessKey' => null,
                         ],
                     ],
                 ],
                 [
-                    'credentials' => false,
                     'region' => 'region',
                     'version' => 'version',
                 ],


### PR DESCRIPTION
I am targeting this branch, because this is a BC compatible fix.

## Changelog
```markdown
### Fixed
- Fixed S3 credentials set to false when no credentials are provided
```

## Subject

The PR #1431 added the possibility to configure S3 without credentials in order to rely on the IAM roles of instances for authorizations. 

However, setting the credentials key to false tells AWS to **not** use any credentials in the requests. To use the default credential provider chain, and let the SDK do proper authent with env vars or IAM roles, we must not provide the credential option as explained in the [SDK documentation](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_configuration.html#credentials).
