### PR TITLE
Console commands returning status code for Symfony4.4 and 5.0

### DIFF
--- a/src/Command/AddMassMediaCommand.php
+++ b/src/Command/AddMassMediaCommand.php
@@ -72,6 +72,8 @@ class AddMassMediaCommand extends BaseCommand
         }
 
         $output->writeln('Done!');
+
+        return 0;
     }
 
     /**

--- a/src/Command/AddMediaCommand.php
+++ b/src/Command/AddMediaCommand.php
@@ -89,5 +89,7 @@ class AddMediaCommand extends BaseCommand
         $this->getMediaManager()->save($media, $context, $provider);
 
         $output->writeln('done!');
+
+        return 0;
     }
 }

--- a/src/Command/CleanMediaCommand.php
+++ b/src/Command/CleanMediaCommand.php
@@ -90,6 +90,8 @@ class CleanMediaCommand extends ContainerAwareCommand
         }
 
         $output->writeln('<info>done!</info>');
+
+        return 0;
     }
 
     /**

--- a/src/Command/FixMediaContextCommand.php
+++ b/src/Command/FixMediaContextCommand.php
@@ -76,5 +76,7 @@ class FixMediaContextCommand extends ContainerAwareCommand
         }
 
         $output->writeln('Done!');
+
+        return 0;
     }
 }

--- a/src/Command/MigrateToJsonTypeCommand.php
+++ b/src/Command/MigrateToJsonTypeCommand.php
@@ -56,5 +56,7 @@ class MigrateToJsonTypeCommand extends BaseCommand
         }
 
         $output->writeln("Migrated $count medias");
+
+        return 0;
     }
 }

--- a/src/Command/RefreshMetadataCommand.php
+++ b/src/Command/RefreshMetadataCommand.php
@@ -105,6 +105,8 @@ class RefreshMetadataCommand extends BaseCommand
         }
 
         $this->log('Done!');
+
+        return 0;
     }
 
     /**

--- a/src/Command/RemoveThumbsCommand.php
+++ b/src/Command/RemoveThumbsCommand.php
@@ -137,6 +137,8 @@ class RemoveThumbsCommand extends BaseCommand
         } while (true);
 
         $this->log("Done (total medias processed: {$totalMediasCount}).");
+
+        return 0;
     }
 
     /**

--- a/src/Command/SyncThumbsCommand.php
+++ b/src/Command/SyncThumbsCommand.php
@@ -154,6 +154,8 @@ class SyncThumbsCommand extends BaseCommand
         } while (true);
 
         $this->log("Done (total medias processed: {$totalMediasCount}).");
+
+        return 0;
     }
 
     /**

--- a/src/Command/UpdateCdnStatusCommand.php
+++ b/src/Command/UpdateCdnStatusCommand.php
@@ -126,6 +126,8 @@ class UpdateCdnStatusCommand extends BaseCommand
         }
 
         $this->log('Done!');
+
+        return 0;
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
As of Symfony 4.4 (and required for 5.0) console commands should return integer as exit code *(`0` if  all gone ok)*

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
Fixed deprecations
- `Return value of "Sonata\MediaBundle\Command\CleanMediaCommand::execute()" should always be of the type int since Symfony 4.4, NULL returned.`
- `Return value of "Sonata\MediaBundle\Command\FixMediaContextCommand::execute()" should always be of the type int since Symfony 4.4, NULL returned.`
- `Return value of "Sonata\MediaBundle\Command\RemoveThumbsCommand::execute()" should always be of the type int since Symfony 4.4, NULL returned.`
and others similar.

```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->