### PR TITLE
Revert "Allow Twig 3"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "symfony/twig-bridge": "^4.3",
         "symfony/twig-bundle": "^4.3",
         "symfony/validator": "^4.3",
-        "twig/twig": "^2.10 || ^3.0"
+        "twig/twig": "^2.10"
     },
     "conflict": {
         "doctrine/dbal": "<2.6.0",


### PR DESCRIPTION
This reverts commit 7c12b071c337e1e32eb407fb6e4785d1968ee782.
We cannot effectively test with Twig 3 since many of our dependencies
are not compatible with it yet.
I'm not adding a changelog since #1717 is not released yet. Furthermore, I am going to remove the changelog and label from #1717 