### PR TITLE
Fix Media Helper (Twig): set picture key setting will ignore other parameters like Title, Alt etc.

### DIFF
--- a/src/Provider/ImageProvider.php
+++ b/src/Provider/ImageProvider.php
@@ -103,7 +103,7 @@ class ImageProvider extends FileProvider
             }
 
             unset($options['picture']);
-            $pictureParams['img'] = $params + $options;
+            $pictureParams['img'] = $options + $params;
             $params = ['picture' => $pictureParams];
         } elseif (MediaProviderInterface::FORMAT_ADMIN !== $format) {
             $srcSetFormats = $this->getFormats();


### PR DESCRIPTION
## Subject

When `picture` key is set via  Twig tag  
 `{% media media, 'large' with {'picture': ['small', 'big'], 'title':'My Title', 'alt':'My alt'} %}`  
  options like `alt`, `title`, etc. are ignored and used default from media Entity.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is PATCH of this version.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

```markdown
### Fixed
- Fix arrays union order of given `$options` and default `$params` in  `src/Provider/ImageProvider.php`
```