### PR TITLE
Add max file size as a parameter in the validation message

### DIFF
--- a/src/Provider/FileProvider.php
+++ b/src/Provider/FileProvider.php
@@ -313,7 +313,10 @@ class FileProvider extends BaseProvider implements FileProviderInterface
         if ($media->getBinaryContent() instanceof UploadedFile && 0 === ($media->getBinaryContent()->getClientSize() ?: 0)) {
             $errorElement
                 ->with('binaryContent')
-                ->addViolation('The file is too big, max size: %maxFileSize%', ['%maxFileSize%' => ini_get('upload_max_filesize')])
+                    ->addViolation(
+                        'The file is too big, max size: %maxFileSize%',
+                        ['%maxFileSize%' => ini_get('upload_max_filesize')]
+                    )
                 ->end();
         }
 

--- a/src/Provider/FileProvider.php
+++ b/src/Provider/FileProvider.php
@@ -312,9 +312,9 @@ class FileProvider extends BaseProvider implements FileProviderInterface
 
         if ($media->getBinaryContent() instanceof UploadedFile && 0 === ($media->getBinaryContent()->getClientSize() ?: 0)) {
             $errorElement
-               ->with('binaryContent')
-                   ->addViolation('The file is too big, max size: '.ini_get('upload_max_filesize'))
-               ->end();
+                ->with('binaryContent')
+                ->addViolation('The file is too big, max size: %maxFileSize%', ['%maxFileSize%' => ini_get('upload_max_filesize')])
+                ->end();
         }
 
         if (!\in_array(strtolower(pathinfo($fileName, PATHINFO_EXTENSION)), $this->allowedExtensions, true)) {


### PR DESCRIPTION

## Subject

Adding max file size as a parameter, it will be easier to override the translation in your projects, now you will have to put 'The file is too big, max size: 256M':'your translation 256M', when using parameters it doesn't matter what the max file size is, This solution will modify the translation key with 'The file is too big, max size: %maxFileSize%':'your translation %maxFileSize%'.

## Changelog
```markdown
### Added
- adding maxFileSize as a parameter in the validation message
### Changed
- Changed the validation message for the validation rule
```
