### PR TITLE
Undeprecated MediaManagerInterface

### DIFF
--- a/src/Model/MediaManagerInterface.php
+++ b/src/Model/MediaManagerInterface.php
@@ -14,11 +14,6 @@ namespace Sonata\MediaBundle\Model;
 use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\Doctrine\Model\PageableManagerInterface;
 
-/**
- * NEXT_MAJOR: remove this class.
- *
- * @deprecated Use Sonata\CoreBundle\Model\ManagerInterface instead
- */
 interface MediaManagerInterface extends ManagerInterface, PageableManagerInterface
 {
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
The deprecation notice is wrong. You couldn't use `ManagerInterface` in any case.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Undeprecated `MediaManagerInterface`
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
