### PR TITLE
Fix alt attribute not displaying the media's description in picture elements

### DIFF
--- a/src/Provider/ImageProvider.php
+++ b/src/Provider/ImageProvider.php
@@ -86,7 +86,7 @@ class ImageProvider extends FileProvider
         $mediaWidth = $box->getWidth();
 
         $params = [
-            'alt' => $media->getName(),
+            'alt' => $media->getDescription() ?: $media->getName(),
             'title' => $media->getName(),
             'src' => $this->generatePublicUrl($media, $format),
             'width' => $mediaWidth,


### PR DESCRIPTION
## Subject

The picture element does not render the correct media image description in the alt tag, getting double content for title and alt, this will result in double reading of the same text in screen readers and you will miss seo value


I am targeting this branch, because i made the PR BC by falling back onto the name.

## Changelog
```markdown
### Changed
- the alt tag of media picture elements to the media description, falling back to the name when no description is present
```
