### PR TITLE
Update constraint for "twig/twig" to ^2.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "symfony/twig-bridge": "^2.8 || ^3.2 || ^4.0",
         "symfony/twig-bundle": "^2.8 || ^3.2 || ^4.0",
         "symfony/validator": "^2.8 || ^3.2 || ^4.0",
-        "twig/twig": "^2.9"
+        "twig/twig": "^2.10"
     },
     "conflict": {
         "doctrine/dbal": "<2.6.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Update constraint for "twig/twig" to ^2.10.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

See https://github.com/sonata-project/SonataAdminBundle/pull/5576#issuecomment-509216140.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Possibility to resolve Twig dependency to versions that don't support arrow functions on Twig filters.
```