### PR TITLE
[Bug]: GalleryMediaCollectionInterface references non existant Interface

### DIFF
--- a/src/Model/GalleryMediaCollectionInterface.php
+++ b/src/Model/GalleryMediaCollectionInterface.php
@@ -19,7 +19,7 @@ namespace Sonata\MediaBundle\Model;
  */
 interface GalleryMediaCollectionInterface
 {
-    public function addGalleryHasMedia(GalleryHasMediaInterface $galleryHasMedia);
+    public function addGalleryHasMedia(GalleryItemInterface $galleryItem);
 
-    public function removeGalleryHasMedia(GalleryHasMediaInterface $galleryHasMedia);
+    public function removeGalleryHasMedia(GalleryItemInterface $galleryItem);
 }


### PR DESCRIPTION
## Subject
- The GalleryMediaCollectionInterface refereced the old
GalleryHasMediaInterface wich was migrated to GalleryItemInterface.
- The old reference was repalced with the new interface

## Why Master branch:
because: Branch `3.x` uses the old  GalleryHasMediaInterface
branch master replaced the old interface with the new one. The Interface: GalleryMediaCollectionInterface was forgotten in this migration

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}

## Changelog
On branch master
Changes to be committed:
- modified:   src/Model/GalleryMediaCollectionInterface.php

```markdown
### Changed
src/Model/GalleryMediaCollectionInterface.php

### Fixed
src/Model/GalleryMediaCollectionInterface.php
```
