### PR TITLE
Deprecate Guzzle with psr http-client

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -14,6 +14,10 @@ version of aws/aws-sdk-php is automatically inferred from the installed package.
 The configuration nodes "sonata_media.cdn.cloudfront.region" and "sonata_media.cdn.cloudfront.version"
 are required when aws/aws-sdk-php 3.x is installed.
 
+## BaseVideoProvider uses `psr/http-client`
+
+The `Guzzle` and `Buzz` dependencies are deprecated and will be replaced with the abstract `http-client` interface, so you can choose your preferred client implementation. You should adapt to the new `BaseVideoProvider::__construct()` signature.
+
 UPGRADE FROM 3.25 to 3.26
 =========================
 

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,9 @@
         "jms/serializer-bundle": "^2.3.1 || ^3.0",
         "knplabs/gaufrette": "^0.8 || ^0.9",
         "kriswallsmith/buzz": "^0.15 || ^0.16",
+        "psr/http-client": "^1.0",
+        "psr/http-factory": "^1.0",
+        "psr/http-message": "^1.0",
         "psr/log": "^1.0",
         "sonata-project/doctrine-extensions": "^1.8",
         "sonata-project/form-extensions": "^0.1.2 || ^1.4",
@@ -88,6 +91,7 @@
         "sonata-project/notification-bundle": "^3.3",
         "sonata-project/seo-bundle": "^2.5",
         "symfony/browser-kit": "^4.4 || ^5.1",
+        "symfony/http-client": "^4.4 || ^5.1",
         "symfony/phpunit-bridge": "^5.1.1",
         "symfony/security-csrf": "^4.4"
     },
@@ -98,6 +102,7 @@
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
         "sonata-project/notification-bundle": "If you want to generate thumbnails asynchronously.",
         "sonata-project/seo-bundle": "^2.1",
+        "symfony/http-client": "If you want to load external content",
         "symfony/monolog-bundle": "If you want to log exceptions produced when dealing with images.",
         "tilleuls/ckeditor-sonata-media-bundle": "^1.0",
         "twig/extra-bundle": "Auto configures the Twig Intl extension"

--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -177,5 +177,17 @@ Full configuration options:
                 generator:  sonata.media.generator.default
                 thumbnail:  sonata.media.thumbnail.format
 
+        # The buzz implementation is deprecated, use a PSR http-client instead
         buzz:
             connector:  sonata.media.buzz.connector.file_get_contents # sonata.media.buzz.connector.curl
+
+        http:
+            client:          'symfony_http_client'       # You need symfony/http-client for this
+            message_factory: 'nyholm.psr7.psr17_factory' # You need nyholm/psr7 for this
+
+        services:
+            symfony_http_client:
+                class: Symfony\Component\HttpClient\Psr18Client
+
+            nyholm.psr7.psr17_factory:
+                class: Nyholm\Psr7\Factory\Psr17Factory

--- a/docs/reference/creating_a_provider_class.rst
+++ b/docs/reference/creating_a_provider_class.rst
@@ -265,7 +265,7 @@ added to the provider pool.
             - '@sonata.media.cdn.server'
             - '@sonata.media.generator.default'
             - '@sonata.media.thumbnail.format'
-            - '@sonata.media.buzz.browser'
+            - '@sonata.media.http.client'
             - '@sonata.media.metadata.proxy'
         calls:
             -

--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -51,6 +51,10 @@ Add ``SonataMediaBundle`` via composer::
 
     composer require sonata-project/media-bundle
 
+To load external resources, e.g. Vimeo or YouTube, you must use a ``psr/http-client`` and ``psr/http-factory``::
+
+    composer require symfony/http-client nyholm/psr7
+
 If you want to use the REST API, you also need ``friendsofsymfony/rest-bundle`` and ``nelmio/api-doc-bundle``::
 
     composer require friendsofsymfony/rest-bundle nelmio/api-doc-bundle

--- a/src/Client/BuzzClient.php
+++ b/src/Client/BuzzClient.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Client;
+
+use Buzz\Browser;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * NEXT_MAJOR: Remove this class.
+ *
+ * @deprecated since sonata-project/media-bundle 3.x, to be removed in version 4.0.
+ */
+final class BuzzClient implements ClientInterface
+{
+    /**
+     * @var Browser
+     */
+    private $browser;
+
+    public function __construct(Browser $browser)
+    {
+        $this->browser = $browser;
+    }
+
+    public function sendRequest(RequestInterface $request): ResponseInterface
+    {
+        return $this->browser->sendRequest($request);
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -79,6 +79,7 @@ class Configuration implements ConfigurationInterface
         $this->addExtraSection($node);
         $this->addModelSection($node);
         $this->addBuzzSection($node);
+        $this->addHttpClientSection($node);
         $this->addResizerSection($node);
         $this->addAdapterSection($node);
 
@@ -522,6 +523,27 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('timeout')->defaultValue(5)->end()
                             ->booleanNode('verify_peer')->defaultValue(true)->end()
                             ->scalarNode('proxy')->defaultNull()->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    private function addHttpClientSection(ArrayNodeDefinition $node): void
+    {
+        $node
+            ->children()
+                ->arrayNode('http')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('client')
+                            ->defaultValue('sonata.media.http.buzz_client')
+                            ->info('Alias of the http client.')
+                        ->end()
+                        ->scalarNode('message_factory')
+                            ->defaultNull()
+                            ->info('Alias of the message factory.')
                         ->end()
                     ->end()
                 ->end()

--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -166,6 +166,7 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
         $this->configureParameterClass($container, $config);
         $this->configureExtra($container, $config);
         $this->configureBuzz($container, $config);
+        $this->configureHttpClient($container, $config);
         $this->configureProviders($container, $config);
         $this->configureAdapters($container, $config);
         $this->configureResizers($container, $config);
@@ -672,5 +673,18 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
                     ])
             );
         }
+    }
+
+    private function configureHttpClient(ContainerBuilder $container, array $config): void
+    {
+        if (null === $config['http']['client'] || null === $config['http']['message_factory']) {
+            // NEXT_MAJOR: Remove this fallback service
+            $container->setAlias('sonata.media.http.client', 'sonata.media.buzz.browser');
+
+            return;
+        }
+
+        $container->setAlias('sonata.media.http.client', $config['http']['client']);
+        $container->setAlias('sonata.media.http.message_factory', $config['http']['message_factory']);
     }
 }

--- a/src/Metadata/AmazonMetadataBuilder.php
+++ b/src/Metadata/AmazonMetadataBuilder.php
@@ -13,8 +13,9 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Metadata;
 
-use GuzzleHttp\Psr7;
 use Sonata\MediaBundle\Model\MediaInterface;
+use Symfony\Component\Mime\MimeTypes;
+use Symfony\Component\Mime\MimeTypesInterface;
 
 /**
  * @final since sonata-project/media-bundle 3.21.0
@@ -49,9 +50,15 @@ class AmazonMetadataBuilder implements MetadataBuilderInterface
         'owner_full_control' => self::BUCKET_OWNER_FULL_CONTROL,
     ];
 
-    public function __construct(array $settings)
+    /**
+     * @var MimeTypes
+     */
+    private $mimeTypes;
+
+    public function __construct(array $settings, ?MimeTypesInterface $mimeTypes = null)
     {
         $this->settings = $settings;
+        $this->mimeTypes = $mimeTypes ?? new MimeTypes();
     }
 
     public function get(MediaInterface $media, $filename)
@@ -113,9 +120,6 @@ class AmazonMetadataBuilder implements MetadataBuilderInterface
      */
     protected function getContentType($filename)
     {
-        $extension = pathinfo($filename, PATHINFO_EXTENSION);
-        $contentType = Psr7\mimetype_from_extension($extension);
-
-        return ['contentType' => $contentType];
+        return ['contentType' => $this->mimeTypes->guessMimeType($filename)];
     }
 }

--- a/src/Provider/YouTubeProvider.php
+++ b/src/Provider/YouTubeProvider.php
@@ -15,6 +15,8 @@ namespace Sonata\MediaBundle\Provider;
 
 use Buzz\Browser;
 use Gaufrette\Filesystem;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 use Sonata\MediaBundle\CDN\CDNInterface;
 use Sonata\MediaBundle\Generator\GeneratorInterface;
 use Sonata\MediaBundle\Metadata\MetadataBuilderInterface;
@@ -35,11 +37,22 @@ class YouTubeProvider extends BaseVideoProvider
     /**
      * @param string                   $name
      * @param MetadataBuilderInterface $metadata
+     * @param ClientInterface|Browser  $client
      * @param bool                     $html5
      */
-    public function __construct($name, Filesystem $filesystem, CDNInterface $cdn, GeneratorInterface $pathGenerator, ThumbnailInterface $thumbnail, Browser $browser, ?MetadataBuilderInterface $metadata = null, $html5 = false)
-    {
-        parent::__construct($name, $filesystem, $cdn, $pathGenerator, $thumbnail, $browser, $metadata);
+    public function __construct(
+        $name,
+        Filesystem $filesystem,
+        CDNInterface $cdn,
+        GeneratorInterface $pathGenerator,
+        ThumbnailInterface $thumbnail,
+        object $client,
+        ?MetadataBuilderInterface $metadata = null,
+        $html5 = false,
+        ?RequestFactoryInterface $requestFactory = null
+    ) {
+        parent::__construct($name, $filesystem, $cdn, $pathGenerator, $thumbnail, $client, $metadata, $requestFactory);
+
         $this->html5 = $html5;
     }
 

--- a/src/Resources/config/provider.xml
+++ b/src/Resources/config/provider.xml
@@ -64,9 +64,10 @@
             <argument/>
             <argument/>
             <argument type="service" id="sonata.media.thumbnail.format"/>
-            <argument type="service" id="sonata.media.buzz.browser"/>
+            <argument type="service" id="sonata.media.http.client"/>
             <argument type="service" id="sonata.media.metadata.proxy"/>
             <argument/>
+            <argument type="service" id="sonata.media.http.message_factory" on-invalid="null"/>
             <call method="setTemplates">
                 <argument type="collection">
                     <argument key="helper_thumbnail">@SonataMedia/Provider/thumbnail.html.twig</argument>
@@ -81,8 +82,9 @@
             <argument/>
             <argument/>
             <argument type="service" id="sonata.media.thumbnail.format"/>
-            <argument type="service" id="sonata.media.buzz.browser"/>
+            <argument type="service" id="sonata.media.http.client"/>
             <argument type="service" id="sonata.media.metadata.proxy"/>
+            <argument type="service" id="sonata.media.http.message_factory" on-invalid="null"/>
             <call method="setTemplates">
                 <argument type="collection">
                     <argument key="helper_thumbnail">@SonataMedia/Provider/thumbnail.html.twig</argument>
@@ -97,8 +99,9 @@
             <argument/>
             <argument/>
             <argument type="service" id="sonata.media.thumbnail.format"/>
-            <argument type="service" id="sonata.media.buzz.browser"/>
+            <argument type="service" id="sonata.media.http.client"/>
             <argument type="service" id="sonata.media.metadata.proxy"/>
+            <argument type="service" id="sonata.media.http.message_factory" on-invalid="null"/>
             <call method="setTemplates">
                 <argument type="collection">
                     <argument key="helper_thumbnail">@SonataMedia/Provider/thumbnail.html.twig</argument>
@@ -110,6 +113,9 @@
         <service id="sonata.media.buzz.connector.curl" class="Buzz\Client\Curl"/>
         <service id="sonata.media.buzz.browser" class="Buzz\Browser">
             <argument/>
+        </service>
+        <service id="sonata.media.http.buzz_client" class="Sonata\MediaBundle\Client\BuzzClient">
+            <argument type="service" id="sonata.media.buzz.browser"/>
         </service>
         <service id="%sonata.media.provider.image.class%" alias="sonata.media.provider.image"/>
         <service id="%sonata.media.provider.file.class%" alias="sonata.media.provider.file"/>

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -30,6 +30,10 @@ class ConfigurationTest extends TestCase
             'sonata_media' => [
                 'db_driver' => 'doctrine_orm',
                 'default_context' => 'default',
+                'http' => [
+                    'client' => 'sonata.media.http.buzz_client',
+                    'message_factory' => null,
+                ],
             ],
         ];
         $processor = new Processor();

--- a/tests/DependencyInjection/SonataMediaExtensionTest.php
+++ b/tests/DependencyInjection/SonataMediaExtensionTest.php
@@ -136,6 +136,27 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
         }
     }
 
+    public function testDefaultHasDefaultHttp(): void
+    {
+        $this->load();
+
+        $this->assertContainerBuilderHasAlias('sonata.media.http.client', 'sonata.media.buzz.browser');
+        $this->assertContainerBuilderNotHasService('sonata.media.http.message_factory');
+    }
+
+    public function testWithHttpClient(): void
+    {
+        $this->load([
+            'http' => [
+                'client' => 'acme_client',
+                'message_factory' => 'acme_factory',
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasAlias('sonata.media.http.client', 'acme_client');
+        $this->assertContainerBuilderHasAlias('sonata.media.http.message_factory', 'acme_factory');
+    }
+
     /**
      * @dataProvider dataResizer
      */

--- a/tests/Metadata/AmazonMetadataBuilderTest.php
+++ b/tests/Metadata/AmazonMetadataBuilderTest.php
@@ -17,6 +17,7 @@ use Aws\S3\Enum\Storage;
 use PHPUnit\Framework\TestCase;
 use Sonata\MediaBundle\Metadata\AmazonMetadataBuilder;
 use Sonata\MediaBundle\Model\MediaInterface;
+use Symfony\Component\Mime\MimeTypesInterface;
 
 final class AmazonMetadataBuilderTest extends TestCase
 {
@@ -25,10 +26,13 @@ final class AmazonMetadataBuilderTest extends TestCase
      */
     public function testAmazon(array $settings, array $expected): void
     {
+        $mimeTypes = $this->createMock(MimeTypesInterface::class);
+        $mimeTypes->method('guessMimeType')->willReturn($expected['contentType']);
+
         $media = $this->createStub(MediaInterface::class);
         $filename = '/test/folder/testfile.png';
 
-        $amazonmetadatabuilder = new AmazonMetadataBuilder($settings);
+        $amazonmetadatabuilder = new AmazonMetadataBuilder($settings, $mimeTypes);
         $this->assertSame($expected, $amazonmetadatabuilder->get($media, $filename));
     }
 

--- a/tests/Provider/AbstractProviderTest.php
+++ b/tests/Provider/AbstractProviderTest.php
@@ -15,6 +15,8 @@ namespace Sonata\MediaBundle\Tests\Provider;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Symfony\Component\Form\FormBuilder;
@@ -85,5 +87,16 @@ abstract class AbstractProviderTest extends TestCase
             ->method('add');
 
         $this->provider->buildMediaType($this->formBuilder);
+    }
+
+    final protected function createResponse(string $content): ResponseInterface
+    {
+        $stream = $this->createStub(StreamInterface::class);
+        $stream->method('getContents')->willReturn($content);
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->once())->method('getBody')->willReturn($stream);
+
+        return $response;
     }
 }

--- a/tests/Provider/YouTubeProviderTest.php
+++ b/tests/Provider/YouTubeProviderTest.php
@@ -14,12 +14,14 @@ declare(strict_types=1);
 namespace Sonata\MediaBundle\Tests\Provider;
 
 use Buzz\Browser;
-use Buzz\Message\AbstractMessage;
 use Buzz\Message\Response;
 use Gaufrette\Adapter;
 use Gaufrette\File;
 use Gaufrette\Filesystem;
 use Imagine\Image\Box;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\MediaBundle\CDN\Server;
@@ -33,10 +35,14 @@ use Sonata\MediaBundle\Thumbnail\FormatThumbnail;
 
 class YouTubeProviderTest extends AbstractProviderTest
 {
-    public function getProvider(?Browser $browser = null): MediaProviderInterface
+    public function getProvider(?object $client = null, ?RequestFactoryInterface $messageFactory = null): MediaProviderInterface
     {
-        if (!$browser) {
-            $browser = $this->createMock(Browser::class);
+        if (null === $client) {
+            $client = $this->createStub(ClientInterface::class);
+        }
+
+        if (null === $messageFactory) {
+            $messageFactory = $this->createStub(RequestFactoryInterface::class);
         }
 
         $resizer = $this->createMock(ResizerInterface::class);
@@ -62,7 +68,7 @@ class YouTubeProviderTest extends AbstractProviderTest
 
         $metadata = $this->createMock(MetadataBuilderInterface::class);
 
-        $provider = new YouTubeProvider('youtube', $filesystem, $cdn, $generator, $thumbnail, $browser, $metadata);
+        $provider = new YouTubeProvider('youtube', $filesystem, $cdn, $generator, $thumbnail, $client, $metadata, false, $messageFactory);
         $provider->setResizer($resizer);
 
         return $provider;
@@ -89,14 +95,15 @@ class YouTubeProviderTest extends AbstractProviderTest
 
     public function testThumbnail(): void
     {
-        $response = $this->createMock(AbstractMessage::class);
-        $response->expects($this->once())->method('getContent')->willReturn('content');
+        $request = $this->createStub(RequestInterface::class);
 
-        $browser = $this->createMock(Browser::class);
+        $requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $requestFactory->expects($this->once())->method('createRequest')->willReturn($request);
 
-        $browser->expects($this->once())->method('get')->willReturn($response);
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())->method('sendRequest')->with($this->equalTo($request))->willReturn($this->createResponse('content'));
 
-        $provider = $this->getProvider($browser);
+        $provider = $this->getProvider($client, $requestFactory);
 
         $media = new Media();
         $media->setProviderName('youtube');
@@ -119,13 +126,16 @@ class YouTubeProviderTest extends AbstractProviderTest
 
     public function testTransformWithSig(): void
     {
-        $response = new Response();
-        $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_youtube.txt'));
+        $request = $this->createStub(RequestInterface::class);
 
-        $browser = $this->createMock(Browser::class);
-        $browser->expects($this->once())->method('get')->willReturn($response);
+        $messageFactory = $this->createMock(RequestFactoryInterface::class);
+        $messageFactory->expects($this->once())->method('createRequest')->willReturn($request);
 
-        $provider = $this->getProvider($browser);
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())->method('sendRequest')->with($this->equalTo($request))
+            ->willReturn($this->createResponse(file_get_contents(__DIR__.'/../fixtures/valid_youtube.txt')));
+
+        $provider = $this->getProvider($client, $messageFactory);
 
         $provider->addFormat('big', ['width' => 200, 'height' => 100, 'constraint' => true]);
 
@@ -145,13 +155,16 @@ class YouTubeProviderTest extends AbstractProviderTest
      */
     public function testTransformWithUrl(string $url): void
     {
-        $response = new Response();
-        $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_youtube.txt'));
+        $request = $this->createStub(RequestInterface::class);
 
-        $browser = $this->createMock(Browser::class);
-        $browser->expects($this->once())->method('get')->willReturn($response);
+        $messageFactory = $this->createMock(RequestFactoryInterface::class);
+        $messageFactory->expects($this->once())->method('createRequest')->willReturn($request);
 
-        $provider = $this->getProvider($browser);
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())->method('sendRequest')->with($this->equalTo($request))
+            ->willReturn($this->createResponse(file_get_contents(__DIR__.'/../fixtures/valid_youtube.txt')));
+
+        $provider = $this->getProvider($client, $messageFactory);
 
         $provider->addFormat('big', ['width' => 200, 'height' => 100, 'constraint' => true]);
 
@@ -193,7 +206,7 @@ class YouTubeProviderTest extends AbstractProviderTest
         $response->setContent(file_get_contents(__DIR__.'/../fixtures/valid_youtube.txt'));
 
         $browser = $this->createMock(Browser::class);
-        $browser->expects($this->once())->method('get')->will($this->throwException(new \RuntimeException('First error on get', 12)));
+        $browser->expects($this->once())->method('call')->will($this->throwException(new \RuntimeException('First error on get', 12)));
 
         $provider = $this->getProvider($browser);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataSeoBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because this adds a new implementation without removing the existing one. This is a rework of https://github.com/sonata-project/SonataMediaBundle/pull/1181, but targets the psr http-client.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Added
- Added support for `psr/http-client` in `BaseVideoProvider`

### Deprecated
 - Deprecate `Guzzle` and `Buzz` usage in `BaseVideoProvider`
```
## Subject

Added support for an abstract http client without removing the existing old guzzle implementation.
