### PR TITLE
fix incorrect docblock

### DIFF
--- a/src/Model/MediaInterface.php
+++ b/src/Model/MediaInterface.php
@@ -261,7 +261,7 @@ interface MediaInterface
     /**
      * Set cdn_flush_identifier.
      *
-     * @param bool $cdnFlushIdentifier
+     * @param string $cdnFlushIdentifier
      */
     public function setCdnFlushIdentifier($cdnFlushIdentifier);
 


### PR DESCRIPTION
## fix incorrect type in the interface method docblock

We use Phpstan in our project, if we try to set the cdnFlushIdentifier with a string (which should be correct) phpstan is complaining about it being a boolean.

## Changelog

```markdown
### Changed
- Changed parameter type in `MediaInterface::setCdnFlushIdentifier`
```
