### PR TITLE
fix(thumbnail): add 'addResizer' method call only if the method exists

### DIFF
--- a/src/DependencyInjection/Compiler/ThumbnailCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ThumbnailCompilerPass.php
@@ -32,6 +32,10 @@ class ThumbnailCompilerPass implements CompilerPassInterface
             'sonata.media.thumbnail.format'
         );
 
+        if (!\is_callable([$container->getParameterBag()->resolveValue($definition->getClass()), 'addResizer'])) {
+            return;
+        }
+
         $taggedServices = $container->findTaggedServiceIds(
             'sonata.media.resizer'
         );

--- a/tests/DependencyInjection/Compiler/ThumbnailCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ThumbnailCompilerPassTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\MediaBundle\DependencyInjection\Compiler\ThumbnailCompilerPass;
+use Sonata\MediaBundle\Thumbnail\ConsumerThumbnail;
+use Sonata\MediaBundle\Thumbnail\FormatThumbnail;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+final class ThumbnailCompilerPassTest extends TestCase
+{
+    /**
+     * @dataProvider processProvider
+     */
+    public function testProcess(bool $expected, string $class, ParameterBagInterface $parameterBag = null): void
+    {
+        $container = new ContainerBuilder($parameterBag);
+        $container
+            ->register('foobar')
+            ->addTag('sonata.media.resizer');
+        $thumbnailDefinition = $container->register('sonata.media.thumbnail.format', $class);
+
+        (new ThumbnailCompilerPass())->process($container);
+
+        $this->assertSame($expected, $thumbnailDefinition->hasMethodCall('addResizer'));
+    }
+
+    public function processProvider(): array
+    {
+        return [
+            [true, FormatThumbnail::class],
+            [false, ConsumerThumbnail::class],
+            [true, '%foo%', new ParameterBag(['foo' => FormatThumbnail::class])],
+            [false, '%bar%', new ParameterBag(['bar' => TestUncallableAddResizerMethod::class])],
+        ];
+    }
+}
+
+final class TestUncallableAddResizerMethod
+{
+    private function addResizer(): void
+    {
+    }
+}


### PR DESCRIPTION
## Subject

The ThumbnailCompilerPass add the "addResizer" method call on the thumbnail service
but this method is not on the ThumbnailInterface, so there is no guarantee it actually exists.
I do not take into account the fact that the service could be a child definition, as this is not the
case in "our" implementation. If someone alters it, it is his/her responsability.

I am targeting this branch, because it is a bug fix, backward compatible.

## Changelog

```markdown
### Fixed
Add the "addResizer" method call on the thumbnail service only if the method exists.
```