### PR TITLE
Add support for <picture> element in media helper

### DIFF
--- a/docs/reference/helpers.rst
+++ b/docs/reference/helpers.rst
@@ -96,10 +96,9 @@ If you need to specify media queries explicitly, do so with an object as follows
 
 .. code-block:: jinja
 
-    {% media media, 'large' with {'srcset': {'(max-width: 500px)': 'small', '(max-width: 1200px)': 'big', 'fallback': 'huge'}} %}
+    {% media media, 'large' with {'srcset': {'(max-width: 500px)': 'small', '(max-width: 1200px)': 'big'}} %}
 
-The ``fallback`` option determines which size is going to be rendered as ``<img>`` inside the ``<picture>`` element.
-If omitted, it defaults to ``'reference'``.
+The format parameter (``'large'`` above) determines which size is going to be rendered as ``<img>`` inside the ``<picture>`` element.
 
 Thumbnails for files
 --------------------

--- a/docs/reference/helpers.rst
+++ b/docs/reference/helpers.rst
@@ -85,6 +85,21 @@ helper. The option expects either a string or an array of formats.
 
     {% media media, 'large' with {'srcset': ['small', 'big']} %}
 
+To render the image as ``<picture>`` element instead of ``<img>``, pass a ``picture`` key instead of ``srcset`` above:
+
+.. code-block:: jinja
+
+    {% media media, 'large' with {'picture': ['small', 'big']} %}
+
+Media queries for ``<source>`` tags will default to a ``max-width`` equal to the image size.
+If you need to specify media queries explicitly, do so with an object as follows:
+
+.. code-block:: jinja
+
+    {% media media, 'large' with {'srcset': {'(max-width: 500px)': 'small', '(max-width: 1200px)': 'big', 'fallback': 'huge'}} %}
+
+The ``fallback`` option determines which size is going to be rendered as ``<img>`` inside the ``<picture>`` element.
+If omitted, it defaults to ``'reference'``.
 
 Thumbnails for files
 --------------------

--- a/src/Provider/ImageProvider.php
+++ b/src/Provider/ImageProvider.php
@@ -106,9 +106,9 @@ class ImageProvider extends FileProvider
                 $pictureParams['source'][] = ['media' => $mediaQuery, 'srcset' => $src];
             }
 
-            $pictureParams['img'] = $params;
-            $params = ['picture' => $pictureParams];
             unset($options['picture']);
+            $pictureParams['img'] = $params + $options;
+            $params = ['picture' => $pictureParams];
         } elseif (MediaProviderInterface::FORMAT_ADMIN !== $format) {
             $srcSetFormats = $this->getFormats();
 

--- a/src/Provider/ImageProvider.php
+++ b/src/Provider/ImageProvider.php
@@ -135,25 +135,21 @@ class ImageProvider extends FileProvider
 
         if (isset($options['picture'])) {
             unset($properties['picture'], $properties['srcset'], $properties['sizes']);
+
             $pictureProperties = [];
-            foreach ($options['picture'] as $key => $format) {
-                $formatName = $this->getFormatName($media, $format);
+            foreach ($options['picture'] as $key => $pictureFormat) {
+                $formatName = $this->getFormatName($media, $pictureFormat);
                 $settings = $this->getFormat($formatName);
                 $src = $this->generatePublicUrl($media, $formatName);
                 $mediaQuery = \is_string($key)
                     ? $key
                     : '(max-width: '.$this->resizer->getBox($media, $settings)->getWidth().'px)';
-                if ('fallback' === $mediaQuery) {
-                    $pictureProperties['img'] = compact('src') + $properties;
-                } else {
-                    $pictureProperties['source'][] = ['media' => $mediaQuery, 'srcset' => $src];
-                }
+
+                $pictureProperties['source'][] = ['media' => $mediaQuery, 'srcset' => $src];
             }
 
-            if (!isset($pictureProperties['img'])) {
-                $src = $this->generatePublicUrl($media, self::FORMAT_REFERENCE);
-                $pictureProperties['img'] = ['src' => $src] + $properties;
-            }
+            $src = $this->generatePublicUrl($media, $format);
+            $pictureProperties['img'] = ['src' => $src] + $properties;
 
             $properties['picture'] = $pictureProperties;
         }

--- a/src/Provider/ImageProvider.php
+++ b/src/Provider/ImageProvider.php
@@ -67,6 +67,10 @@ class ImageProvider extends FileProvider
      */
     public function getHelperProperties(MediaInterface $media, $format, $options = [])
     {
+        if (isset($options['srcset'], $options['picture'])) {
+            throw new \LogicException("The 'srcset' and 'picture' options must not be used simultaneously.");
+        }
+
         if (MediaProviderInterface::FORMAT_REFERENCE === $format) {
             $box = $media->getBox();
         } else {

--- a/src/Provider/ImageProvider.php
+++ b/src/Provider/ImageProvider.php
@@ -101,7 +101,7 @@ class ImageProvider extends FileProvider
                 $src = $this->generatePublicUrl($media, $formatName);
                 $mediaQuery = \is_string($key)
                     ? $key
-                    : '(max-width: '.$this->resizer->getBox($media, $settings)->getWidth().'px)';
+                    : sprintf('(max-width: %dpx)', $this->resizer->getBox($media, $settings)->getWidth());
 
                 $pictureParams['source'][] = ['media' => $mediaQuery, 'srcset' => $src];
             }

--- a/src/Resizer/SimpleResizer.php
+++ b/src/Resizer/SimpleResizer.php
@@ -80,11 +80,11 @@ class SimpleResizer implements ResizerInterface
         }
 
         if (null === $settings['height']) {
-            $settings['height'] = (int) ($settings['width'] * $size->getHeight() / $size->getWidth());
+            $settings['height'] = (int) round($settings['width'] * $size->getHeight() / $size->getWidth());
         }
 
         if (null === $settings['width']) {
-            $settings['width'] = (int) ($settings['height'] * $size->getWidth() / $size->getHeight());
+            $settings['width'] = (int) round($settings['height'] * $size->getWidth() / $size->getHeight());
         }
 
         return $this->computeBox($media, $settings);
@@ -117,6 +117,11 @@ class SimpleResizer implements ResizerInterface
             $ratio = max($ratios);
         }
 
-        return $size->scale($ratio);
+        $scaledBox = $size->scale($ratio);
+
+        return new Box(
+            min($scaledBox->getWidth(), $settings['width']),
+            min($scaledBox->getHeight(), $settings['height'])
+        );
     }
 }

--- a/src/Resources/views/Provider/view_image.html.twig
+++ b/src/Resources/views/Provider/view_image.html.twig
@@ -9,4 +9,13 @@ file that was distributed with this source code.
 
 #}
 
-<img {% for name, value in options %}{{ name }}="{{ value }}" {% endfor %} />
+{% if options.picture is defined %}
+    <picture>
+        {% for source in options.picture.source %}
+            <source {% for name, value in source %}{{ name }}="{{ value }}" {% endfor %} />
+        {% endfor %}
+        <img {% for name, value in options.picture.img %}{{ name }}="{{ value }}" {% endfor %} />
+    </picture>
+{% else %}
+    <img {% for name, value in options %}{{ name }}="{{ value }}" {% endfor %} />
+{% endif %}

--- a/tests/Provider/ImageProviderTest.php
+++ b/tests/Provider/ImageProviderTest.php
@@ -122,6 +122,9 @@ class ImageProviderTest extends AbstractProviderTest
                 $adminBox, // Third call
                 $largeBox, // Fourth call
                 $mediumBox,
+                $largeBox,
+                $largeBox, // Fifth call
+                $mediumBox,
                 $largeBox
             ));
 
@@ -167,12 +170,25 @@ class ImageProviderTest extends AbstractProviderTest
 
         $this->assertSame(150, $properties['width']);
 
-        $properties = $provider->getHelperProperties($media, 'default_large', ['picture' => ['default_medium', 'default_large']]);
+        $properties = $provider->getHelperProperties($media, 'default_large', ['picture' => ['default_medium', 'default_large'], 'class' => 'some-class']);
         $this->assertArrayHasKey('picture', $properties);
         $this->assertArrayNotHasKey('srcset', $properties);
         $this->assertArrayNotHasKey('sizes', $properties);
         $this->assertArrayHasKey('source', $properties['picture']);
         $this->assertArrayHasKey('img', $properties['picture']);
+        $this->assertArrayHasKey('class', $properties['picture']['img']);
+        $this->assertArrayHasKey('media', $properties['picture']['source'][0]);
+        $this->assertSame('(max-width: 500px)', $properties['picture']['source'][0]['media']);
+
+        $properties = $provider->getHelperProperties($media, 'default_large', ['picture' => ['(max-width: 200px)' => 'default_medium', 'default_large'], 'class' => 'some-class']);
+        $this->assertArrayHasKey('picture', $properties);
+        $this->assertArrayNotHasKey('srcset', $properties);
+        $this->assertArrayNotHasKey('sizes', $properties);
+        $this->assertArrayHasKey('source', $properties['picture']);
+        $this->assertArrayHasKey('img', $properties['picture']);
+        $this->assertArrayHasKey('class', $properties['picture']['img']);
+        $this->assertArrayHasKey('media', $properties['picture']['source'][0]);
+        $this->assertSame('(max-width: 200px)', $properties['picture']['source'][0]['media']);
     }
 
     public function testThumbnail()

--- a/tests/Provider/ImageProviderTest.php
+++ b/tests/Provider/ImageProviderTest.php
@@ -93,6 +93,16 @@ class ImageProviderTest extends AbstractProviderTest
         $this->assertSame('default/0011/24/thumb_1023456_big.png', $provider->generatePrivateUrl($media, 'big'));
     }
 
+    public function testHelperOptions()
+    {
+        $this->expectException(\LogicException::class);
+
+        $provider = $this->getProvider([], [], $this->returnValue(new Box(50, 50)));
+        $media = new Media();
+
+        $provider->getHelperProperties($media, 'any_format', ['srcset' => [], 'picture' => []]);
+    }
+
     public function testHelperProperties()
     {
         $adminBox = new Box(100, 100);

--- a/tests/Provider/ImageProviderTest.php
+++ b/tests/Provider/ImageProviderTest.php
@@ -119,7 +119,10 @@ class ImageProviderTest extends AbstractProviderTest
                 $mediumBox, // second call
                 $mediumBox,
                 $largeBox,
-                $adminBox // Third call
+                $adminBox, // Third call
+                $largeBox, // Fourth call
+                $mediumBox,
+                $largeBox
             ));
 
         $provider->addFormat('admin', ['width' => 100]);
@@ -163,6 +166,13 @@ class ImageProviderTest extends AbstractProviderTest
         $this->assertArrayNotHasKey('srcset', $properties);
 
         $this->assertSame(150, $properties['width']);
+
+        $properties = $provider->getHelperProperties($media, 'default_large', ['picture' => ['default_medium', 'default_large']]);
+        $this->assertArrayHasKey('picture', $properties);
+        $this->assertArrayNotHasKey('srcset', $properties);
+        $this->assertArrayNotHasKey('sizes', $properties);
+        $this->assertArrayHasKey('source', $properties['picture']);
+        $this->assertArrayHasKey('img', $properties['picture']);
     }
 
     public function testThumbnail()

--- a/tests/Provider/ImageProviderTest.php
+++ b/tests/Provider/ImageProviderTest.php
@@ -93,7 +93,7 @@ class ImageProviderTest extends AbstractProviderTest
         $this->assertSame('default/0011/24/thumb_1023456_big.png', $provider->generatePrivateUrl($media, 'big'));
     }
 
-    public function testHelperProperies()
+    public function testHelperProperties()
     {
         $adminBox = new Box(100, 100);
         $mediumBox = new Box(500, 250);

--- a/tests/Resizer/SimpleResizerTest.php
+++ b/tests/Resizer/SimpleResizerTest.php
@@ -92,10 +92,11 @@ class SimpleResizerTest extends TestCase
             ['inset', ['width' => 90, 'height' => 90], new Box(100, 120), new Box(75, 90)],
             ['inset', ['width' => 90, 'height' => 90], new Box(50, 50), new Box(90, 90)],
             ['inset', ['width' => 90, 'height' => null], new Box(50, 50), new Box(90, 90)],
-            ['inset', ['width' => 90, 'height' => null], new Box(567, 200), new Box(88, 31)],
+            ['inset', ['width' => 90, 'height' => null], new Box(567, 200), new Box(90, 32)],
             ['inset', ['width' => 100, 'height' => 100], new Box(567, 200), new Box(100, 35)],
 
-            ['outbound', ['width' => 90, 'height' => 90], new Box(100, 120), new Box(90, 108)],
+            ['outbound', ['width' => 90, 'height' => 90], new Box(100, 120), new Box(90, 90)],
+            ['outbound', ['width' => 90, 'height' => 90], new Box(120, 100), new Box(90, 90)],
             ['outbound', ['width' => 90, 'height' => 90], new Box(50, 50), new Box(90, 90)],
             ['outbound', ['width' => 90, 'height' => null], new Box(50, 50), new Box(90, 90)],
             ['outbound', ['width' => 90, 'height' => null], new Box(567, 50), new Box(90, 8)],


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Add support for <picture> element in media helper

<!-- Describe your Pull Request content here -->
This PR adds an additional configuration option `picture` to the media helper, that can act as an alternative to `srcset` and `sizes` and will trigger rendering of a `<picture>` element instead of an `<img>`.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because the PR offers an additional configuration option to the media helper. It is backwards compatible because media helper output remains unchanged if the new option is not used.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1543

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added configuration option for the media helper to generate a <picture> instead of <img>

### Fixed
- SimpleResizer::computeBox() will return the size of the resulting image instead of just the scaled image before the cropping step.
```

## To do
    - [X] Add tests
