### PR TITLE
Revert "Allow Twig 3"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "symfony/twig-bridge": "^4.3",
         "symfony/twig-bundle": "^4.3",
         "symfony/validator": "^4.3",
-        "twig/twig": "^2.10 || ^3.0"
+        "twig/twig": "^2.10"
     },
     "conflict": {
         "doctrine/dbal": "<2.6.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Revert "Allow Twig 3".

This reverts commit 7c12b071c337e1e32eb407fb6e4785d1968ee782.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

See https://github.com/sonata-project/SonataMediaBundle/pull/1717#issuecomment-602165154.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

There is no need for changelog since the reverted commit is not released yet.