### PR TITLE
Remove useless duplicated code

### DIFF
--- a/src/Provider/ImageProvider.php
+++ b/src/Provider/ImageProvider.php
@@ -130,17 +130,6 @@ class ImageProvider extends FileProvider
     /**
      * {@inheritdoc}
      */
-    public function getReferenceImage(MediaInterface $media)
-    {
-        return sprintf('%s/%s',
-            $this->generatePath($media),
-            $media->getProviderReference()
-        );
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function updateMetadata(MediaInterface $media, $force = true)
     {
         try {


### PR DESCRIPTION
I am targeting this branch, because it removes useless duplicated code. The code is already the same in the `FileProvider::getReferenceImage` parent method


