### PR TITLE
CategoryManager - wrong type hint

### DIFF
--- a/src/Model/CategoryManager.php
+++ b/src/Model/CategoryManager.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Model;
 
+use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface as ManagerInterface;
-use Sonata\MediaBundle\Tests\fixtures\SonataClassificationBundle\Model\CategoryInterface;
 
 /**
  * @author Joao Albuquerque <albuquerque.joao.filipe@gmail.com>
@@ -54,7 +54,7 @@ final class CategoryManager implements CategoryManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function find($categoryId): iterable
+    public function find($categoryId): ?CategoryInterface
     {
         return $this->categoryManager->find($categoryId);
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## CategoryManager - wrong FQDN for CategoryInterface

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because branch 3.x is currently broken.

## Changelog


```markdown
### Fixed
- return type for `CategoryManager::find()`
```