### PR TITLE
Remove exception when the media is null

### DIFF
--- a/src/Twig/Extension/MediaExtension.php
+++ b/src/Twig/Extension/MediaExtension.php
@@ -200,7 +200,7 @@ class MediaExtension extends \Twig_Extension implements \Twig_Extension_InitRunt
      */
     private function getMedia($media)
     {
-        if (!$media instanceof MediaInterface && \strlen($media) > 0) {
+        if (!$media instanceof MediaInterface && \strlen((string) $media) > 0) {
             $media = $this->mediaManager->findOneBy([
                 'id' => $media,
             ]);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## The thumbnail or path function is used for Sonata Media and the media is null an exception is thrown

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
The thumbnail or path function is used for Sonata Media and the media is null an exception is thrown

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1517 

```markdown
### Fixes
- crashes on pages with null medias
```