### PR TITLE
Fix command media:clean-uploads

### DIFF
--- a/src/Command/CleanMediaCommand.php
+++ b/src/Command/CleanMediaCommand.php
@@ -18,7 +18,6 @@ use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Sonata\MediaBundle\Provider\FileProvider;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\MediaBundle\Provider\Pool;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/Resources/config/command.xml
+++ b/src/Resources/config/command.xml
@@ -8,6 +8,9 @@
             <tag name="console.command"/>
         </service>
         <service id="Sonata\MediaBundle\Command\CleanMediaCommand" class="Sonata\MediaBundle\Command\CleanMediaCommand" public="true">
+            <argument type="service" id="sonata.media.adapter.filesystem.local"/>
+            <argument type="service" id="sonata.media.pool"/>
+            <argument type="service" id="sonata.media.manager.media"/>
             <tag name="console.command"/>
         </service>
         <service id="Sonata\MediaBundle\Command\FixMediaContextCommand" class="Sonata\MediaBundle\Command\FixMediaContextCommand" public="true">

--- a/tests/Command/CleanMediaCommandTest.php
+++ b/tests/Command/CleanMediaCommandTest.php
@@ -89,8 +89,8 @@ class CleanMediaCommandTest extends FilesystemTestCase
             'providers' => [],
             'formats' => [],
             'download' => [],
-
         ];
+
         $this->pool->expects($this->once())->method('getContexts')->willReturn(['foo' => $context]);
 
         $output = $this->tester->execute(['command' => $this->command->getName()]);

--- a/tests/Command/CleanMediaCommandTest.php
+++ b/tests/Command/CleanMediaCommandTest.php
@@ -21,11 +21,10 @@ use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Sonata\MediaBundle\Provider\FileProvider;
 use Sonata\MediaBundle\Provider\Pool;
 use Sonata\MediaBundle\Tests\Fixtures\FilesystemTestCase;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
-use Symfony\Component\DependencyInjection\Container;
 
 /**
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
@@ -33,17 +32,12 @@ use Symfony\Component\DependencyInjection\Container;
 class CleanMediaCommandTest extends FilesystemTestCase
 {
     /**
-     * @var Container
-     */
-    protected $container;
-
-    /**
      * @var Application
      */
     protected $application;
 
     /**
-     * @var ContainerAwareCommand
+     * @var Command
      */
     protected $command;
 
@@ -74,16 +68,6 @@ class CleanMediaCommandTest extends FilesystemTestCase
     {
         parent::setUp();
 
-        $this->container = new Container();
-
-        $this->command = new CleanMediaCommand();
-        $this->command->setContainer($this->container);
-
-        $this->application = new Application();
-        $this->application->add($this->command);
-
-        $this->tester = new CommandTester($this->application->find('sonata:media:clean-uploads'));
-
         $this->pool = $pool = $this->createMock(Pool::class);
 
         $this->mediaManager = $mediaManager = $this->createMock(MediaManagerInterface::class);
@@ -91,9 +75,12 @@ class CleanMediaCommandTest extends FilesystemTestCase
         $this->fileSystemLocal = $fileSystemLocal = $this->createMock(Local::class);
         $this->fileSystemLocal->expects($this->once())->method('getDirectory')->willReturn($this->workspace);
 
-        $this->container->set('sonata.media.pool', $pool);
-        $this->container->set('sonata.media.manager.media', $mediaManager);
-        $this->container->set('sonata.media.adapter.filesystem.local', $fileSystemLocal);
+        $this->command = new CleanMediaCommand($this->fileSystemLocal, $this->pool, $this->mediaManager);
+
+        $this->application = new Application();
+        $this->application->add($this->command);
+
+        $this->tester = new CommandTester($this->application->find('sonata:media:clean-uploads'));
     }
 
     public function testExecuteDirectoryNotExists(): void
@@ -102,8 +89,8 @@ class CleanMediaCommandTest extends FilesystemTestCase
             'providers' => [],
             'formats' => [],
             'download' => [],
-        ];
 
+        ];
         $this->pool->expects($this->once())->method('getContexts')->willReturn(['foo' => $context]);
 
         $output = $this->tester->execute(['command' => $this->command->getName()]);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Fixes the command `sonata:media:clean-uploads`

> The "sonata.media.adapter.filesystem.local" service or alias has been removed or inlined when the container was compiled. You should either make it public, or stop using the contai
>   ner directly and use dependency injection instead.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1645

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Removed all calls to container inside the CleanMediaCommand 
```
