### PR TITLE
Public (API) controller services for FOSRest

### DIFF
--- a/src/Resources/config/api_controllers.xml
+++ b/src/Resources/config/api_controllers.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
+        <defaults public="true"/>
         <service id="sonata.media.controller.api.gallery" class="Sonata\MediaBundle\Controller\Api\GalleryController">
             <argument type="service" id="sonata.media.manager.gallery"/>
             <argument type="service" id="sonata.media.manager.media"/>


### PR DESCRIPTION
Because I am not able to move forward on #1654, I submit this separate pull request to fix the bug in the service definition. I Hope we can merge this one without adding functional tests. 

------

For the route loader in the FOSRestBundle a (service) resource defined in a route needs to be public.
Otherwise, their route loader can't load the service.

I am targeting this branch because this is a bugfix and backwards compatible.

Closes #1652

```markdown
### Fixed
API routes config, made them public for the FOSRest routeloader.
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
