### PR TITLE
Extract FileProviderInterface from FileProvider

### DIFF
--- a/src/Provider/FileProvider.php
+++ b/src/Provider/FileProvider.php
@@ -38,7 +38,7 @@ use Symfony\Component\Validator\Constraints\NotNull;
 /**
  * @final since sonata-project/media-bundle 3.21.0
  */
-class FileProvider extends BaseProvider
+class FileProvider extends BaseProvider implements FileProviderInterface
 {
     protected $allowedExtensions;
 

--- a/src/Provider/FileProviderInterface.php
+++ b/src/Provider/FileProviderInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Provider;
+
+interface FileProviderInterface extends MediaProviderInterface
+{
+    /**
+     * @return string[]
+     */
+    public function getAllowedExtensions();
+
+    /**
+     * @return string[]
+     */
+    public function getAllowedMimeTypes();
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

The `FileProvider` currently extends `BaseProvider`, but exposes additional methods in its public API beyond those from `MediaProviderInterface`, such as `getAllowedExtensions` and `getAllowedMimeTypes`, which are not part of any interface.

This hampers decoration as no interface provides these methods. Instead, one must either check for an instance of `FileProvider`, forcing you to extend rather than decorate, or use `method_exists`, which is suboptimal as well.

This extracts a new extending interface. 

This change should be backwards compatible with 3.x as only a new interface is added, but the contract for it was already implemented. Existing code targeting the `FileProvider` or extending it will remain operational.

Closes #1638.

## Changelog
```markdown
### Changed
Extract and implement FileProviderInterface from FileProvider to allow decoration (fixes #1638).

```
