### PR TITLE
fix bc break: restore sonata.media.metadata.amazon service defaults

### DIFF
--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -384,7 +384,7 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
             ;
 
             $container->getDefinition('sonata.media.metadata.amazon')
-                ->addArgument([
+                ->replaceArgument(0, [
                         'acl' => $config['filesystem']['s3']['acl'],
                         'storage' => $config['filesystem']['s3']['storage'],
                         'encryption' => $config['filesystem']['s3']['encryption'],


### PR DESCRIPTION
## Subject

This PR fixes passing the default values to the `sonata.media.metadata.amazon` service. Since https://github.com/sonata-project/SonataMediaBundle/pull/1647, those defaults are passed as the second argument instead (making them useless). That regression prevent files from being publicly accessible by default in our case.

I am targeting this branch, because it fixes a bc break.

## Changelog

```markdown
### Fixed
- Fixed passing the default values to the `sonata.media.metadata.amazon` service.
```

I would appreciate a fast release ❤️