### PR TITLE
Use Twig namespaced classes where possible

### DIFF
--- a/src/Twig/Extension/FormatterMediaExtension.php
+++ b/src/Twig/Extension/FormatterMediaExtension.php
@@ -23,7 +23,7 @@ use Twig\Extension\ExtensionInterface;
 class FormatterMediaExtension extends AbstractExtension implements ExtensionInterface
 {
     /**
-     * @var \Twig_Extension
+     * @var AbstractExtension
      */
     protected $twigExtension;
 

--- a/src/Twig/Extension/MediaExtension.php
+++ b/src/Twig/Extension/MediaExtension.php
@@ -19,8 +19,11 @@ use Sonata\MediaBundle\Provider\Pool;
 use Sonata\MediaBundle\Twig\TokenParser\MediaTokenParser;
 use Sonata\MediaBundle\Twig\TokenParser\PathTokenParser;
 use Sonata\MediaBundle\Twig\TokenParser\ThumbnailTokenParser;
+use Twig\Environment;
+use Twig\Extension\AbstractExtension;
+use Twig\Extension\InitRuntimeInterface;
 
-class MediaExtension extends \Twig_Extension implements \Twig_Extension_InitRuntimeInterface
+class MediaExtension extends AbstractExtension implements InitRuntimeInterface
 {
     /**
      * @var Pool
@@ -38,7 +41,7 @@ class MediaExtension extends \Twig_Extension implements \Twig_Extension_InitRunt
     protected $mediaManager;
 
     /**
-     * @var \Twig_Environment
+     * @var Environment
      */
     protected $environment;
 

--- a/src/Twig/Node/MediaNode.php
+++ b/src/Twig/Node/MediaNode.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Twig\Node;
 
-class MediaNode extends \Twig_Node
+use Twig\Node\Expression\AbstractExpression;
+use Twig\Node\Node;
+
+class MediaNode extends Node
 {
     /**
      * @var string
@@ -25,7 +28,7 @@ class MediaNode extends \Twig_Node
      * @param int    $lineno
      * @param string $tag
      */
-    public function __construct($extensionName, \Twig_Node_Expression $media, \Twig_Node_Expression $format, \Twig_Node_Expression $attributes, $lineno, $tag = null)
+    public function __construct($extensionName, AbstractExpression $media, AbstractExpression $format, AbstractExpression $attributes, $lineno, $tag = null)
     {
         $this->extensionName = $extensionName;
 

--- a/src/Twig/Node/PathNode.php
+++ b/src/Twig/Node/PathNode.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Twig\Node;
 
-class PathNode extends \Twig_Node
+use Twig\Node\Expression\AbstractExpression;
+use Twig\Node\Node;
+
+class PathNode extends Node
 {
     /**
      * @var string
@@ -25,7 +28,7 @@ class PathNode extends \Twig_Node
      * @param int    $lineno
      * @param string $tag
      */
-    public function __construct($extensionName, \Twig_Node_Expression $media, \Twig_Node_Expression $format, $lineno, $tag = null)
+    public function __construct($extensionName, AbstractExpression $media, AbstractExpression $format, $lineno, $tag = null)
     {
         $this->extensionName = $extensionName;
 

--- a/src/Twig/Node/ThumbnailNode.php
+++ b/src/Twig/Node/ThumbnailNode.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Twig\Node;
 
-class ThumbnailNode extends \Twig_Node
+use Twig\Node\Expression\AbstractExpression;
+use Twig\Node\Node;
+
+class ThumbnailNode extends Node
 {
     /**
      * @var string
@@ -25,7 +28,7 @@ class ThumbnailNode extends \Twig_Node
      * @param int    $lineno
      * @param string $tag
      */
-    public function __construct($extensionName, \Twig_Node_Expression $media, \Twig_Node_Expression $format, \Twig_Node_Expression $attributes, $lineno, $tag = null)
+    public function __construct($extensionName, AbstractExpression $media, AbstractExpression $format, AbstractExpression $attributes, $lineno, $tag = null)
     {
         $this->extensionName = $extensionName;
 

--- a/src/Twig/TokenParser/MediaTokenParser.php
+++ b/src/Twig/TokenParser/MediaTokenParser.php
@@ -14,8 +14,11 @@ declare(strict_types=1);
 namespace Sonata\MediaBundle\Twig\TokenParser;
 
 use Sonata\MediaBundle\Twig\Node\MediaNode;
+use Twig\Node\Expression\ArrayExpression;
+use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
 
-class MediaTokenParser extends \Twig_TokenParser
+class MediaTokenParser extends AbstractTokenParser
 {
     /**
      * @var string
@@ -42,15 +45,15 @@ class MediaTokenParser extends \Twig_TokenParser
         $format = $this->parser->getExpressionParser()->parseExpression();
 
         // attributes
-        if ($this->parser->getStream()->test(\Twig_Token::NAME_TYPE, 'with')) {
+        if ($this->parser->getStream()->test(Token::NAME_TYPE, 'with')) {
             $this->parser->getStream()->next();
 
             $attributes = $this->parser->getExpressionParser()->parseExpression();
         } else {
-            $attributes = new \Twig_Node_Expression_Array([], $token->getLine());
+            $attributes = new ArrayExpression([], $token->getLine());
         }
 
-        $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
+        $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
 
         return new MediaNode($this->extensionName, $media, $format, $attributes, $token->getLine(), $this->getTag());
     }

--- a/src/Twig/TokenParser/PathTokenParser.php
+++ b/src/Twig/TokenParser/PathTokenParser.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace Sonata\MediaBundle\Twig\TokenParser;
 
 use Sonata\MediaBundle\Twig\Node\PathNode;
+use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
 
-class PathTokenParser extends \Twig_TokenParser
+class PathTokenParser extends AbstractTokenParser
 {
     /**
      * @var string
@@ -41,7 +43,7 @@ class PathTokenParser extends \Twig_TokenParser
 
         $format = $this->parser->getExpressionParser()->parseExpression();
 
-        $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
+        $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
 
         return new PathNode($this->extensionName, $media, $format, $token->getLine(), $this->getTag());
     }

--- a/src/Twig/TokenParser/ThumbnailTokenParser.php
+++ b/src/Twig/TokenParser/ThumbnailTokenParser.php
@@ -14,8 +14,11 @@ declare(strict_types=1);
 namespace Sonata\MediaBundle\Twig\TokenParser;
 
 use Sonata\MediaBundle\Twig\Node\ThumbnailNode;
+use Twig\Node\Expression\ArrayExpression;
+use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
 
-class ThumbnailTokenParser extends \Twig_TokenParser
+class ThumbnailTokenParser extends AbstractTokenParser
 {
     /**
      * @var string
@@ -42,15 +45,15 @@ class ThumbnailTokenParser extends \Twig_TokenParser
         $format = $this->parser->getExpressionParser()->parseExpression();
 
         // attributes
-        if ($this->parser->getStream()->test(\Twig_Token::NAME_TYPE, 'with')) {
+        if ($this->parser->getStream()->test(Token::NAME_TYPE, 'with')) {
             $this->parser->getStream()->next();
 
             $attributes = $this->parser->getExpressionParser()->parseExpression();
         } else {
-            $attributes = new \Twig_Node_Expression_Array([], $token->getLine());
+            $attributes = new ArrayExpression([], $token->getLine());
         }
 
-        $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
+        $this->parser->getStream()->expect(Token::BLOCK_END_TYPE);
 
         return new ThumbnailNode($this->extensionName, $media, $format, $attributes, $token->getLine(), $this->getTag());
     }

--- a/tests/Controller/GalleryAdminControllerTest.php
+++ b/tests/Controller/GalleryAdminControllerTest.php
@@ -37,6 +37,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Twig\Environment;
 
 class GalleryAdminControllerTest extends TestCase
 {
@@ -130,7 +131,7 @@ class GalleryAdminControllerTest extends TestCase
 
     private function configureSetFormTheme(FormView $formView, array $formTheme): void
     {
-        $twig = $this->prophesize(\Twig_Environment::class);
+        $twig = $this->prophesize(Environment::class);
 
         // Remove this trick when bumping Symfony requirement to 3.4+
         if (method_exists(DebugCommand::class, 'getLoaderPaths')) {

--- a/tests/Controller/MediaAdminControllerTest.php
+++ b/tests/Controller/MediaAdminControllerTest.php
@@ -41,6 +41,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Twig\Environment;
+use Twig\Error\RuntimeError;
 
 class MediaAdminControllerTest extends TestCase
 {
@@ -194,7 +196,7 @@ class MediaAdminControllerTest extends TestCase
 
     private function configureSetFormTheme(FormView $formView, $formTheme): void
     {
-        $twig = $this->prophesize(\Twig_Environment::class);
+        $twig = $this->prophesize(Environment::class);
 
         // Remove this trick when bumping Symfony requirement to 3.4+
         if (method_exists(DebugCommand::class, 'getLoaderPaths')) {
@@ -215,7 +217,7 @@ class MediaAdminControllerTest extends TestCase
             $formExtension->renderer = $twigRenderer->reveal();
 
             // This Throw is for the CRUDController::setFormTheme()
-            $twig->getRuntime($rendererClass)->willThrow(\Twig_Error_Runtime::class);
+            $twig->getRuntime($rendererClass)->willThrow(RuntimeError::class);
             $twig->getExtension(FormExtension::class)->willReturn($formExtension->reveal());
         }
         $twigRenderer->setTheme($formView, $formTheme)->shouldBeCalled();

--- a/tests/Twig/Extension/MediaExtensionTest.php
+++ b/tests/Twig/Extension/MediaExtensionTest.php
@@ -18,6 +18,8 @@ use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Sonata\MediaBundle\Twig\Extension\MediaExtension;
+use Twig\Environment;
+use Twig\Template;
 
 /**
  * @author Geza Buza <bghome@gmail.com>
@@ -30,12 +32,12 @@ class MediaExtensionTest extends TestCase
     private $provider;
 
     /**
-     * @var Twig_Template
+     * @var Template
      */
     private $template;
 
     /**
-     * @var Twig_Environment
+     * @var Environment
      */
     private $environment;
 
@@ -107,7 +109,7 @@ class MediaExtensionTest extends TestCase
     public function getTemplate()
     {
         if (null === $this->template) {
-            $this->template = $this->getMockBuilder('Twig_Template')
+            $this->template = $this->getMockBuilder(Template::class)
                                    ->disableOriginalConstructor()
                                    ->setMethods(['render'])
                                    ->getMockForAbstractClass();
@@ -119,7 +121,7 @@ class MediaExtensionTest extends TestCase
     public function getEnvironment()
     {
         if (null === $this->environment) {
-            $this->environment = $this->getMockBuilder('Twig_Environment')
+            $this->environment = $this->getMockBuilder(Environment::class)
                 ->disableOriginalConstructor()
                 ->getMock();
             $this->environment->method('loadTemplate')->willReturn($this->getTemplate());


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Use Twig namespaced classes where possible.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

The non namespaced classes were left intact at public method signatures where they can't be replaced.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Using deprecated `\Twig_` classes without namespace.
```