### PR TITLE
Modernize references to controllers

### DIFF
--- a/src/Resources/config/doctrine_mongodb_admin.xml
+++ b/src/Resources/config/doctrine_mongodb_admin.xml
@@ -6,15 +6,15 @@
         <parameter key="sonata.media.admin.groupicon"><![CDATA[<i class='fa fa-image'></i>]]></parameter>
         <!-- MEDIA -->
         <parameter key="sonata.media.admin.media.class">Sonata\MediaBundle\Admin\ODM\MediaAdmin</parameter>
-        <parameter key="sonata.media.admin.media.controller">SonataMediaBundle:MediaAdmin</parameter>
+        <parameter key="sonata.media.admin.media.controller">Sonata\MediaBundle\Controller\MediaAdminController</parameter>
         <parameter key="sonata.media.admin.media.translation_domain">SonataMediaBundle</parameter>
         <!-- GALLERY -->
         <parameter key="sonata.media.admin.gallery.class">Sonata\MediaBundle\Admin\GalleryAdmin</parameter>
-        <parameter key="sonata.media.admin.gallery.controller">SonataMediaBundle:GalleryAdmin</parameter>
+        <parameter key="sonata.media.admin.gallery.controller">Sonata\MediaBundle\Controller\GalleryAdminController</parameter>
         <parameter key="sonata.media.admin.gallery.translation_domain">%sonata.media.admin.media.translation_domain%</parameter>
         <!-- GALLERY HAS MEDIA -->
         <parameter key="sonata.media.admin.gallery_has_media.class">Sonata\MediaBundle\Admin\GalleryHasMediaAdmin</parameter>
-        <parameter key="sonata.media.admin.gallery_has_media.controller">SonataAdminBundle:CRUD</parameter>
+        <parameter key="sonata.media.admin.gallery_has_media.controller">Sonata\AdminBundle\Controller\CRUDController</parameter>
         <parameter key="sonata.media.admin.gallery_has_media.translation_domain">%sonata.media.admin.media.translation_domain%</parameter>
     </parameters>
     <services>

--- a/src/Resources/config/doctrine_orm_admin.xml
+++ b/src/Resources/config/doctrine_orm_admin.xml
@@ -6,15 +6,15 @@
         <parameter key="sonata.media.admin.groupicon"><![CDATA[<i class='fa fa-image'></i>]]></parameter>
         <!-- MEDIA -->
         <parameter key="sonata.media.admin.media.class">Sonata\MediaBundle\Admin\ORM\MediaAdmin</parameter>
-        <parameter key="sonata.media.admin.media.controller">SonataMediaBundle:MediaAdmin</parameter>
+        <parameter key="sonata.media.admin.media.controller">Sonata\MediaBundle\Controller\MediaAdminController</parameter>
         <parameter key="sonata.media.admin.media.translation_domain">SonataMediaBundle</parameter>
         <!-- GALLERY -->
         <parameter key="sonata.media.admin.gallery.class">Sonata\MediaBundle\Admin\GalleryAdmin</parameter>
-        <parameter key="sonata.media.admin.gallery.controller">SonataMediaBundle:GalleryAdmin</parameter>
+        <parameter key="sonata.media.admin.gallery.controller">Sonata\MediaBundle\Controller\GalleryAdminController</parameter>
         <parameter key="sonata.media.admin.gallery.translation_domain">%sonata.media.admin.media.translation_domain%</parameter>
         <!-- GALLERY HAS MEDIA -->
         <parameter key="sonata.media.admin.gallery_has_media.class">Sonata\MediaBundle\Admin\GalleryHasMediaAdmin</parameter>
-        <parameter key="sonata.media.admin.gallery_has_media.controller">SonataAdminBundle:CRUD</parameter>
+        <parameter key="sonata.media.admin.gallery_has_media.controller">Sonata\AdminBundle\Controller\CRUDController</parameter>
         <parameter key="sonata.media.admin.gallery_has_media.translation_domain">%sonata.media.admin.media.translation_domain%</parameter>
     </parameters>
     <services>

--- a/src/Resources/config/doctrine_phpcr_admin.xml
+++ b/src/Resources/config/doctrine_phpcr_admin.xml
@@ -6,15 +6,15 @@
         <parameter key="sonata.media.admin.groupicon"><![CDATA[<i class='fa fa-image'></i>]]></parameter>
         <!-- MEDIA -->
         <parameter key="sonata.media.admin.media.class">Sonata\MediaBundle\Admin\PHPCR\MediaAdmin</parameter>
-        <parameter key="sonata.media.admin.media.controller">SonataMediaBundle:MediaAdmin</parameter>
+        <parameter key="sonata.media.admin.media.controller">Sonata\MediaBundle\Controller\MediaAdminController</parameter>
         <parameter key="sonata.media.admin.media.translation_domain">SonataMediaBundle</parameter>
         <!-- GALLERY -->
         <parameter key="sonata.media.admin.gallery.class">Sonata\MediaBundle\Admin\PHPCR\GalleryAdmin</parameter>
-        <parameter key="sonata.media.admin.gallery.controller">SonataMediaBundle:GalleryAdmin</parameter>
+        <parameter key="sonata.media.admin.gallery.controller">Sonata\MediaBundle\Controller\GalleryAdminController</parameter>
         <parameter key="sonata.media.admin.gallery.translation_domain">%sonata.media.admin.media.translation_domain%</parameter>
         <!-- GALLERY HAS MEDIA -->
         <parameter key="sonata.media.admin.gallery_has_media.class">Sonata\MediaBundle\Admin\GalleryHasMediaAdmin</parameter>
-        <parameter key="sonata.media.admin.gallery_has_media.controller">SonataAdminBundle:CRUD</parameter>
+        <parameter key="sonata.media.admin.gallery_has_media.controller">Sonata\AdminBundle\Controller\CRUDController</parameter>
         <parameter key="sonata.media.admin.gallery_has_media.translation_domain">%sonata.media.admin.media.translation_domain%</parameter>
     </parameters>
     <services>

--- a/src/Resources/config/routing/gallery.xml
+++ b/src/Resources/config/routing/gallery.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
     <route id="sonata_media_gallery_index" path="/">
-        <default key="_controller">SonataMediaBundle:Gallery:index</default>
+        <default key="_controller">Sonata\MediaBundle\Controller\GalleryController::indexAction</default>
     </route>
     <route id="sonata_media_gallery_view" path="/view/{id}">
-        <default key="_controller">SonataMediaBundle:Gallery:view</default>
+        <default key="_controller">Sonata\MediaBundle\Controller\GalleryController::viewAction</default>
         <requirement key="id">.*</requirement>
     </route>
 </routes>

--- a/src/Resources/config/routing/media.xml
+++ b/src/Resources/config/routing/media.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
     <route id="sonata_media_view" path="/view/{id}/{format}">
-        <default key="_controller">SonataMediaBundle:Media:view</default>
+        <default key="_controller">Sonata\MediaBundle\Controller\MediaController::viewAction</default>
         <default key="format">reference</default>
     </route>
     <route id="sonata_media_download" path="/download/{id}/{format}">
-        <default key="_controller">SonataMediaBundle:Media:download</default>
+        <default key="_controller">Sonata\MediaBundle\Controller\MediaController::downloadAction</default>
         <default key="format">reference</default>
         <requirement key="id">.*</requirement>
     </route>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Modernize references to controllers in order to avoid deprecated syntaxes.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Updated "_controller" attribute for routes which were using deprecated syntax.
```
