### PR TITLE
Bump "twig/twig" to "^2.9" in order to replace usage of deprecated features

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "symfony/twig-bridge": "^2.8 || ^3.2 || ^4.0",
         "symfony/twig-bundle": "^2.8 || ^3.2 || ^4.0",
         "symfony/validator": "^2.8 || ^3.2 || ^4.0",
-        "twig/twig": "^1.35 || ^2.0"
+        "twig/twig": "^2.9"
     },
     "conflict": {
         "doctrine/dbal": "<2.6.0",

--- a/src/Resources/views/MediaAdmin/edit.html.twig
+++ b/src/Resources/views/MediaAdmin/edit.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% import _self as macros %}
 
 {% macro bytesToSize(bytes) %}
-{% spaceless %}
+{% apply spaceless %}
     {% set kilobyte = 1024 %}
     {% set megabyte = kilobyte * 1024 %}
 
@@ -23,7 +23,7 @@ file that was distributed with this source code.
     {% else %}
         {{ (bytes / megabyte)|number_format(2) ~ ' MB' }}
     {% endif %}
-{% endspaceless %}
+{% endapply %}
 {% endmacro %}
 
 {% extends '@SonataAdmin/CRUD/base_edit.html.twig' %}

--- a/src/Resources/views/MediaAdmin/list.html.twig
+++ b/src/Resources/views/MediaAdmin/list.html.twig
@@ -22,7 +22,7 @@ file that was distributed with this source code.
         </div>
     {% endif %}
     <ul{% if root %} class="sonata-tree sonata-tree--small js-treeview sonata-tree--toggleable"{% endif %}>
-        {% for element in collection if element is not null %}
+        {% for element in collection|filter(element => element is not null) %}
             <li>
                 <div class="sonata-tree__item{% if element.id == current_category_id %} is-active{% endif %}"{% if depth < 2 %} data-treeview-toggled{% endif %}>
                     {% if element.parent or root %}<i class="fa fa-caret-right" data-treeview-toggler></i>{% endif %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Bump "twig/twig" to "^2.9" in order to replace usages of deprecated features.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because the changes are considered BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Bumped "twig/twig" dependency to "^2.9";
- Changed usages of `{% spaceless %}` tag, which is deprecated as of Twig 1.38 with `{% apply spaceless %}` filter;
- Changed usages of `{% for .. if .. %}`, which is deprecated as of Twig 2.10 with `filter` filter'.
```

Follow up of sonata-project/SonataAdminBundle#5576.
