### PR TITLE
remove deprecated core-bundle from dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
         "knplabs/gaufrette": "^0.8 || ^0.9",
         "kriswallsmith/buzz": "^0.15 || ^0.16",
         "psr/log": "^1.0",
-        "sonata-project/core-bundle": "^3.14",
         "sonata-project/doctrine-extensions": "^1.5.1",
         "sonata-project/easy-extends-bundle": "^2.5",
         "symfony/config": "^4.3",


### PR DESCRIPTION
## Subject

Remove deprecated dependency (see related issue)

I am targeting 3.x, because there's no BC-break.

Closes #1694

## Changelog

No notable changes to log

