### PR TITLE
[Dependencies] Allow "jms/serializer-bundle:^3.0"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php": "^7.1",
         "guzzlehttp/psr7": "^1.0",
         "imagine/imagine": "^0.6 || ^0.7",
-        "jms/serializer-bundle": "^1.0 || ^2.0",
+        "jms/serializer-bundle": "^1.0 || ^2.0 || ^3.0",
         "knplabs/gaufrette": "^0.8",
         "kriswallsmith/buzz": "^0.15 || ^0.16",
         "psr/log": "^1.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Allow to use "jms/serializer-bundle:^3.0"

I am targeting this branch, because the version 3 of jms/serializer-bundle is now stable and it is compatible with the implementation in this branch.

## Changelog

```markdown
### Added
- Added compatibility with "jms/serializer-bundle:^3.0"

```    
## To do
    
- [x] Check the tests
