### PR TITLE
Remove some non required function calls

### DIFF
--- a/src/Command/AddMassMediaCommand.php
+++ b/src/Command/AddMassMediaCommand.php
@@ -92,7 +92,7 @@ class AddMassMediaCommand extends BaseCommand
         $media = $this->getMediaManager()->create();
 
         foreach ($this->setters as $pos => $name) {
-            \call_user_func([$media, 'set'.$name], $data[$pos]);
+            $media->{'set'.$name}($data[$pos]);
         }
 
         try {

--- a/src/Twig/Extension/MediaExtension.php
+++ b/src/Twig/Extension/MediaExtension.php
@@ -54,9 +54,9 @@ class MediaExtension extends \Twig_Extension implements \Twig_Extension_InitRunt
     public function getTokenParsers()
     {
         return [
-            new MediaTokenParser(\get_called_class()),
-            new ThumbnailTokenParser(\get_called_class()),
-            new PathTokenParser(\get_called_class()),
+            new MediaTokenParser(static::class),
+            new ThumbnailTokenParser(static::class),
+            new PathTokenParser(static::class),
         ];
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Remove some non required function calls (`call_user_func()`, `get_called_class()`).
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->