### PR TITLE
Add support for imagine ^1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,10 @@ matrix:
       env: SONATA_ADMIN='dev-master as 3.x-dev'
     - php: '7.3'
       env: SYMFONY_DEPRECATIONS_HELPER=0
+    - php: '7.3'
+      env: IMAGINE='^1.0'
+    - php: '7.3'
+      env: IMAGINE='^0.7'
   allow_failures:
     - php: nightly
     - env: SYMFONY_DEPRECATIONS_HELPER=0

--- a/.travis/before_install_test.sh
+++ b/.travis/before_install_test.sh
@@ -18,4 +18,5 @@ sed --in-place "s/\"dev-master\":/\"dev-${TRAVIS_COMMIT}\":/" composer.json
         if [ "$DOCTRINE_ODM" != "" ]; then composer require "doctrine/mongodb-odm:$DOCTRINE_ODM" --no-update; fi;
         if [ "$SONATA_CORE" != "" ]; then composer require "sonata-project/core-bundle:$SONATA_CORE" --no-update; fi;
         if [ "$SONATA_ADMIN" != "" ]; then composer require "sonata-project/admin-bundle:$SONATA_ADMIN" --no-update; fi;
-    
+        if [ "$SONATA_ADMIN" != "" ]; then composer require "sonata-project/admin-bundle:$SONATA_ADMIN" --no-update; fi;
+        if [ "$IMAGINE" != "" ]; then composer require "imagine/imagine:$IMAGINE" --no-update; fi;

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^7.1",
         "guzzlehttp/psr7": "^1.0",
-        "imagine/imagine": "^0.6 || ^0.7",
+        "imagine/imagine": "^0.6 || ^0.7 || ^1.0",
         "jms/serializer-bundle": "^1.0 || ^2.0 || ^3.0",
         "knplabs/gaufrette": "^0.8",
         "kriswallsmith/buzz": "^0.15 || ^0.16",
@@ -73,7 +73,7 @@
         "aws/aws-sdk-php": "^2.8",
         "friendsofsymfony/rest-bundle": "^2.1",
         "jackalope/jackalope-doctrine-dbal": "^1.1",
-        "liip/imagine-bundle": "^1.9",
+        "liip/imagine-bundle": "^1.9 || ^2.0",
         "matthiasnoback/symfony-dependency-injection-test": "^3.1",
         "nelmio/api-doc-bundle": "^2.11",
         "sonata-project/admin-bundle": "^3.31",

--- a/src/Resizer/ImagineCompatibleResizerTrait.php
+++ b/src/Resizer/ImagineCompatibleResizerTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Resizer;
+
+use Imagine\Image\ImageInterface;
+use Imagine\Image\ImagineInterface;
+
+/**
+ * This trait is used to provide compatibility with Imagine >= 1.0.0.
+ */
+trait ImagineCompatibleResizerTrait
+{
+    /**
+     * Convert mode for compatibility with imagine >= 1.0.0.
+     *
+     * @param int|string $mode
+     *
+     * @return int|string
+     */
+    final protected function convertMode($mode)
+    {
+        if (\is_string($mode) && version_compare(ImagineInterface::VERSION, '1.0.0', '>=')) {
+            if ('inset' === $mode) {
+                $mode = ImageInterface::THUMBNAIL_INSET;
+            } elseif ('outbound' === $mode) {
+                $mode = ImageInterface::THUMBNAIL_OUTBOUND;
+            } elseif (is_numeric($mode)) {
+                $mode = (int) $mode;
+            }
+        }
+
+        return $mode;
+    }
+}

--- a/src/Resizer/SimpleResizer.php
+++ b/src/Resizer/SimpleResizer.php
@@ -26,6 +26,8 @@ use Sonata\MediaBundle\Model\MediaInterface;
  */
 class SimpleResizer implements ResizerInterface
 {
+    use ImagineCompatibleResizerTrait;
+
     /**
      * @var ImagineInterface
      */
@@ -47,7 +49,7 @@ class SimpleResizer implements ResizerInterface
     public function __construct(ImagineInterface $adapter, $mode, MetadataBuilderInterface $metadata)
     {
         $this->adapter = $adapter;
-        $this->mode = $mode;
+        $this->mode = $this->convertMode($mode);
         $this->metadata = $metadata;
     }
 

--- a/src/Resizer/SquareResizer.php
+++ b/src/Resizer/SquareResizer.php
@@ -32,6 +32,8 @@ use Sonata\MediaBundle\Model\MediaInterface;
  */
 class SquareResizer implements ResizerInterface
 {
+    use ImagineCompatibleResizerTrait;
+
     /**
      * @var ImagineInterface
      */
@@ -53,7 +55,7 @@ class SquareResizer implements ResizerInterface
     public function __construct(ImagineInterface $adapter, $mode, MetadataBuilderInterface $metadata)
     {
         $this->adapter = $adapter;
-        $this->mode = $mode;
+        $this->mode = $this->convertMode($mode);
         $this->metadata = $metadata;
     }
 

--- a/tests/Resizer/ImagineCompatibleResizerTraitTest.php
+++ b/tests/Resizer/ImagineCompatibleResizerTraitTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\Resizer;
+
+use Imagine\Image\ImageInterface;
+use PHPUnit\Framework\TestCase;
+use Sonata\MediaBundle\Resizer\ImagineCompatibleResizerTrait;
+
+class ImagineCompatibleResizerTraitTest extends TestCase
+{
+    /**
+     * @dataProvider getModes
+     */
+    public function testModeConversion($mode, $result): void
+    {
+        $objectWithTrait = $this->getObjectForTrait(ImagineCompatibleResizerTrait::class);
+        $reflection = new \ReflectionObject($objectWithTrait);
+        $method = $reflection->getMethod('convertMode');
+        $method->setAccessible(true);
+
+        $convertedMode = $method->invokeArgs($objectWithTrait, [$mode]);
+
+        $this->assertSame($result, $convertedMode);
+    }
+
+    public static function getModes()
+    {
+        return [
+            ['inset', ImageInterface::THUMBNAIL_INSET],
+            ['outbound', ImageInterface::THUMBNAIL_OUTBOUND],
+        ];
+    }
+}


### PR DESCRIPTION
## Subject

Add possibility to use imagine >= 1.0.0

I am targeting this branch, because there should be no BC-break.



Closes #1605 

## Changelog

```markdown
### Added
- Imagine `^1.0` support

### Changed
- SimpleResizer and SquareResizer resizers now use ImagineCompatibleResizerTrait
```
    
 ## To do
    
 - [x] Update travis config to run tests using imagine `^0.7` and `^1.0`
 - [x] Update tests