### PR TITLE
Use array type hint for theme

### DIFF
--- a/src/Controller/MediaAdminController.php
+++ b/src/Controller/MediaAdminController.php
@@ -118,7 +118,7 @@ class MediaAdminController extends Controller
     /**
      * Sets the admin form theme to form view. Used for compatibility between Symfony versions.
      */
-    private function setFormTheme(FormView $formView, string $theme)
+    private function setFormTheme(FormView $formView, array $theme)
     {
         $twig = $this->get('twig');
 

--- a/tests/Controller/MediaAdminControllerTest.php
+++ b/tests/Controller/MediaAdminControllerTest.php
@@ -108,7 +108,7 @@ class MediaAdminControllerTest extends TestCase
         $form = $this->prophesize(Form::class);
         $formView = $this->prophesize(FormView::class);
 
-        $this->configureSetFormTheme($formView->reveal(), 'filterTheme');
+        $this->configureSetFormTheme($formView->reveal(), ['filterTheme']);
         $this->configureSetCsrfToken('sonata.batch');
         $this->configureRender('templateList', Argument::type('array'), 'renderResponse');
         $datagrid->setValue('context', null, 'another_context')->shouldBeCalled();
@@ -129,7 +129,7 @@ class MediaAdminControllerTest extends TestCase
         $this->admin->setListMode('mosaic')->shouldBeCalled();
         $this->admin->getDatagrid()->willReturn($datagrid->reveal());
         $this->admin->getPersistentParameter('context', 'context')->willReturn('another_context');
-        $this->admin->getFilterTheme()->willReturn('filterTheme');
+        $this->admin->getFilterTheme()->willReturn(['filterTheme']);
         $this->admin->getTemplate('list')->willReturn('templateList');
         $this->request->get('_list_mode', 'mosaic')->willReturn('mosaic');
         $this->request->get('filter')->willReturn([]);


### PR DESCRIPTION
## Subject

I wrongly assumed `$theme` could only be a string in a previous PR.
I am targeting this branch, because this is BC.

Fixes #1557

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Crash about `setFormTheme` when viewing the media list
```

## How can I test this?

```shell
composer config repositories.greg0ire vcs https://github.com/greg0ire/SonataMediaBundle
composer require sonata-project/media-bundle "dev-fix-wrong-type-hint as 3.18.1"
```