### PR TITLE
Allow gaufrette 0.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "guzzlehttp/psr7": "^1.0",
         "imagine/imagine": "^0.6 || ^0.7",
         "jms/serializer-bundle": "^1.0 || ^2.0",
-        "knplabs/gaufrette": "^0.3 || ^0.4 || ^0.5 || ^0.6",
+        "knplabs/gaufrette": "^0.3 || ^0.4 || ^0.5 || ^0.6 || ^0.7",
         "kriswallsmith/buzz": "^0.15 || ^0.16",
         "psr/log": "^1.0",
         "sonata-project/core-bundle": "^3.9",


### PR DESCRIPTION
I am targeting this branch, because this is a vendor update.

## Changelog
```markdown
### Changed
- Allow Gaufrette 0.7
```