### PR TITLE
fix(provider): fix loosing provider on multi providers context & max …

### DIFF
--- a/src/Admin/BaseMediaAdmin.php
+++ b/src/Admin/BaseMediaAdmin.php
@@ -91,6 +91,12 @@ abstract class BaseMediaAdmin extends AbstractAdmin
             $this->getRequest()->query->set('provider', $provider);
         }
 
+        // if there is a post server error, provider is not posted and in case of
+        // multiple providers, it has to be persistent to not being lost
+        if (1 < \count($providers) && null !== $provider) {
+            $parameters['provider'] = $provider;
+        }
+
         $categoryId = $this->getRequest()->get('category');
 
         if (null !== $this->categoryManager && !$categoryId) {


### PR DESCRIPTION
…post size exceeded

## Subject

When a post is done but that it exceeds php max post size, post values seems to be empty. Then we loose the provider as it is a post parameter. With a multi providers context, the provider is lost so it has to be persistent. 

I am targeting this branch, because it's not a BC break i presume.

## Changelog

```markdown
### Fixed
Fix error 500 when max post size is exceeded on multi providers context
```