### PR TITLE
Document how to inject $mediaManager in Symfony 4+ projects

### DIFF
--- a/docs/reference/usage.rst
+++ b/docs/reference/usage.rst
@@ -26,6 +26,19 @@ or this::
 
     $mediaManager->save($media, 'user', 'sonata.media.provider.youtube');
 
+``$mediaManager`` is an instance of ``Sonata\MediaBundle\Model\MediaManagerInterface``. In order to us it, inject it into constructor of a class::
+
+    public function __construct(MediaManagerInterface $mediaManager)
+    {
+        $this->mediaManager = $mediaManager;
+    }
+
+And create an alias so that Symfony understands what implementation to use::
+
+    // config/services.yaml
+
+    Sonata\MediaBundle\Model\MediaManagerInterface: '@sonata.media.manager.media'
+
 Retrieving metadata information
 -------------------------------
 


### PR DESCRIPTION
Document how to inject $mediaManager in Symfony 4+ projects, since after reading "Installation" and "Usage" articles, it's not clear how to get `$mediaManager` inside any class.

For example, there is a similar answer in SO: https://stackoverflow.com/a/58296157/2579875

This solution uses interface though rather than concrete implementation