### PR TITLE
NoDriver should extend ManagerInterface to be able to be passed to `sonata.media.block.gallery_list` service

### DIFF
--- a/src/Model/NoDriverManager.php
+++ b/src/Model/NoDriverManager.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Model;
 
-use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\MediaBundle\Exception\NoDriverException;
 
 /**
@@ -21,7 +20,7 @@ use Sonata\MediaBundle\Exception\NoDriverException;
  *
  * @author Andrey F. Mindubaev <covex.mobile@gmail.com>
  */
-final class NoDriverManager implements ManagerInterface
+final class NoDriverManager implements GalleryManagerInterface
 {
     public function getClass()
     {
@@ -84,6 +83,11 @@ final class NoDriverManager implements ManagerInterface
     }
 
     public function getConnection(): void
+    {
+        throw new NoDriverException();
+    }
+
+    public function getPager(array $criteria, $page, $limit = 10, array $sort = [])
     {
         throw new NoDriverException();
     }

--- a/tests/Model/NoDriverManagerTest.php
+++ b/tests/Model/NoDriverManagerTest.php
@@ -15,6 +15,7 @@ namespace Sonata\MediaBundle\Tests\Model;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\MediaBundle\Exception\NoDriverException;
+use Sonata\MediaBundle\Model\GalleryManagerInterface;
 use Sonata\MediaBundle\Model\NoDriverManager;
 
 class NoDriverManagerTest extends TestCase
@@ -27,6 +28,11 @@ class NoDriverManagerTest extends TestCase
         $this->expectException(NoDriverException::class);
 
         \call_user_func_array([new NoDriverManager(), $method], $arguments);
+    }
+
+    public function testIsInstanceOfGalleryManagerInterface()
+    {
+        $this->assertInstanceOf(GalleryManagerInterface::class, new NoDriverManager());
     }
 
     public function providerMethods(): array
@@ -42,6 +48,7 @@ class NoDriverManagerTest extends TestCase
             ['delete', [null]],
             ['getTableName', []],
             ['getConnection', []],
+            ['getPager', [[], 1]],
         ];
     }
 }


### PR DESCRIPTION
## Subject

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataMediaBundle/issues/1721

## Changelog

```markdown
### Fixed

* Fix `bin/console lint:container` command and pass an object of class `NoDriverManager` of the expected `GalleryManagerInterface` interface
```