### PR TITLE
Add breadcrumb context to seo blocks

### DIFF
--- a/src/Resources/config/seo_block.xml
+++ b/src/Resources/config/seo_block.xml
@@ -7,7 +7,7 @@
     </parameters>
     <services>
         <service id="sonata.media.block.breadcrumb_view" class="%sonata.media.block.breadcrumb_view.class%">
-            <tag name="sonata.block"/>
+            <tag name="sonata.block" context="breadcrumb"/>
             <tag name="sonata.breadcrumb"/>
             <argument>gallery_view</argument>
             <argument>sonata.media.block.breadcrumb_view</argument>
@@ -16,7 +16,7 @@
             <argument type="service" id="knp_menu.factory"/>
         </service>
         <service id="sonata.media.block.breadcrumb_index" class="%sonata.media.block.breadcrumb_index.class%">
-            <tag name="sonata.block"/>
+            <tag name="sonata.block" context="breadcrumb"/>
             <tag name="sonata.breadcrumb"/>
             <argument>gallery_index</argument>
             <argument>sonata.media.block.breadcrumb_view</argument>
@@ -25,7 +25,7 @@
             <argument type="service" id="knp_menu.factory"/>
         </service>
         <service id="sonata.media.block.breadcrumb_view_media" class="%sonata.media.block.breadcrumb_media.class%">
-            <tag name="sonata.block"/>
+            <tag name="sonata.block" context="breadcrumb"/>
             <tag name="sonata.breadcrumb"/>
             <argument>media_view</argument>
             <argument>sonata.media.block.breadcrumb_view_media</argument>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because this is technically a BC break, because it removes breadcrumb blocks from the page composer, but no one should ever used it.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Add `breadcrumb` as default context for seo blocks
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
