### PR TITLE
fix(exception): fix value of code exception to respect strict type

### DIFF
--- a/src/Provider/BaseVideoProvider.php
+++ b/src/Provider/BaseVideoProvider.php
@@ -209,7 +209,7 @@ abstract class BaseVideoProvider extends BaseProvider
         try {
             $response = $this->browser->get($url);
         } catch (\RuntimeException $e) {
-            throw new \RuntimeException('Unable to retrieve the video information for :'.$url, null, $e);
+            throw new \RuntimeException('Unable to retrieve the video information for :'.$url, $e->getCode(), $e);
         }
 
         $metadata = json_decode($response->getContent(), true);

--- a/tests/Provider/DailyMotionProviderTest.php
+++ b/tests/Provider/DailyMotionProviderTest.php
@@ -177,6 +177,32 @@ class DailyMotionProviderTest extends AbstractProviderTest
         ];
     }
 
+    public function testGetMetadataException(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unable to retrieve the video information for :x9wjql');
+        $this->expectExceptionCode(12);
+
+        $response = new Response();
+        $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_dailymotion.txt'));
+
+        $browser = $this->createMock(Browser::class);
+        $browser->expects($this->once())->method('get')->will($this->throwException(new \RuntimeException('First error on get', 12)));
+
+        $provider = $this->getProvider($browser);
+
+        $provider->addFormat('big', ['width' => 200, 'height' => 100, 'constraint' => true]);
+
+        $media = new Media();
+        $media->setBinaryContent('x9wjql');
+        $media->setId(1023456);
+
+        $method = new \ReflectionMethod($provider, 'getMetadata');
+        $method->setAccessible(true);
+
+        $method->invokeArgs($provider, [$media, 'x9wjql']);
+    }
+
     public function testForm(): void
     {
         $provider = $this->getProvider();

--- a/tests/Provider/VimeoProviderTest.php
+++ b/tests/Provider/VimeoProviderTest.php
@@ -179,6 +179,32 @@ class VimeoProviderTest extends AbstractProviderTest
         ];
     }
 
+    public function testGetMetadataException(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unable to retrieve the video information for :012341231');
+        $this->expectExceptionCode(12);
+
+        $response = new Response();
+        $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_vimeo.txt'));
+
+        $browser = $this->createMock(Browser::class);
+        $browser->expects($this->once())->method('get')->will($this->throwException(new \RuntimeException('First error on get', 12)));
+
+        $provider = $this->getProvider($browser);
+
+        $provider->addFormat('big', ['width' => 200, 'height' => 100, 'constraint' => true]);
+
+        $media = new Media();
+        $media->setBinaryContent('https://vimeo.com/012341231');
+        $media->setId(1023456);
+
+        $method = new \ReflectionMethod($provider, 'getMetadata');
+        $method->setAccessible(true);
+
+        $method->invokeArgs($provider, [$media, '012341231']);
+    }
+
     public function testForm(): void
     {
         $provider = $this->getProvider();

--- a/tests/Provider/YouTubeProviderTest.php
+++ b/tests/Provider/YouTubeProviderTest.php
@@ -182,6 +182,32 @@ class YouTubeProviderTest extends AbstractProviderTest
         ];
     }
 
+    public function testGetMetadataException(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unable to retrieve the video information for :BDYAbAtaDzA');
+        $this->expectExceptionCode(12);
+
+        $response = new Response();
+        $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_youtube.txt'));
+
+        $browser = $this->createMock(Browser::class);
+        $browser->expects($this->once())->method('get')->will($this->throwException(new \RuntimeException('First error on get', 12)));
+
+        $provider = $this->getProvider($browser);
+
+        $provider->addFormat('big', ['width' => 200, 'height' => 100, 'constraint' => true]);
+
+        $media = new Media();
+        $media->setBinaryContent('BDYAbAtaDzA');
+        $media->setId(1023456);
+
+        $method = new \ReflectionMethod($provider, 'getMetadata');
+        $method->setAccessible(true);
+
+        $method->invokeArgs($provider, [$media, 'BDYAbAtaDzA']);
+    }
+
     public function testForm(): void
     {
         $provider = $this->getProvider();


### PR DESCRIPTION
## Subject

In function `getMetadata` in class `BaseVideoProvider` there were an error to throw an exception (line: 212) because this `RuntimeException` receive `null` to second parameter but this class is strict type and this exception normally receive a long, 

## Changelog
```markdown
### Fixed
- Value of code to throw RuntimeException when url of video throw an exception
```
