### PR TITLE
Fix php upload_max_filesize message not showing when size is null

### DIFF
--- a/src/Provider/FileProvider.php
+++ b/src/Provider/FileProvider.php
@@ -313,7 +313,7 @@ class FileProvider extends BaseProvider
             throw new \RuntimeException(sprintf('Invalid binary content type: %s', \get_class($media->getBinaryContent())));
         }
 
-        if ($media->getBinaryContent() instanceof UploadedFile && 0 === $media->getBinaryContent()->getClientSize()) {
+        if ($media->getBinaryContent() instanceof UploadedFile && 0 === ($media->getBinaryContent()->getClientSize() ?: 0)) {
             $errorElement
                ->with('binaryContent')
                    ->addViolation('The file is too big, max size: '.ini_get('upload_max_filesize'))

--- a/tests/Provider/FileProviderTest.php
+++ b/tests/Provider/FileProviderTest.php
@@ -365,6 +365,66 @@ class FileProviderTest extends AbstractProviderTest
         $provider->validate($errorElement, $media);
     }
 
+    public function testValidateUploadNullSize(): void
+    {
+        $errorElement = $this->createMock(ErrorElement::class);
+        $errorElement->expects($this->once())->method('with')
+            ->will($this->returnSelf());
+        $errorElement->expects($this->once())->method('addViolation')
+            ->with($this->stringContains('The file is too big, max size:'))
+            ->will($this->returnSelf());
+        $errorElement->expects($this->once())->method('end')
+            ->will($this->returnSelf());
+
+        $upload = $this->getMockBuilder(UploadedFile::class)
+            ->setConstructorArgs([tempnam(sys_get_temp_dir(), ''), 'dummy'])
+            ->getMock();
+        $upload->expects($this->any())->method('getClientSize')
+            ->will($this->returnValue(null));
+        $upload->expects($this->any())->method('getFilename')
+            ->will($this->returnValue('test.txt'));
+        $upload->expects($this->any())->method('getClientOriginalName')
+            ->will($this->returnValue('test.txt'));
+        $upload->expects($this->any())->method('getMimeType')
+            ->will($this->returnValue('foo/bar'));
+
+        $media = new Media();
+        $media->setBinaryContent($upload);
+
+        $provider = $this->getProvider();
+        $provider->validate($errorElement, $media);
+    }
+
+    public function testValidateUploadSizeOK(): void
+    {
+        $errorElement = $this->createMock(ErrorElement::class);
+        $errorElement->expects($this->never())->method('with')
+            ->will($this->returnSelf());
+        $errorElement->expects($this->never())->method('addViolation')
+            ->with($this->stringContains('The file is too big, max size:'))
+            ->will($this->returnSelf());
+        $errorElement->expects($this->never())->method('end')
+            ->will($this->returnSelf());
+
+        $upload = $this->getMockBuilder(UploadedFile::class)
+            ->setConstructorArgs([tempnam(sys_get_temp_dir(), ''), 'dummy'])
+            ->getMock();
+        $upload->expects($this->any())->method('getClientSize')
+            ->will($this->returnValue(1));
+        $upload->expects($this->any())->method('getFilename')
+            ->will($this->returnValue('test.txt'));
+        $upload->expects($this->any())->method('getClientOriginalName')
+            ->will($this->returnValue('test.txt'));
+        $upload->expects($this->any())->method('getMimeType')
+            ->will($this->returnValue('foo/bar'));
+
+        $media = new Media();
+        $media->setBinaryContent($upload);
+
+        $provider = $this->getProvider();
+        $provider->validate($errorElement, $media);
+    }
+
     public function testValidateUploadType(): void
     {
         $errorElement = $this->getMockBuilder(ErrorElement::class)


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it's a bug fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix file too big message not displayed when `$media->getBinaryContent()->getClientSize()` return `null`
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
