### PR TITLE
Made width setting non-mandatory

### DIFF
--- a/src/Resizer/SimpleResizer.php
+++ b/src/Resizer/SimpleResizer.php
@@ -58,8 +58,8 @@ class SimpleResizer implements ResizerInterface
      */
     public function resize(MediaInterface $media, File $in, File $out, $format, array $settings)
     {
-        if (!isset($settings['width'])) {
-            throw new \RuntimeException(sprintf('Width parameter is missing in context "%s" for provider "%s"', $media->getContext(), $media->getProviderName()));
+        if (!isset($settings['width']) && !isset($settings['height'])) {
+            throw new \RuntimeException(sprintf('Width or height parameter is missing in context "%s" for provider "%s"', $media->getContext(), $media->getProviderName()));
         }
 
         $image = $this->adapter->load($in->getContent());

--- a/tests/Resizer/SimpleResizerTest.php
+++ b/tests/Resizer/SimpleResizerTest.php
@@ -26,7 +26,7 @@ use Sonata\MediaBundle\Resizer\SimpleResizer;
 
 class SimpleResizerTest extends TestCase
 {
-    public function testResizeWithNoWidth(): void
+    public function testResizeWithNoWidthAndHeight(): void
     {
         $this->expectException(\RuntimeException::class);
 


### PR DESCRIPTION
Made width setting non-mandatory but made width or height setting mandatory on the resizer because there's no reason AFAIK to make one dimension mandatory, as long as there's one of them. See 
https://github.com/sonata-project/SonataMediaBundle/blob/315fe533dd4237243e6964efddaa314482970077/src/Resizer/SimpleResizer.php#L81-L83

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this doesn't backwards compatible.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1571

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Made width setting non-mandatory but made width or height setting mandatory on the resizer.
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
