### PR TITLE
change to nelmio 3.0 #1390

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
         "jackalope/jackalope-doctrine-dbal": "^1.1",
         "liip/imagine-bundle": "^1.9",
         "matthiasnoback/symfony-dependency-injection-test": "^3.1",
-        "nelmio/api-doc-bundle": "^2.11",
+        "nelmio/api-doc-bundle": "^3.3",
         "sonata-project/admin-bundle": "^3.31",
         "sonata-project/block-bundle": "^3.14",
         "sonata-project/datagrid-bundle": "^2.3",

--- a/src/Controller/Api/GalleryController.php
+++ b/src/Controller/Api/GalleryController.php
@@ -13,22 +13,25 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Controller\Api;
 
-use FOS\RestBundle\Context\Context;
 use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\View;
+use JMS\Serializer\SerializationContext;
 use FOS\RestBundle\Request\ParamFetcherInterface;
-use FOS\RestBundle\View\View as FOSRestView;
-use Nelmio\ApiDocBundle\Annotation\ApiDoc;
-use Sonata\DatagridBundle\Pager\PagerInterface;
+use Sonata\MediaBundle\Model\Gallery;
+use Sonata\MediaBundle\Model\GalleryHasMedia;
+use Sonata\MediaBundle\Model\GalleryHasMediaInterface;
 use Sonata\MediaBundle\Model\GalleryInterface;
-use Sonata\MediaBundle\Model\GalleryItemInterface;
 use Sonata\MediaBundle\Model\GalleryManagerInterface;
+use Symfony\Component\Form\FormInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Model\MediaManagerInterface;
-use Symfony\Component\Form\FormFactoryInterface;
-use Symfony\Component\Form\FormInterface;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+use FOS\RestBundle\View\View as FOSRestView;
+use Nelmio\ApiDocBundle\Annotation\Operation;
+use Nelmio\ApiDocBundle\Annotation\Model;
+use Swagger\Annotations as SWG;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
@@ -74,10 +77,44 @@ class GalleryController
     /**
      * Retrieves the list of galleries (paginated).
      *
-     * @ApiDoc(
-     *  resource=true,
-     *  output={"class"="Sonata\DatagridBundle\Pager\PagerInterface", "groups"={"sonata_api_read"}}
+     * @Operation(
+     *     tags={""},
+     *     summary="Retrieves the list of galleries (paginated).",
+     *     @SWG\Parameter(
+     *         name="page",
+     *         in="query",
+     *         description="Page for gallery list pagination",
+     *         required=false,
+     *         type="string"
+     *     ),
+     *     @SWG\Parameter(
+     *         name="count",
+     *         in="query",
+     *         description="Number of galleries by page",
+     *         required=false,
+     *         type="string"
+     *     ),
+     *     @SWG\Parameter(
+     *         name="enabled",
+     *         in="query",
+     *         description="Enabled/Disabled galleries filter",
+     *         required=false,
+     *         type="string"
+     *     ),
+     *     @SWG\Parameter(
+     *         name="orderBy",
+     *         in="query",
+     *         description="Order by array (key is field, value is direction)",
+     *         required=false,
+     *         type="string"
+     *     ),
+     *     @SWG\Response(
+     *         response="200",
+     *         description="Returned when successful",
+     *         @SWG\Schema(ref=@Model(type="Sonata\DatagridBundle\Pager\PagerInterface",groups={"sonata_api_read"}))
+     *     )
      * )
+     *
      *
      * @QueryParam(
      *     name="page",
@@ -142,16 +179,27 @@ class GalleryController
     /**
      * Retrieves a specific gallery.
      *
-     * @ApiDoc(
-     *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="gallery id"}
-     *  },
-     *  output={"class"="sonata_media_api_form_gallery", "groups"={"sonata_api_read"}},
-     *  statusCodes={
-     *      200="Returned when successful",
-     *      404="Returned when gallery is not found"
-     *  }
+     * @Operation(
+     *     tags={""},
+     *     summary="Retrieves a specific gallery.",
+     *     @SWG\Parameter(
+     *          type="integer",
+     *          name="id",
+     *          in="path",
+     *          description="gallery id",
+     *          required=true,
+     *     ),
+     *     @SWG\Response(
+     *         response="200",
+     *         description="Returned when successful",
+     *         @SWG\Schema(ref=@Model(type="Sonata\MediaBundle\Form\Type\ApiGalleryType",groups={"sonata_api_read"}))
+     *     ),
+     *     @SWG\Response(
+     *         response="404",
+     *         description="Returned when gallery is not found"
+     *     )
      * )
+     *
      *
      * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
@@ -167,16 +215,27 @@ class GalleryController
     /**
      * Retrieves the medias of specified gallery.
      *
-     * @ApiDoc(
-     *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="gallery id"}
-     *  },
-     *  output={"class"="Sonata\MediaBundle\Model\Media", "groups"={"sonata_api_read"}},
-     *  statusCodes={
-     *      200="Returned when successful",
-     *      404="Returned when gallery is not found"
-     *  }
+     * @Operation(
+     *     tags={""},
+     *     summary="Retrieves the medias of specified gallery.",
+     *     @SWG\Parameter(
+     *          type="integer",
+     *          name="id",
+     *          in="path",
+     *          description="gallery id",
+     *          required=true,
+     *     ),
+     *     @SWG\Response(
+     *         response="200",
+     *         description="Returned when successful",
+     *         @SWG\Schema(ref=@Model(type="Sonata\MediaBundle\Model\Media",groups={"sonata_api_read"}))
+     *     ),
+     *     @SWG\Response(
+     *         response="404",
+     *         description="Returned when gallery is not found"
+     *     )
      * )
+     *
      *
      * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
@@ -199,16 +258,27 @@ class GalleryController
     /**
      * Retrieves the gallery items of specified gallery.
      *
-     * @ApiDoc(
-     *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="gallery id"}
-     *  },
-     *  output={"class"="Sonata\MediaBundle\Model\GalleryItem", "groups"={"sonata_api_read"}},
-     *  statusCodes={
-     *      200="Returned when successful",
-     *      404="Returned when gallery is not found"
-     *  }
+     * @Operation(
+     *     tags={""},
+     *     summary="Retrieves the gallery items of specified gallery.",
+     *     @SWG\Parameter(
+     *          type="integer",
+     *          name="id",
+     *          in="path",
+     *          description="gallery id",
+     *          required=true,
+     *     ),
+     *     @SWG\Response(
+     *         response="200",
+     *         description="Returned when successful",
+     *         @SWG\Schema(ref=@Model(type="Sonata\MediaBundle\Model\GalleryItem",groups={"sonata_api_read"}))
+     *     ),
+     *     @SWG\Response(
+     *         response="404",
+     *         description="Returned when gallery is not found"
+     *     )
      * )
+     *
      *
      * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
@@ -224,14 +294,28 @@ class GalleryController
     /**
      * Adds a gallery.
      *
-     * @ApiDoc(
-     *  input={"class"="sonata_media_api_form_gallery", "name"="", "groups"={"sonata_api_write"}},
-     *  output={"class"="sonata_media_api_form_gallery", "groups"={"sonata_api_read"}},
-     *  statusCodes={
-     *      200="Returned when successful",
-     *      400="Returned when an error has occurred while gallery creation",
-     *  }
+     * @Operation(
+     *     tags={""},
+     *     summary="Adds a gallery.",
+     *     @SWG\Parameter(
+     *          type="object",
+     *          name="",
+     *          in="body",
+     *          description="Gallery data",
+     *          required=true,
+     *          @Model(type="Sonata\MediaBundle\Form\Type\ApiGalleryType",groups={"sonata_api_write"})
+     *     ),
+     *     @SWG\Response(
+     *         response="200",
+     *         description="Returned when successful",
+     *         @SWG\Schema(ref=@Model(type="Sonata\MediaBundle\Form\Type\ApiGalleryType",groups={"sonata_api_read"}))
+     *     ),
+     *     @SWG\Response(
+     *         response="400",
+     *         description="Returned when an error has occurred while gallery creation"
+     *     )
      * )
+     *
      *
      * @param Request $request A Symfony request
      *
@@ -247,18 +331,39 @@ class GalleryController
     /**
      * Updates a gallery.
      *
-     * @ApiDoc(
-     *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="gallery identifier"}
-     *  },
-     *  input={"class"="sonata_media_api_form_gallery", "name"="", "groups"={"sonata_api_write"}},
-     *  output={"class"="sonata_media_api_form_gallery", "groups"={"sonata_api_read"}},
-     *  statusCodes={
-     *      200="Returned when successful",
-     *      400="Returned when an error has occurred while gallery creation",
-     *      404="Returned when unable to find gallery"
-     *  }
+     * @Operation(
+     *     tags={""},
+     *     summary="Updates a gallery.",
+     *     @SWG\Parameter(
+     *          type="integer",
+     *          name="id",
+     *          in="path",
+     *          description="gallery id",
+     *          required=true,
+     *     ),
+     *     @SWG\Parameter(
+     *          type="object",
+     *          name="",
+     *          in="body",
+     *          description="Gallery data",
+     *          required=true,
+     *          @Model(type="Sonata\MediaBundle\Form\Type\ApiGalleryType",groups={"sonata_api_write"})
+     *     ),
+     *     @SWG\Response(
+     *         response="200",
+     *         description="Returned when successful",
+     *         @SWG\Schema(ref=@Model(type="Sonata\MediaBundle\Form\Type\ApiGalleryType"))
+     *     ),
+     *     @SWG\Response(
+     *         response="400",
+     *         description="Returned when an error has occurred while gallery creation"
+     *     ),
+     *     @SWG\Response(
+     *         response="404",
+     *         description="Returned when unable to find gallery"
+     *     )
      * )
+     *
      *
      * @param int     $id      User id
      * @param Request $request A Symfony request
@@ -275,18 +380,42 @@ class GalleryController
     /**
      * Adds a media to a gallery.
      *
-     * @ApiDoc(
-     *  requirements={
-     *      {"name"="galleryId", "dataType"="integer", "requirement"="\d+", "description"="gallery identifier"},
-     *      {"name"="mediaId", "dataType"="integer", "requirement"="\d+", "description"="media identifier"}
-     *  },
-     *  input={"class"="sonata_media_api_form_gallery_item", "name"="", "groups"={"sonata_api_write"}},
-     *  output={"class"="sonata_media_api_form_gallery", "groups"={"sonata_api_read"}},
-     *  statusCodes={
-     *      200="Returned when successful",
-     *      400="Returned when an error has occurred while gallery/media attachment",
-     *  }
+     * @Operation(
+     *     tags={""},
+     *     summary="Adds a media to a gallery.",
+     *     @SWG\Parameter(
+     *          type="integer",
+     *          name="galleryId",
+     *          in="path",
+     *          description="gallery id",
+     *          required=true,
+     *     ),
+     *     @SWG\Parameter(
+     *          type="integer",
+     *          name="mediaId",
+     *          in="path",
+     *          description="media id",
+     *          required=true,
+     *     ),
+     *     @SWG\Parameter(
+     *          type="object",
+     *          name="",
+     *          in="body",
+     *          description="Gallery data",
+     *          required=true,
+     *          @Model(type="Sonata\MediaBundle\Form\Type\ApiGalleryItemType",groups={"sonata_api_write"})
+     *     ),
+     *     @SWG\Response(
+     *         response="200",
+     *         description="Returned when successful",
+     *         @SWG\Schema(ref=@Model(type="Sonata\MediaBundle\Form\Type\ApiGalleryType",groups={"sonata_api_read"}))
+     *     ),
+     *     @SWG\Response(
+     *         response="400",
+     *         description="Returned when an error has occurred while gallery/media attachment"
+     *     )
      * )
+     *
      *
      * @param int     $galleryId A gallery identifier
      * @param int     $mediaId   A media identifier
@@ -315,18 +444,42 @@ class GalleryController
     /**
      * Updates a media to a gallery.
      *
-     * @ApiDoc(
-     *  requirements={
-     *      {"name"="galleryId", "dataType"="integer", "requirement"="\d+", "description"="gallery identifier"},
-     *      {"name"="mediaId", "dataType"="integer", "requirement"="\d+", "description"="media identifier"}
-     *  },
-     *  input={"class"="sonata_media_api_form_gallery_item", "name"="", "groups"={"sonata_api_write"}},
-     *  output={"class"="sonata_media_api_form_gallery", "groups"={"sonata_api_read"}},
-     *  statusCodes={
-     *      200="Returned when successful",
-     *      404="Returned when an error if media cannot be found in gallery",
-     *  }
+     * @Operation(
+     *     tags={""},
+     *     summary="Updates a media to a gallery.",
+     *     @SWG\Parameter(
+     *          type="integer",
+     *          name="galleryId",
+     *          in="path",
+     *          description="gallery id",
+     *          required=true,
+     *     ),
+     *     @SWG\Parameter(
+     *          type="integer",
+     *          name="mediaId",
+     *          in="path",
+     *          description="media id",
+     *          required=true,
+     *     ),
+     *     @SWG\Parameter(
+     *          type="object",
+     *          name="",
+     *          in="body",
+     *          description="Gallery data",
+     *          required=true,
+     *          @Model(type="Sonata\MediaBundle\Form\Type\ApiGalleryItemType",groups={"sonata_api_write"})
+     *     ),
+     *     @SWG\Response(
+     *         response="200",
+     *         description="Returned when successful",
+     *         @SWG\Schema(ref=@Model(type="Sonata\MediaBundle\Form\Type\ApiGalleryType"))
+     *     ),
+     *     @SWG\Response(
+     *         response="404",
+     *         description="Returned when an error if media cannot be found in gallery"
+     *     )
      * )
+     *
      *
      * @param int     $galleryId A gallery identifier
      * @param int     $mediaId   A media identifier
@@ -353,17 +506,37 @@ class GalleryController
     /**
      * Deletes a media association to a gallery.
      *
-     * @ApiDoc(
-     *  requirements={
-     *      {"name"="galleryId", "dataType"="integer", "requirement"="\d+", "description"="gallery identifier"},
-     *      {"name"="mediaId", "dataType"="integer", "requirement"="\d+", "description"="media identifier"}
-     *  },
-     *  statusCodes={
-     *      200="Returned when media is successfully deleted from gallery",
-     *      400="Returned when an error has occurred while media deletion of gallery",
-     *      404="Returned when unable to find gallery or media"
-     *  }
+     * @Operation(
+     *     tags={""},
+     *     summary="Deletes a media association to a gallery.",
+     *     @SWG\Parameter(
+     *          type="integer",
+     *          name="galleryId",
+     *          in="path",
+     *          description="gallery id",
+     *          required=true,
+     *     ),
+     *     @SWG\Parameter(
+     *          type="integer",
+     *          name="mediaId",
+     *          in="path",
+     *          description="media id",
+     *          required=true,
+     *     ),
+     *     @SWG\Response(
+     *         response="200",
+     *         description="Returned when media is successfully deleted from gallery"
+     *     ),
+     *     @SWG\Response(
+     *         response="400",
+     *         description="Returned when an error has occurred while media deletion of gallery"
+     *     ),
+     *     @SWG\Response(
+     *         response="404",
+     *         description="Returned when unable to find gallery or media"
+     *     )
      * )
+     *
      *
      * @param int $galleryId A gallery identifier
      * @param int $mediaId   A media identifier
@@ -394,16 +567,30 @@ class GalleryController
     /**
      * Deletes a gallery.
      *
-     * @ApiDoc(
-     *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="gallery identifier"}
-     *  },
-     *  statusCodes={
-     *      200="Returned when gallery is successfully deleted",
-     *      400="Returned when an error has occurred while gallery deletion",
-     *      404="Returned when unable to find gallery"
-     *  }
+     * @Operation(
+     *     tags={""},
+     *     summary="Deletes a gallery.",
+     *     @SWG\Parameter(
+     *          type="integer",
+     *          name="galleryId",
+     *          in="path",
+     *          description="gallery id",
+     *          required=true,
+     *     ),
+     *     @SWG\Response(
+     *         response="200",
+     *         description="Returned when gallery is successfully deleted"
+     *     ),
+     *     @SWG\Response(
+     *         response="400",
+     *         description="Returned when an error has occurred while gallery deletion"
+     *     ),
+     *     @SWG\Response(
+     *         response="404",
+     *         description="Returned when unable to find gallery"
+     *     )
      * )
+     *
      *
      * @param int $id A Gallery identifier
      *

--- a/src/Controller/Api/MediaController.php
+++ b/src/Controller/Api/MediaController.php
@@ -19,7 +19,9 @@ use FOS\RestBundle\Controller\Annotations\Route;
 use FOS\RestBundle\Controller\Annotations\View;
 use FOS\RestBundle\Request\ParamFetcherInterface;
 use FOS\RestBundle\View\View as FOSRestView;
-use Nelmio\ApiDocBundle\Annotation\ApiDoc;
+use Nelmio\ApiDocBundle\Annotation\Operation;
+use Nelmio\ApiDocBundle\Annotation\Model;
+use Swagger\Annotations as SWG;
 use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Model\MediaManagerInterface;
@@ -72,10 +74,44 @@ class MediaController
     /**
      * Retrieves the list of medias (paginated).
      *
-     * @ApiDoc(
-     *  resource=true,
-     *  output={"class"="Sonata\DatagridBundle\Pager\PagerInterface", "groups"={"sonata_api_read"}}
+     * @Operation(
+     *     tags={""},
+     *     summary="Retrieves the list of medias (paginated).",
+     *     @SWG\Parameter(
+     *         name="page",
+     *         in="query",
+     *         description="Page for media list pagination",
+     *         required=false,
+     *         type="string"
+     *     ),
+     *     @SWG\Parameter(
+     *         name="count",
+     *         in="query",
+     *         description="Number of medias by page",
+     *         required=false,
+     *         type="string"
+     *     ),
+     *     @SWG\Parameter(
+     *         name="enabled",
+     *         in="query",
+     *         description="Enabled/Disabled medias filter",
+     *         required=false,
+     *         type="string"
+     *     ),
+     *     @SWG\Parameter(
+     *         name="orderBy",
+     *         in="query",
+     *         description="Order by array (key is field, value is direction)",
+     *         required=false,
+     *         type="string"
+     *     ),
+     *     @SWG\Response(
+     *         response="200",
+     *         description="Returned when successful",
+     *         @SWG\Schema(ref=@Model(type="Sonata\DatagridBundle\Pager\PagerInterface",groups={"sonata_api_read"}))
+     *     )
      * )
+     *
      *
      * @QueryParam(name="page", requirements="\d+", default="1", description="Page for media list pagination")
      * @QueryParam(name="count", requirements="\d+", default="10", description="Number of medias by page")
@@ -117,16 +153,27 @@ class MediaController
     /**
      * Retrieves a specific media.
      *
-     * @ApiDoc(
-     *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="media id"}
-     *  },
-     *  output={"class"="Sonata\MediaBundle\Model\Media", "groups"={"sonata_api_read"}},
-     *  statusCodes={
-     *      200="Returned when successful",
-     *      404="Returned when media is not found"
-     *  }
+     * @Operation(
+     *     tags={""},
+     *     summary="Retrieves a specific media.",
+     *     @SWG\Parameter(
+     *          type="integer",
+     *          name="id",
+     *          in="path",
+     *          description="media id",
+     *          required=true,
+     *     ),
+     *     @SWG\Response(
+     *         response="200",
+     *         description="Returned when successful",
+     *         @SWG\Schema(ref=@Model(type="Sonata\MediaBundle\Model\Media",groups={"sonata_api_read"}))
+     *     ),
+     *     @SWG\Response(
+     *         response="404",
+     *         description="Returned when media is not found"
+     *     )
      * )
+     *
      *
      * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
@@ -142,15 +189,26 @@ class MediaController
     /**
      * Returns media urls for each format.
      *
-     * @ApiDoc(
-     *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="media id"}
-     *  },
-     *  statusCodes={
-     *      200="Returned when successful",
-     *      404="Returned when media is not found"
-     *  }
+     * @Operation(
+     *     tags={""},
+     *     summary="Returns media urls for each format.",
+     *     @SWG\Parameter(
+     *          type="integer",
+     *          name="id",
+     *          in="path",
+     *          description="media id",
+     *          required=true,
+     *     ),
+     *     @SWG\Response(
+     *         response="200",
+     *         description="Returned when successful"
+     *     ),
+     *     @SWG\Response(
+     *         response="404",
+     *         description="Returned when media is not found"
+     *     )
      * )
+     *
      *
      * @param $id
      *
@@ -177,16 +235,33 @@ class MediaController
     /**
      * Returns media binary content for each format.
      *
-     * @ApiDoc(
-     *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="media id"},
-     *      {"name"="format", "dataType"="string", "description"="media format"}
-     *  },
-     *  statusCodes={
-     *      200="Returned when successful",
-     *      404="Returned when media is not found"
-     *  }
+     * @Operation(
+     *     tags={""},
+     *     summary="Returns media binary content for each format.",
+     *     @SWG\Parameter(
+     *          type="integer",
+     *          name="id",
+     *          in="path",
+     *          description="media id",
+     *          required=true,
+     *     ),
+     *     @SWG\Parameter(
+     *          type="string",
+     *          name="format",
+     *          in="path",
+     *          description="media format",
+     *          required=true,
+     *     ),
+     *     @SWG\Response(
+     *         response="200",
+     *         description="Returned when successful"
+     *     ),
+     *     @SWG\Response(
+     *         response="404",
+     *         description="Returned when media is not found"
+     *     )
      * )
+     *
      *
      * @param int     $id      The media id
      * @param string  $format  The format
@@ -210,16 +285,30 @@ class MediaController
     /**
      * Deletes a medium.
      *
-     * @ApiDoc(
-     *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="medium identifier"}
-     *  },
-     *  statusCodes={
-     *      200="Returned when medium is successfully deleted",
-     *      400="Returned when an error has occurred while deleting the medium",
-     *      404="Returned when unable to find medium"
-     *  }
+     * @Operation(
+     *     tags={""},
+     *     summary="Deletes a medium.",
+     *     @SWG\Parameter(
+     *          type="integer",
+     *          name="id",
+     *          in="path",
+     *          description="media id",
+     *          required=true,
+     *     ),
+     *     @SWG\Response(
+     *         response="200",
+     *         description="Returned when medium is successfully deleted"
+     *     ),
+     *     @SWG\Response(
+     *         response="400",
+     *         description="Returned when an error has occurred while deleting the medium"
+     *     ),
+     *     @SWG\Response(
+     *         response="404",
+     *         description="Returned when unable to find medium"
+     *     )
      * )
+     *
      *
      * @param int $id A medium identifier
      *
@@ -241,18 +330,39 @@ class MediaController
      * If you need to upload a file (depends on the provider) you will need to do so by sending content as a multipart/form-data HTTP Request
      * See documentation for more details.
      *
-     * @ApiDoc(
-     *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="medium identifier"}
-     *  },
-     *  input={"class"="sonata_media_api_form_media", "name"="", "groups"={"sonata_api_write"}},
-     *  output={"class"="Sonata\MediaBundle\Model\Media", "groups"={"sonata_api_read"}},
-     *  statusCodes={
-     *      200="Returned when successful",
-     *      400="Returned when an error has occurred while medium update",
-     *      404="Returned when unable to find medium"
-     *  }
+     * @Operation(
+     *     tags={""},
+     *     summary="Updates a medium",
+     *     @SWG\Parameter(
+     *          type="integer",
+     *          name="id",
+     *          in="path",
+     *          description="media id",
+     *          required=true,
+     *     ),
+     *     @SWG\Parameter(
+     *          type="object",
+     *          name="",
+     *          in="body",
+     *          description="Media data",
+     *          required=true,
+     *          @Model(type="Sonata\MediaBundle\Form\Type\ApiMediaType",groups={"sonata_api_write"})
+     *     ),
+     *     @SWG\Response(
+     *         response="200",
+     *         description="Returned when successful",
+     *         @SWG\Schema(ref=@Model(type="Sonata\MediaBundle\Model\Media",groups={"sonata_api_read"}))
+     *     ),
+     *     @SWG\Response(
+     *         response="400",
+     *         description="Returned when an error has occurred while medium update"
+     *     ),
+     *     @SWG\Response(
+     *         response="404",
+     *         description="Returned when unable to find medium"
+     *     )
      * )
+     *
      *
      * @param int     $id      A Medium identifier
      * @param Request $request A Symfony request
@@ -281,16 +391,39 @@ class MediaController
      * If you need to upload a file (depends on the provider) you will need to do so by sending content as a multipart/form-data HTTP Request
      * See documentation for more details.
      *
-     * @ApiDoc(
-     *  resource=true,
-     *  input={"class"="sonata_media_api_form_media", "name"="", "groups"={"sonata_api_write"}},
-     *  output={"class"="Sonata\MediaBundle\Model\Media", "groups"={"sonata_api_read"}},
-     *  statusCodes={
-     *      200="Returned when successful",
-     *      400="Returned when an error has occurred while medium creation",
-     *      404="Returned when unable to find medium"
-     *  }
+     * @Operation(
+     *     tags={""},
+     *     summary="Adds a medium of given provider",
+     *     @SWG\Parameter(
+     *          type="string",
+     *          name="provider",
+     *          in="path",
+     *          description="provider id",
+     *          required=true,
+     *     ),
+     *     @SWG\Parameter(
+     *          type="object",
+     *          name="",
+     *          in="body",
+     *          description="Media data",
+     *          required=true,
+     *          @Model(type="Sonata\MediaBundle\Form\Type\ApiMediaType",groups={"sonata_api_write"})
+     *     ),
+     *     @SWG\Response(
+     *         response="200",
+     *         description="Returned when successful",
+     *         @SWG\Schema(ref=@Model(type="Sonata\MediaBundle\Model\Media",groups={"sonata_api_read"}))
+     *     ),
+     *     @SWG\Response(
+     *         response="400",
+     *         description="Returned when an error has occurred while medium creation"
+     *     ),
+     *     @SWG\Response(
+     *         response="404",
+     *         description="Returned when unable to find medium"
+     *     )
      * )
+     *
      *
      * @Route(requirements={"provider"="[A-Za-z0-9.]*"})
      *
@@ -320,14 +453,34 @@ class MediaController
     /**
      * Set Binary content for a specific media.
      *
-     * @ApiDoc(
-     *  input={"class"="Sonata\MediaBundle\Model\Media", "groups"={"sonata_api_write"}},
-     *  output={"class"="Sonata\MediaBundle\Model\Media", "groups"={"sonata_api_read"}},
-     *  statusCodes={
-     *      200="Returned when successful",
-     *      404="Returned when media is not found"
-     *  }
+     * @Operation(
+     *     tags={""},
+     *     summary="Set Binary content for a specific media.",
+     *     @SWG\Parameter(
+     *          type="integer",
+     *          name="id",
+     *          in="path",
+     *          description="media id",
+     *          required=true,
+     *     ),
+     *     @SWG\Parameter(
+     *         name="binaryContent",
+     *         in="body",
+     *         description="Binary content of media",
+     *         required=true,
+     *         @SWG\Schema(type="string")
+     *     ),
+     *     @SWG\Response(
+     *         response="200",
+     *         description="Returned when successful",
+     *         @SWG\Schema(ref=@Model(type="Sonata\MediaBundle\Model\Media",groups={"sonata_api_read"}))
+     *     ),
+     *     @SWG\Response(
+     *         response="404",
+     *         description="Returned when media is not found"
+     *     )
      * )
+     *
      *
      * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *

--- a/src/Model/Gallery.php
+++ b/src/Model/Gallery.php
@@ -20,7 +20,7 @@ use Sonata\MediaBundle\Provider\MediaProviderInterface;
 /**
  * NEXT_MAJOR: remove GalleryMediaCollectionInterface interface. Move its content into GalleryInterface.
  */
-abstract class Gallery implements GalleryInterface, GalleryMediaCollectionInterface
+abstract class Gallery implements GalleryInterface
 {
     /**
      * @var string

--- a/src/Resources/config/routing/api.xml
+++ b/src/Resources/config/routing/api.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://friendsofsymfony.github.com/schema/rest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://friendsofsymfony.github.com/schema/rest https://raw.github.com/FriendsOfSymfony/FOSRestBundle/master/Resources/config/schema/routing/rest_routing-1.0.xsd">
-    <import type="rest" resource="sonata.media.controller.api.gallery" name-prefix="sonata_api_media_gallery_"/>
-    <import type="rest" resource="sonata.media.controller.api.media" name-prefix="sonata_api_media_media_"/>
+    <import type="rest" resource="Sonata\MediaBundle\Controller\Api\GalleryController" name-prefix="sonata_api_media_gallery_"/>
+    <import type="rest" resource="Sonata\MediaBundle\Controller\Api\MediaController" name-prefix="sonata_api_media_media_"/>
 </routes>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Make Api Controllers compatible to Nelmio Api Doc 3.0

<!-- Describe your Pull Request content here -->
This PR changes the ApiDoc to be compatible with with NelmioApiDoc in Version 3.x.
I have used the update script, posted in Upgrade docs by nelmio: https://github.com/nelmio/NelmioApiDocBundle/blob/master/UPGRADE-3.0.md

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because there was a change in naming from GalleryHasMedia to GalleryItems. And these changes effect the ApiDoc section in the api controllers.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1390 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
- ApiDocs in Api/GalleryController
- ApiDocs in Api/MediaController
- Updated require-dev of nelmio/api-doc-bundle to 3.3
- service ids to FQDN in routing/api.xml

### Fixed
- could not find GalleryMediaCollectionInterface (was removed by earlier commit)

```


## To do    
- [ ] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note
