### PR TITLE
align MediaAdminController test code with parameter requirement

### DIFF
--- a/tests/Controller/MediaAdminControllerTest.php
+++ b/tests/Controller/MediaAdminControllerTest.php
@@ -94,7 +94,6 @@ class MediaAdminControllerTest extends TestCase
         $this->admin->checkAccess('create')->shouldBeCalled();
         $this->request->get('provider')->willReturn(true);
         $this->request->isMethod('get')->willReturn(true);
-
         $response = $this->controller->createAction($this->request->reveal());
 
         $this->assertInstanceOf(Response::class, $response);
@@ -172,13 +171,13 @@ class MediaAdminControllerTest extends TestCase
         $form = $this->prophesize(Form::class);
         $formView = $this->prophesize(FormView::class);
 
-        $this->configureSetFormTheme($formView->reveal(), 'formTheme');
+        $this->configureSetFormTheme($formView->reveal(), ['formTheme']);
         $this->admin->hasActiveSubClass()->willReturn(false);
         $this->admin->getClass()->willReturn($class);
         $this->admin->getNewInstance()->willReturn($object->reveal());
         $this->admin->setSubject($object->reveal())->shouldBeCalled();
         $this->admin->getForm()->willReturn($form->reveal());
-        $this->admin->getFormTheme()->willReturn('formTheme');
+        $this->admin->getFormTheme()->willReturn(['formTheme']);
         $this->admin->getTemplate('edit')->willReturn('template');
         $form->createView()->willReturn($formView->reveal());
         $form->setData($object->reveal())->shouldBeCalled();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because the test is broken for code in the branch.

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

## Subject

The admin bundle CRUDController had its setFormTheme signature updated in https://github.com/sonata-project/SonataAdminBundle/commit/06e1e7ffd837fcf117bd0ee317f885fe93a3168c
due to it nwo enforcing an array the test has to be adjusted.
This doesn't seem like a BC break as the docblock did state array before
