### PR TITLE
Fix command media:clean-uploads

### DIFF
--- a/src/Resources/config/gaufrette.xml
+++ b/src/Resources/config/gaufrette.xml
@@ -7,7 +7,7 @@
         <parameter key="sonata.media.adapater.filesystem.opencloud.class"/>
     </parameters>
     <services>
-        <service id="sonata.media.adapter.filesystem.local" class="Sonata\MediaBundle\Filesystem\Local"/>
+        <service id="sonata.media.adapter.filesystem.local" public="true" class="Sonata\MediaBundle\Filesystem\Local"/>
         <service id="sonata.media.adapter.filesystem.ftp" class="Gaufrette\Adapter\Ftp"/>
         <service id="sonata.media.adapter.service.s3" class="Aws\S3\S3Client">
             <factory class="Aws\S3\S3Client" method="factory"/>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Fixes the command `sonata:media:clean-uploads`

> The "sonata.media.adapter.filesystem.local" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the contai
>   ner directly and use dependency injection instead.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1645

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Changed private service to public one by adding `public=true` to service `sonata.media.adapter.filesystem.local`
```
