### PR TITLE
FileProvider::fixBinaryContent(MediaInterface $media) bug fix.

### DIFF
--- a/src/Provider/FileProvider.php
+++ b/src/Provider/FileProvider.php
@@ -342,6 +342,14 @@ class FileProvider extends BaseProvider
             return;
         }
 
+        // if the binary content is a \SplFileInfo => convert to a valid File
+        if ($media->getBinaryContent() instanceof \SplFileInfo) {
+            $binaryContent = new File($media->getBinaryContent()->getPathName());
+            $media->setBinaryContent($binaryContent);
+
+            return;
+        }
+
         // if the binary content is a filename => convert to a valid File
         if (!is_file($media->getBinaryContent())) {
             throw new \RuntimeException('The file does not exist : '.$media->getBinaryContent());

--- a/tests/Provider/BaseProviderTest.php
+++ b/tests/Provider/BaseProviderTest.php
@@ -25,6 +25,7 @@ use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Provider\BaseProvider;
 use Sonata\MediaBundle\Tests\Entity\Media;
 use Sonata\MediaBundle\Thumbnail\ThumbnailInterface;
+use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Form\FormBuilder;
 
 class BaseProviderTest extends AbstractProviderTest
@@ -120,6 +121,20 @@ class BaseProviderTest extends AbstractProviderTest
         $this->assertSame('/0001/02/1f981a048e7d8b671415d17e9633abc0059df394.png', $provider->prevReferenceImage);
 
         $prop->setAccessible(false);
+    }
+
+    public function testTransform(): void
+    {
+        $provider = $this->getProvider();
+
+        $image = new SplFileInfo(__DIR__.'/../fixtures/logo.jpg', '', 'logo.jpg');
+        $media = new Media();
+        $media->setBinaryContent($image);
+        $media->setEnabled(true);
+        $media->setName($image->getFilename());
+        $media->setContext('default');
+        $media->setProviderName('sonata.media.provider.image');
+        $provider->transform($media);
     }
 }
 


### PR DESCRIPTION
"Is_file () expects that parameter 1 is a valid path and an object is given." Error correction.
Bug report is https://github.com/sonata-project/SonataMediaBundle/issues/1596

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
FileProvider::fixBinaryContent(MediaInterface $media) bug fix.
<!-- Describe your Pull Request content here -->
src/Provider/FileProvider.php
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I found this bug in 3.x.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1596

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
- "is_file () expects parameter 1 to be a valid path, object given" error is no longer issued.
```
<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
