### PR TITLE
[BC break] Fix commands return type

### DIFF
--- a/src/Command/AddMassMediaCommand.php
+++ b/src/Command/AddMassMediaCommand.php
@@ -45,7 +45,7 @@ class AddMassMediaCommand extends BaseCommand
     /**
      * {@inheritdoc}
      */
-    public function execute(InputInterface $input, OutputInterface $output): void
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $fp = $this->getFilePointer($input, $output);
         $imported = -1;

--- a/src/Command/AddMediaCommand.php
+++ b/src/Command/AddMediaCommand.php
@@ -57,7 +57,7 @@ class AddMediaCommand extends BaseCommand
     /**
      * {@inheritdoc}
      */
-    public function execute(InputInterface $input, OutputInterface $output): void
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $provider = $input->getArgument('providerName');
         $context = $input->getArgument('context');

--- a/src/Command/CleanMediaCommand.php
+++ b/src/Command/CleanMediaCommand.php
@@ -46,7 +46,7 @@ class CleanMediaCommand extends ContainerAwareCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output): void
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $dryRun = (bool) $input->getOption('dry-run');
         $verbose = $output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE;

--- a/src/Command/FixMediaContextCommand.php
+++ b/src/Command/FixMediaContextCommand.php
@@ -35,7 +35,7 @@ class FixMediaContextCommand extends ContainerAwareCommand
     /**
      * {@inheritdoc}
      */
-    public function execute(InputInterface $input, OutputInterface $output): void
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         if (!$this->getContainer()->has('sonata.media.manager.category')) {
             throw new \LogicException('The classification feature is disabled.');

--- a/src/Command/MigrateToJsonTypeCommand.php
+++ b/src/Command/MigrateToJsonTypeCommand.php
@@ -37,7 +37,7 @@ class MigrateToJsonTypeCommand extends BaseCommand
     /**
      * {@inheritdoc}
      */
-    public function execute(InputInterface $input, OutputInterface $output): void
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $count = 0;
         $table = $input->getOption('table');

--- a/src/Command/RefreshMetadataCommand.php
+++ b/src/Command/RefreshMetadataCommand.php
@@ -62,7 +62,7 @@ class RefreshMetadataCommand extends BaseCommand
     /**
      * {@inheritdoc}
      */
-    public function execute(InputInterface $input, OutputInterface $output): void
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->quiet = $input->getOption('quiet');
 

--- a/src/Command/RemoveThumbsCommand.php
+++ b/src/Command/RemoveThumbsCommand.php
@@ -141,9 +141,6 @@ class RemoveThumbsCommand extends BaseCommand
         return 0;
     }
 
-    /**
-     * @return MediaProviderInterface
-     */
     public function getProvider(): MediaProviderInterface
     {
         $providerName = $this->input->getArgument('providerName');
@@ -159,9 +156,6 @@ class RemoveThumbsCommand extends BaseCommand
         return $this->getMediaPool()->getProvider($providerName);
     }
 
-    /**
-     * @return string
-     */
     public function getContext(): string
     {
         $context = $this->input->getArgument('context');
@@ -179,8 +173,6 @@ class RemoveThumbsCommand extends BaseCommand
 
     /**
      * @param string $context
-     *
-     * @return string
      */
     public function getFormat(MediaProviderInterface $provider, $context): string
     {
@@ -209,8 +201,6 @@ class RemoveThumbsCommand extends BaseCommand
     /**
      * @param string $context
      * @param string $format
-     *
-     * @return bool
      */
     protected function processMedia(MediaInterface $media, MediaProviderInterface $provider, $context, $format): bool
     {

--- a/src/Command/RemoveThumbsCommand.php
+++ b/src/Command/RemoveThumbsCommand.php
@@ -68,7 +68,7 @@ class RemoveThumbsCommand extends BaseCommand
     /**
      * {@inheritdoc}
      */
-    public function execute(InputInterface $input, OutputInterface $output): void
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->input = $input;
         $this->output = $output;
@@ -144,7 +144,7 @@ class RemoveThumbsCommand extends BaseCommand
     /**
      * @return MediaProviderInterface
      */
-    public function getProvider()
+    public function getProvider(): MediaProviderInterface
     {
         $providerName = $this->input->getArgument('providerName');
 
@@ -162,7 +162,7 @@ class RemoveThumbsCommand extends BaseCommand
     /**
      * @return string
      */
-    public function getContext()
+    public function getContext(): string
     {
         $context = $this->input->getArgument('context');
 
@@ -182,7 +182,7 @@ class RemoveThumbsCommand extends BaseCommand
      *
      * @return string
      */
-    public function getFormat(MediaProviderInterface $provider, $context)
+    public function getFormat(MediaProviderInterface $provider, $context): string
     {
         $format = $this->input->getArgument('format');
 
@@ -212,7 +212,7 @@ class RemoveThumbsCommand extends BaseCommand
      *
      * @return bool
      */
-    protected function processMedia(MediaInterface $media, MediaProviderInterface $provider, $context, $format)
+    protected function processMedia(MediaInterface $media, MediaProviderInterface $provider, $context, $format): bool
     {
         $this->log('Deleting thumbs for '.$media->getName().' - '.$media->getId());
 

--- a/src/Command/SyncThumbsCommand.php
+++ b/src/Command/SyncThumbsCommand.php
@@ -61,7 +61,7 @@ class SyncThumbsCommand extends BaseCommand
     /**
      * {@inheritdoc}
      */
-    public function execute(InputInterface $input, OutputInterface $output): void
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $helper = $this->getHelper('question');
 
@@ -164,7 +164,7 @@ class SyncThumbsCommand extends BaseCommand
      *
      * @return bool
      */
-    protected function processMedia($media, $provider)
+    protected function processMedia($media, $provider): bool
     {
         $this->log('Generating thumbs for '.$media->getName().' - '.$media->getId());
 

--- a/src/Command/SyncThumbsCommand.php
+++ b/src/Command/SyncThumbsCommand.php
@@ -161,8 +161,6 @@ class SyncThumbsCommand extends BaseCommand
     /**
      * @param MediaInterface         $media
      * @param MediaProviderInterface $provider
-     *
-     * @return bool
      */
     protected function processMedia($media, $provider): bool
     {

--- a/src/Command/UpdateCdnStatusCommand.php
+++ b/src/Command/UpdateCdnStatusCommand.php
@@ -63,7 +63,7 @@ class UpdateCdnStatusCommand extends BaseCommand
     /**
      * {@inheritdoc}
      */
-    public function execute(InputInterface $input, OutputInterface $output): void
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->quiet = $input->getOption('quiet');
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
PR https://github.com/sonata-project/SonataMediaBundle/pull/1679 fixes some deprecations as of Symfony 4.4 and required for Symfony 5.0, but breaks commands in `master` branch.
This PR fixes commands return types.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
BC break as commands return types changes.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
Completes https://github.com/sonata-project/SonataMediaBundle/pull/1679

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Method `Sonata\MediaBundle\Command\AddMassMediaCommand::execute()` returns integer exit code
- Method `Sonata\MediaBundle\Command\AddMediaCommand::execute()` returns integer exit code
- Method `Sonata\MediaBundle\Command\CleanMediaCommand::execute()` returns integer exit code
- Method `Sonata\MediaBundle\Command\FixMediaContextCommand::execute()` returns integer exit code
- Method `Sonata\MediaBundle\Command\MigrateToJsonTypeCommand::execute()` returns integer exit code
- Method `Sonata\MediaBundle\Command\RefreshMetadataCommand::execute()` returns integer exit code
- Method `Sonata\MediaBundle\Command\RemoveThumbsCommand::execute()` returns integer exit code
- Method `Sonata\MediaBundle\Command\SyncThumbsCommand::execute()` returns integer exit code
- Method `Sonata\MediaBundle\Command\UpdateCdnStatusCommand::execute()` returns integer exit code
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
