### PR TITLE
Generate path when using VO as UUID representation

### DIFF
--- a/src/Generator/ODMGenerator.php
+++ b/src/Generator/ODMGenerator.php
@@ -25,7 +25,7 @@ class ODMGenerator implements GeneratorInterface
      */
     public function generatePath(MediaInterface $media)
     {
-        $id = $media->getId();
+        $id = (string) $media->getId();
 
         return sprintf('%s/%04s/%02s', $media->getContext(), substr($id, 0, 4), substr($id, 4, 2));
     }

--- a/tests/Generator/ODMGeneratorTest.php
+++ b/tests/Generator/ODMGeneratorTest.php
@@ -29,4 +29,23 @@ class ODMGeneratorTest extends TestCase
         $media->setId('550e8400-e29b-41d4-a716-446655440000');
         $this->assertSame('user/550e/84', $generator->generatePath($media));
     }
+
+    public function testWithValueObjectStringable(): void
+    {
+        $generator = new ODMGenerator();
+
+        $media = new Media();
+        $media->setContext('user');
+
+        // Dummy Value Object representing UUID
+        $vo = new class() {
+            public function __toString()
+            {
+                return '550e8400-e29b-41d4-a716-446655440000';
+            }
+        };
+        $media->setId($vo);
+
+        $this->assertSame('user/550e/84', $generator->generatePath($media));
+    }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Class `Sonata\MediaBundle\Generator\ODMGenerator` can now be used *(instead of making a custom generator class)* in the case your domain is using VOs instead of UUID strings.

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because no BC breaks.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataMediaBundle/issues/1681

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Generating path when using VO representing UUID
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
