### PR TITLE
Add option to lazy load images

### DIFF
--- a/docs/reference/helpers.rst
+++ b/docs/reference/helpers.rst
@@ -98,6 +98,16 @@ If you need to specify media queries explicitly, do so with an object as follows
 
 The format parameter (``'large'`` above) determines which size is going to be rendered as ``<img>`` inside the ``<picture>`` element.
 
+To make the ``<img>`` or ``<picture>`` lazy-loadable, add the parameter ``lazy: true``. ``src`` and ``srcset`` attributes
+will then become ``data-src`` and ``data-srcset``, respectively. You can define a loader or placeholder image through
+the ``src`` option if desired, otherwise ``src`` will default to ``#``. Please note that this will only prevent the image
+from loading, you will need to add code or a library that performs actual lazy-loading yourself.
+
+.. code-block:: jinja
+
+    {% media media, 'large' with {'lazy': true} %}
+
+
 Thumbnails for files
 --------------------
 

--- a/src/Provider/ImageProvider.php
+++ b/src/Provider/ImageProvider.php
@@ -71,6 +71,8 @@ class ImageProvider extends FileProvider
             throw new \LogicException("The 'srcset' and 'picture' options must not be used simultaneously.");
         }
 
+        $attrPrefix = isset($options['lazy']) && true === $options['lazy'] ? 'data-' : '';
+
         if (MediaProviderInterface::FORMAT_REFERENCE === $format) {
             $box = $media->getBox();
         } else {
@@ -88,7 +90,8 @@ class ImageProvider extends FileProvider
         $params = [
             'alt' => $media->getName(),
             'title' => $media->getName(),
-            'src' => $this->generatePublicUrl($media, $format),
+            'src' => $options['src'] ?? '#',
+            $attrPrefix.'src' => $this->generatePublicUrl($media, $format),
             'width' => $mediaWidth,
             'height' => $box->getHeight(),
         ];
@@ -103,7 +106,7 @@ class ImageProvider extends FileProvider
                     ? $key
                     : sprintf('(max-width: %dpx)', $this->resizer->getBox($media, $settings)->getWidth());
 
-                $pictureParams['source'][] = ['media' => $mediaQuery, 'srcset' => $src];
+                $pictureParams['source'][] = ['media' => $mediaQuery, $attrPrefix.'srcset' => $src];
             }
 
             unset($options['picture']);
@@ -145,7 +148,10 @@ class ImageProvider extends FileProvider
                     $media->getBox()->getWidth()
                 );
 
-                $params['srcset'] = implode(', ', $srcSet);
+                $params[$attrPrefix.'srcset'] = implode(', ', $srcSet);
+            } elseif ($attrPrefix) {
+                $options[$attrPrefix.'srcset'] = $options['srcset'];
+                unset($options['srcset']);
             }
 
             $params['sizes'] = sprintf('(max-width: %1$dpx) 100vw, %1$dpx', $mediaWidth);

--- a/src/Provider/ImageProvider.php
+++ b/src/Provider/ImageProvider.php
@@ -149,7 +149,7 @@ class ImageProvider extends FileProvider
                 );
 
                 $params[$attrPrefix.'srcset'] = implode(', ', $srcSet);
-            } elseif ($attrPrefix) {
+            } elseif ($attrPrefix !== '') {
                 $options[$attrPrefix.'srcset'] = $options['srcset'];
                 unset($options['srcset']);
             }

--- a/tests/Provider/ImageProviderTest.php
+++ b/tests/Provider/ImageProviderTest.php
@@ -124,6 +124,12 @@ class ImageProviderTest extends AbstractProviderTest
                 $mediumBox,
                 $largeBox,
                 $largeBox, // Fifth call
+                $largeBox,
+                $largeBox, // Sixth call
+                $mediumBox,
+                $largeBox,
+                $largeBox, // Seventh call
+                $largeBox, // Eighth call
                 $mediumBox,
                 $largeBox
             ));
@@ -189,6 +195,32 @@ class ImageProviderTest extends AbstractProviderTest
         $this->assertArrayHasKey('class', $properties['picture']['img']);
         $this->assertArrayHasKey('media', $properties['picture']['source'][0]);
         $this->assertSame('(max-width: 200px)', $properties['picture']['source'][0]['media']);
+
+        $properties = $provider->getHelperProperties($media, 'default_large', ['lazy' => true]);
+        $this->assertArrayHasKey('data-src', $properties);
+        $this->assertArrayHasKey('data-srcset', $properties);
+        $this->assertSame('#', $properties['src']);
+        $this->assertArrayNotHasKey('srcset', $properties);
+
+        $properties = $provider->getHelperProperties($media, 'default_large', ['src' => 'scalar src', 'srcset' => 'scalar srcset', 'lazy' => true]);
+        $this->assertArrayHasKey('data-src', $properties);
+        $this->assertSame('scalar src', $properties['src']);
+        $this->assertSame('scalar srcset', $properties['data-srcset']);
+        $this->assertArrayNotHasKey('srcset', $properties);
+
+        $properties = $provider->getHelperProperties($media, 'default_large', ['picture' => ['default_medium', 'default_large'], 'class' => 'some-class', 'lazy' => true]);
+        $this->assertArrayHasKey('picture', $properties);
+        $this->assertArrayNotHasKey('srcset', $properties);
+        $this->assertArrayNotHasKey('sizes', $properties);
+        $this->assertArrayHasKey('source', $properties['picture']);
+        $this->assertArrayHasKey('img', $properties['picture']);
+        $this->assertArrayHasKey('data-src', $properties['picture']['img']);
+        $this->assertSame('#', $properties['picture']['img']['src']);
+        $this->assertArrayHasKey('class', $properties['picture']['img']);
+        $this->assertArrayHasKey('media', $properties['picture']['source'][0]);
+        $this->assertArrayHasKey('data-srcset', $properties['picture']['source'][0]);
+        $this->assertArrayNotHasKey('srcset', $properties['picture']['source'][0]);
+        $this->assertSame('(max-width: 500px)', $properties['picture']['source'][0]['media']);
     }
 
     public function testThumbnail(): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Adds the `lazy` option to the media helper to allow moving `src` and `srcset` attributes to `data-src` and `data-srcset`, respectively.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because the introduced option has no effect if omitted and thus is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1584 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- `lazy` option to media helper for images

```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
