### PR TITLE
LiipImagineThumbnail add support for generatePrivateUrl and delete

### DIFF
--- a/src/DependencyInjection/Compiler/FilterResolverRegistryCompilerPass.php
+++ b/src/DependencyInjection/Compiler/FilterResolverRegistryCompilerPass.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Sonata Project package.
  *

--- a/src/DependencyInjection/Compiler/FilterResolverRegistryCompilerPass.php
+++ b/src/DependencyInjection/Compiler/FilterResolverRegistryCompilerPass.php
@@ -11,11 +11,11 @@
 
 namespace SonataMediaBundle\DependencyInjection\Compiler;
 
-use Liip\ImagineBundle\DependencyInjection\Compiler\AbstractCompilerPass;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class FilterResolverRegistryCompilerPass extends AbstractCompilerPass
+final class FilterResolverRegistryCompilerPass implements CompilerPassInterface
 {
     /**
      * {@inheritdoc}
@@ -29,7 +29,6 @@ class FilterResolverRegistryCompilerPass extends AbstractCompilerPass
 
             foreach ($tags as $id => $tag) {
                 $manager->addMethodCall('addResolver', [$tag[0]['resolver'], new Reference($id)]);
-                $this->log($container, 'Registered cache resolver: %s', $id);
             }
         }
     }

--- a/src/DependencyInjection/Compiler/FilterResolverRegistryCompilerPass.php
+++ b/src/DependencyInjection/Compiler/FilterResolverRegistryCompilerPass.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SonataMediaBundle\DependencyInjection\Compiler;
+
+use Liip\ImagineBundle\DependencyInjection\Compiler\AbstractCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class FilterResolverRegistryCompilerPass extends AbstractCompilerPass
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $tags = $container->findTaggedServiceIds('liip_imagine.cache.resolver');
+
+        if (count($tags) > 0 && $container->hasDefinition('sonata.media.liip_imagine.filter_resolver_registry')) {
+            $manager = $container->getDefinition('sonata.media.liip_imagine.filter_resolver_registry');
+
+            foreach ($tags as $id => $tag) {
+                $manager->addMethodCall('addResolver', [$tag[0]['resolver'], new Reference($id)]);
+                $this->log($container, 'Registered cache resolver: %s', $id);
+            }
+        }
+    }
+}

--- a/src/DependencyInjection/Compiler/FilterResolverRegistryCompilerPass.php
+++ b/src/DependencyInjection/Compiler/FilterResolverRegistryCompilerPass.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace SonataMediaBundle\DependencyInjection\Compiler;
 
 use Liip\ImagineBundle\DependencyInjection\Compiler\AbstractCompilerPass;
@@ -15,7 +24,7 @@ class FilterResolverRegistryCompilerPass extends AbstractCompilerPass
     {
         $tags = $container->findTaggedServiceIds('liip_imagine.cache.resolver');
 
-        if (count($tags) > 0 && $container->hasDefinition('sonata.media.liip_imagine.filter_resolver_registry')) {
+        if (\count($tags) > 0 && $container->hasDefinition('sonata.media.liip_imagine.filter_resolver_registry')) {
             $manager = $container->getDefinition('sonata.media.liip_imagine.filter_resolver_registry');
 
             foreach ($tags as $id => $tag) {

--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -127,8 +127,8 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
             $loader->load('seo_block.xml');
         }
 
-        if (!isset($bundles['LiipImagineBundle'])) {
-            $container->removeDefinition('sonata.media.thumbnail.liip_imagine');
+        if (isset($bundles['LiipImagineBundle'])) {
+            $loader->load('liip_imagine.xml');
         }
 
         if ($this->isClassificationEnabled($config)) {

--- a/src/LiipImagine/FilterResolverRegistry.php
+++ b/src/LiipImagine/FilterResolverRegistry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Sonata Project package.
  *

--- a/src/LiipImagine/FilterResolverRegistry.php
+++ b/src/LiipImagine/FilterResolverRegistry.php
@@ -30,8 +30,7 @@ final class FilterResolverRegistry implements ResolverRegistryInterface
     private $defaultResolver;
 
     /**
-     * @param FilterConfiguration $filterConfiguration
-     * @param string              $defaultResolver
+     * @param string $defaultResolver
      */
     public function __construct(FilterConfiguration $filterConfiguration, $defaultResolver = 'default')
     {

--- a/src/LiipImagine/FilterResolverRegistry.php
+++ b/src/LiipImagine/FilterResolverRegistry.php
@@ -14,7 +14,7 @@ namespace Sonata\MediaBundle\LiipImagine;
 use Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface;
 use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
 
-class FilterResolverRegistry implements ResolverRegistryInterface
+final class FilterResolverRegistry implements ResolverRegistryInterface
 {
     /**
      * @var ResolverInterface[]
@@ -43,7 +43,7 @@ class FilterResolverRegistry implements ResolverRegistryInterface
     {
         if (isset($this->resolvers[$name])) {
             throw new \LogicException(sprintf(
-                'There is already a resolver `%s` registered with name `%s`',
+                'There is already a resolver "%s" registered with name "%s"',
                 \get_class($this->resolvers[$name]),
                 $name
             ));
@@ -58,7 +58,7 @@ class FilterResolverRegistry implements ResolverRegistryInterface
         $name = empty($config['cache']) ? $this->defaultResolver : $config['cache'];
         if (!isset($this->resolvers[$name])) {
             throw new \OutOfBoundsException(sprintf(
-                'No cache resolver `%s registered, verify your resolver tags configuration',
+                'No "%s" cache resolver registered, verify your resolver tags configuration',
                 $name
             ));
         }

--- a/src/LiipImagine/FilterResolverRegistry.php
+++ b/src/LiipImagine/FilterResolverRegistry.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Sonata\MediaBundle\LiipImagine;
+
+use Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface;
+use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
+
+class FilterResolverRegistry implements ResolverRegistryInterface
+{
+    /**
+     * @var ResolverInterface[]
+     */
+    private $resolvers;
+    /**
+     * @var FilterConfiguration
+     */
+    private $filterConfiguration;
+    /**
+     * @var string
+     */
+    private $defaultResolver;
+
+    /**
+     * @param FilterConfiguration $filterConfiguration
+     * @param string              $defaultResolver
+     */
+    public function __construct(FilterConfiguration $filterConfiguration, $defaultResolver = 'default')
+    {
+        $this->filterConfiguration = $filterConfiguration;
+        $this->defaultResolver = $defaultResolver;
+    }
+
+
+    public function addResolver($name, ResolverInterface $resolver)
+    {
+        if (isset($this->resolvers[$name])) {
+            throw new \LogicException(sprintf(
+                'There is already a resolver `%s` registered with name `%s`',
+                get_class($this->resolvers[$name]),
+                $name
+            ));
+        }
+
+        $this->resolvers[$name] = $resolver;
+    }
+
+    public function getResolver($name)
+    {
+        $config = $this->filterConfiguration->get($name);
+        $name = empty($config['cache']) ? $this->defaultResolver : $config['cache'];
+        if (!isset($this->resolvers[$name])) {
+            throw new \OutOfBoundsException(sprintf(
+                'No cache resolver `%s registered, verify your resolver tags configuration',
+                $name
+            ));
+        }
+
+        return $this->resolvers[$name];
+    }
+}

--- a/src/LiipImagine/FilterResolverRegistry.php
+++ b/src/LiipImagine/FilterResolverRegistry.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Sonata\MediaBundle\LiipImagine;
 
 use Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface;
@@ -30,13 +39,12 @@ class FilterResolverRegistry implements ResolverRegistryInterface
         $this->defaultResolver = $defaultResolver;
     }
 
-
     public function addResolver($name, ResolverInterface $resolver)
     {
         if (isset($this->resolvers[$name])) {
             throw new \LogicException(sprintf(
                 'There is already a resolver `%s` registered with name `%s`',
-                get_class($this->resolvers[$name]),
+                \get_class($this->resolvers[$name]),
                 $name
             ));
         }

--- a/src/LiipImagine/ResolverRegistryInterface.php
+++ b/src/LiipImagine/ResolverRegistryInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Sonata Project package.
  *

--- a/src/LiipImagine/ResolverRegistryInterface.php
+++ b/src/LiipImagine/ResolverRegistryInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Sonata\MediaBundle\LiipImagine;
+
+use Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface;
+
+interface ResolverRegistryInterface
+{
+    /**
+     * @param string $name
+     *
+     * @return ResolverInterface
+     * @throws \OutOfBoundsException when resolver cannot be found in the registry
+     */
+    public function getResolver($name);
+}

--- a/src/LiipImagine/ResolverRegistryInterface.php
+++ b/src/LiipImagine/ResolverRegistryInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Sonata\MediaBundle\LiipImagine;
 
 use Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface;
@@ -9,8 +18,9 @@ interface ResolverRegistryInterface
     /**
      * @param string $name
      *
-     * @return ResolverInterface
      * @throws \OutOfBoundsException when resolver cannot be found in the registry
+     *
+     * @return ResolverInterface
      */
     public function getResolver($name);
 }

--- a/src/Resources/config/liip_imagine.xml
+++ b/src/Resources/config/liip_imagine.xml
@@ -6,7 +6,7 @@
     <services>
         <service id="sonata.media.thumbnail.liip_imagine" class="%sonata.media.thumbnail.liip_imagine%">
             <argument type="service" id="liip_imagine.cache.manager" on-invalid="null"/>
-            <argument type="service" id="inventis.media.liip_imagine.filter_resolver_registry" on-invalid="null"/>
+            <argument type="service" id="sonata.media.liip_imagine.filter_resolver_registry" on-invalid="null"/>
         </service>
         <service id="sonata.media.liip_imagine.filter_resolver_registry" class="Sonata\MediaBundle\LiipImagine\FilterResolverRegistry">
             <argument type="service" id="liip_imagine.filter.configuration" />

--- a/src/Resources/config/liip_imagine.xml
+++ b/src/Resources/config/liip_imagine.xml
@@ -10,7 +10,7 @@
         </service>
         <service id="sonata.media.liip_imagine.filter_resolver_registry" class="Sonata\MediaBundle\LiipImagine\FilterResolverRegistry">
             <argument type="service" id="liip_imagine.filter.configuration" />
-            <argument type="string" id="%liip_imagine.cache.resolver.default%" />
+            <argument type="string">%liip_imagine.cache.resolver.default%</argument>
         </service>
     </services>
 </container>

--- a/src/Resources/config/liip_imagine.xml
+++ b/src/Resources/config/liip_imagine.xml
@@ -9,7 +9,7 @@
             <argument type="service" id="sonata.media.liip_imagine.filter_resolver_registry" on-invalid="null"/>
         </service>
         <service id="sonata.media.liip_imagine.filter_resolver_registry" class="Sonata\MediaBundle\LiipImagine\FilterResolverRegistry">
-            <argument type="service" id="liip_imagine.filter.configuration" />
+            <argument type="service" id="liip_imagine.filter.configuration"/>
             <argument type="string">%liip_imagine.cache.resolver.default%</argument>
         </service>
     </services>

--- a/src/Resources/config/liip_imagine.xml
+++ b/src/Resources/config/liip_imagine.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <parameters>
+        <parameter key="sonata.media.thumbnail.liip_imagine">Sonata\MediaBundle\Thumbnail\LiipImagineThumbnail</parameter>
+    </parameters>
+    <services>
+        <service id="sonata.media.thumbnail.liip_imagine" class="%sonata.media.thumbnail.liip_imagine%">
+            <argument type="service" id="liip_imagine.cache.manager" on-invalid="null"/>
+            <argument type="service" id="inventis.media.liip_imagine.filter_resolver_registry" on-invalid="null"/>
+        </service>
+        <service id="sonata.media.liip_imagine.filter_resolver_registry" class="Sonata\MediaBundle\LiipImagine\FilterResolverRegistry">
+            <argument type="service" id="liip_imagine.filter.configuration" />
+            <argument type="string" id="%liip_imagine.cache.resolver.default%" />
+        </service>
+    </services>
+</container>

--- a/src/Resources/config/provider.xml
+++ b/src/Resources/config/provider.xml
@@ -8,7 +8,6 @@
         <parameter key="sonata.media.provider.vimeo.class">Sonata\MediaBundle\Provider\VimeoProvider</parameter>
         <parameter key="sonata.media.thumbnail.format">Sonata\MediaBundle\Thumbnail\FormatThumbnail</parameter>
         <parameter key="sonata.media.thumbnail.format.default">jpg</parameter>
-        <parameter key="sonata.media.thumbnail.liip_imagine">Sonata\MediaBundle\Thumbnail\LiipImagineThumbnail</parameter>
         <parameter key="sonata.media.pool.class">Sonata\MediaBundle\Provider\Pool</parameter>
     </parameters>
     <services>
@@ -18,9 +17,6 @@
         <service id="%sonata.media.pool.class%" alias="sonata.media.pool"/>
         <service id="sonata.media.thumbnail.format" class="%sonata.media.thumbnail.format%">
             <argument type="string">%sonata.media.thumbnail.format.default%</argument>
-        </service>
-        <service id="sonata.media.thumbnail.liip_imagine" class="%sonata.media.thumbnail.liip_imagine%">
-            <argument type="service" id="liip_imagine.cache.manager" on-invalid="null"/>
         </service>
         <service id="sonata.media.provider.image" class="%sonata.media.provider.image.class%" public="true">
             <tag name="sonata.media.provider"/>

--- a/src/SonataMediaBundle.php
+++ b/src/SonataMediaBundle.php
@@ -23,6 +23,7 @@ use Sonata\MediaBundle\Form\Type\ApiGalleryHasMediaType;
 use Sonata\MediaBundle\Form\Type\ApiGalleryType;
 use Sonata\MediaBundle\Form\Type\ApiMediaType;
 use Sonata\MediaBundle\Form\Type\MediaType;
+use SonataMediaBundle\DependencyInjection\Compiler\FilterResolverRegistryCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -37,6 +38,9 @@ class SonataMediaBundle extends Bundle
         $container->addCompilerPass(new GlobalVariablesCompilerPass());
         $container->addCompilerPass(new SecurityContextCompilerPass());
         $container->addCompilerPass(new ThumbnailCompilerPass());
+        if ($container->hasExtension('liip_imagine')) {
+            $container->addCompilerPass(new FilterResolverRegistryCompilerPass());
+        }
 
         $this->registerFormMapping();
     }

--- a/src/Thumbnail/LiipImagineThumbnail.php
+++ b/src/Thumbnail/LiipImagineThumbnail.php
@@ -54,7 +54,7 @@ class LiipImagineThumbnail implements ThumbnailInterface
         $this->cacheManager = $cacheManager;
         if (!$resolverRegistry instanceof ResolverRegistryInterface) {
             @trigger_error(sprintf(
-                'Using %s without a %s is deprecated since version 3.16 and will be removed in 4.0.',
+                'Using %s without a %s is deprecated since version 3.16 and will no longer be possible in 4.0.',
                 __CLASS__,
                 ResolverRegistryInterface::class
             ), E_USER_DEPRECATED);
@@ -98,7 +98,7 @@ class LiipImagineThumbnail implements ThumbnailInterface
         }
         if (!$this->resolverRegistry instanceof ResolverRegistryInterface) {
             throw new \RuntimeException(sprintf(
-                'Cannot generate private url for LiipImagine, use the in 3.16 added %s to add support.',
+                'Cannot generate private url for LiipImagine, use the "%s" added in 3.16 to add support.',
                 ResolverRegistryInterface::class
             ));
         }

--- a/tests/Thumbnail/LiipImagineThumbnailTest.php
+++ b/tests/Thumbnail/LiipImagineThumbnailTest.php
@@ -17,7 +17,9 @@ use Gaufrette\Adapter\InMemory;
 use Gaufrette\File;
 use Gaufrette\Filesystem;
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;
+use Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface;
 use PHPUnit\Framework\TestCase;
+use Sonata\MediaBundle\LiipImagine\ResolverRegistryInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\MediaBundle\Resizer\ResizerInterface;
@@ -28,6 +30,84 @@ use Symfony\Component\Routing\RouterInterface;
 class LiipImagineThumbnailTest extends TestCase
 {
     public function testGenerate(): void
+    {
+        $cacheManager = $this->prophesize(CacheManager::class);
+        $cacheManager->getBrowserPath()->willReturn('cache/media/default/0011/24/ASDASDAS.png');
+        $resolver = $this->prophesize(ResolverInterface::class);
+        $resolver->remove(
+            ['default/0011/24/ASDASDAS.png'],
+            ['mycontext_medium']
+        )->shouldBeCalled();
+        $resolver->resolve(
+            'default/0011/24/ASDASDAS.png',
+            'mycontext_medium'
+        )->willReturn('/my/private/path/default/0011/24/ASDASDAS.png');
+        $resolverRegistry = $this->prophesize(ResolverRegistryInterface::class);
+        $resolverRegistry->getResolver('mycontext_medium')->willReturn($resolver->reveal());
+
+        $thumbnail = new LiipImagineThumbnail($cacheManager, $resolverRegistry->reveal());
+
+        $filesystem = new Filesystem(new InMemory(['myfile' => 'content']));
+        $referenceFile = new File('myfile', $filesystem);
+
+        $formats = [
+            'admin' => ['height' => 50, 'width' => 50, 'quality' => 100],
+            'mycontext_medium' => ['height' => 500, 'width' => 500, 'quality' => 100],
+            'anothercontext_large' => ['height' => 500, 'width' => 500, 'quality' => 100],
+        ];
+
+        $resizer = $this->prophesize(ResizerInterface::class);
+        $resizer->resize()->willReturn(true);
+
+        $media = new Media();
+        $media->setName('ASDASDAS.png');
+        $media->setProviderReference('ASDASDAS.png');
+        $media->setId(1023456);
+        $media->setContext('default');
+
+        $provider = $this->prophesize(MediaProviderInterface::class);
+        $provider->requireThumbnails()->willReturn(true);
+        $provider->getReferenceFile()->willReturn($referenceFile);
+        $provider->getFormats()->willReturn($formats);
+        $provider->getResizer()->willReturn($resizer);
+        $provider->generatePrivateUrl()->willReturn('/my/private/path');
+        $provider->generatePublicUrl()->willReturn('/my/public/path');
+        $provider->getFilesystem()->willReturn($filesystem);
+        $provider->getReferenceImage($media)->willReturn('default/0011/24/ASDASDAS.png');
+        $provider->getCdnPath(
+            'default/0011/24/ASDASDAS.png',
+            null
+        )->willReturn('cache/media/default/0011/24/ASDASDAS.png');
+
+        $thumbnail->generate($provider->reveal(), $media);
+        $this->assertSame('default/0011/24/ASDASDAS.png', $thumbnail->generatePublicUrl(
+            $provider->reveal(),
+            $media,
+            MediaProviderInterface::FORMAT_ADMIN
+        ));
+        $this->assertSame('cache/media/default/0011/24/ASDASDAS.png', $thumbnail->generatePublicUrl(
+            $provider->reveal(),
+            $media,
+            'mycontext_medium'
+        ));
+        $this->assertSame('/my/private/path/default/0011/24/ASDASDAS.png', $thumbnail->generatePrivateUrl(
+            $provider->reveal(),
+            $media,
+            'mycontext_medium'
+        ));
+        // trigger prophecy remove assertion
+        $thumbnail->delete(
+            $provider->reveal(),
+            $media,
+            'mycontext_medium'
+        );
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Using Sonata\MediaBundle\Thumbnail\LiipImagineThumbnail without a Sonata\MediaBundle\LiipImagine\ResolverRegistryInterface is deprecated since version 3.16 and will be removed in 4.0.
+     */
+    public function testAnotherLegacyGenerate()
     {
         $cacheManager = $this->prophesize(CacheManager::class);
         $cacheManager->getBrowserPath()->willReturn('cache/media/default/0011/24/ASDASDAS.png');

--- a/tests/Thumbnail/LiipImagineThumbnailTest.php
+++ b/tests/Thumbnail/LiipImagineThumbnailTest.php
@@ -105,7 +105,7 @@ class LiipImagineThumbnailTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Using Sonata\MediaBundle\Thumbnail\LiipImagineThumbnail without a Sonata\MediaBundle\LiipImagine\ResolverRegistryInterface is deprecated since version 3.16 and will be removed in 4.0.
+     * @expectedDeprecation Using Sonata\MediaBundle\Thumbnail\LiipImagineThumbnail without a Sonata\MediaBundle\LiipImagine\ResolverRegistryInterface is deprecated since version 3.16 and will no longer be possible in 4.0.
      */
     public function testAnotherLegacyGenerate()
     {


### PR DESCRIPTION
As described in #1467 updating media would fail due to not being able
to generate a private url for liip imagine thumbnails as they must be
flushed on the CDN

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because the implementation in it is currently broken.

Closes #1467

## Changelog


```markdown
### Added
- Added `\Sonata\MediaBundle\LiipImagine\ResolverRegistryInterface` to generate cache paths for LiipImagineThumbnail based on format
- Added support for thumbnail removal when using `LiipImagineThumbnail`

### Changed

### Deprecated
- The use of `\Sonata\MediaBundle\Thumbnail\LiipImagineThumbnail` without a second argument `\Sonata\MediaBundle\LiipImagine\ResolverRegistryInterface`

### Fixed
- Updating existing media would always trigger a `RuntimeException` when using `LiipImagineThumbnail` for thumbnail generation

```

    
## To do
    
- [ ] Update the documentation
- [ ] Add an upgrade note


## Subject

adds support for private url generation and thumbnail removal as the current implementation lacks both crucial features
