### PR TITLE
Prevent formatter v4 from being installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "liip/imagine-bundle": "<1.9",
         "sonata-project/block-bundle": "<3.11 || >=4.0",
         "sonata-project/classification-bundle": "<3.0 || >= 5.0",
-        "sonata-project/formatter-bundle": "<3.2",
+        "sonata-project/formatter-bundle": "<3.2 || >= 4.0",
         "sonata-project/notification-bundle": "<3.3",
         "sonata-project/seo-bundle": "<2.1 || >=3.0",
         "symfony/monolog-bundle": "<2.4"


### PR DESCRIPTION
I am targeting this branch, because this is a patch.

Closes https://github.com/sonata-project/SonataFormatterBundle/issues/367

## Changelog

```markdown
### Fixed
- Prevent incompatible `sonata-project/formatter-bundle` 4 from being installed
```

## Subject

The media bundle is not yet compatible with it, there is at least
`FormatterMediaExtension::getTwigExtension()` that needs a signature
change.