### PR TITLE
Prepare for BlockBundle 4.0 support and fix #1731

### DIFF
--- a/src/Block/FeatureMediaBlockService.php
+++ b/src/Block/FeatureMediaBlockService.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Block;
 
-use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
 use Sonata\BlockBundle\Meta\Metadata;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\Form\Type\ImmutableArrayType;

--- a/src/Block/GalleryBlockService.php
+++ b/src/Block/GalleryBlockService.php
@@ -145,7 +145,7 @@ class GalleryBlockService extends AbstractBlockService implements EditableBlockS
             'translation_domain' => 'SonataMediaBundle',
         ]);
         $fieldDescription->setAssociationAdmin($this->getGalleryAdmin());
-        $fieldDescription->setAdmin($formMapper->getAdmin());
+        $fieldDescription->setAdmin($this->container->get('sonata.page.admin.block'));
         $fieldDescription->setOption('edit', 'list');
         $fieldDescription->setAssociationMapping(['fieldName' => 'gallery', 'type' => ClassMetadataInfo::MANY_TO_ONE]);
 
@@ -202,10 +202,17 @@ class GalleryBlockService extends AbstractBlockService implements EditableBlockS
     }
 
     /**
-     * NEXT_MAJOR: Remove this method. 
+     * NEXT_MAJOR: Remove this method.
      */
     public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[2] ?? null)) {
+            @trigger_error(sprintf(
+                'Method %s() is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0. Use %s::configureCreateForm() instead.',
+                __METHOD__,
+                static::class,
+            ), E_USER_DEPRECATED);
+        }
         $this->configureCreateForm($formMapper, $block);
     }
 
@@ -214,6 +221,13 @@ class GalleryBlockService extends AbstractBlockService implements EditableBlockS
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[2] ?? null)) {
+            @trigger_error(sprintf(
+                'Method %s() is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0. Use %s::configureEditForm() instead.',
+                __METHOD__,
+                static::class,
+            ), E_USER_DEPRECATED);
+        }
         $this->configureEditForm($formMapper, $block);
     }
 
@@ -222,6 +236,14 @@ class GalleryBlockService extends AbstractBlockService implements EditableBlockS
      */
     public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[2] ?? null)) {
+            @trigger_error(sprintf(
+                'Method %s() is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0. Use %s::validate() instead.',
+                __METHOD__,
+                static::class,
+            ), E_USER_DEPRECATED);
+        }
+        $this->validate($errorElement,$block);
     }
 
     public function validate(ErrorElement $errorElement, BlockInterface $block)
@@ -284,10 +306,17 @@ class GalleryBlockService extends AbstractBlockService implements EditableBlockS
     }
 
     /**
-     * NEXT_MAJOR: Remove this method. 
+     * NEXT_MAJOR: Remove this method.
      */
     public function getBlockMetadata($code = null)
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[2] ?? null)) {
+            @trigger_error(sprintf(
+                'Method %s() is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0. Use %s::getMetadata() instead.',
+                __METHOD__,
+                static::class,
+            ), E_USER_DEPRECATED);
+        }
         return $this->getMetadata();
     }
 

--- a/src/Block/GalleryBlockService.php
+++ b/src/Block/GalleryBlockService.php
@@ -202,7 +202,7 @@ class GalleryBlockService extends AbstractBlockService implements EditableBlockS
     }
 
     /**
-     * NEXT_MAJOR: delete it.
+     * NEXT_MAJOR: Remove this method. 
      */
     public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
     {
@@ -210,7 +210,7 @@ class GalleryBlockService extends AbstractBlockService implements EditableBlockS
     }
 
     /**
-     * NEXT_MAJOR: delete it.
+     * NEXT_MAJOR: Remove this method.
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
@@ -218,7 +218,7 @@ class GalleryBlockService extends AbstractBlockService implements EditableBlockS
     }
 
     /**
-     * NEXT_MAJOR: delete it.
+     * NEXT_MAJOR: Remove this method.
      */
     public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
     {
@@ -284,7 +284,7 @@ class GalleryBlockService extends AbstractBlockService implements EditableBlockS
     }
 
     /**
-     * NEXT_MAJOR: delete it.
+     * NEXT_MAJOR: Remove this method. 
      */
     public function getBlockMetadata($code = null)
     {

--- a/src/Block/GalleryBlockService.php
+++ b/src/Block/GalleryBlockService.php
@@ -115,6 +115,14 @@ class GalleryBlockService extends AbstractBlockService
     /**
      * {@inheritdoc}
      */
+    public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
+    {  
+       $this->buildEditForm($formMapper, $block);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
         $contextChoices = [];

--- a/src/Block/GalleryBlockService.php
+++ b/src/Block/GalleryBlockService.php
@@ -319,7 +319,9 @@ class GalleryBlockService extends AbstractBlockService implements EditableBlockS
             ), E_USER_DEPRECATED);
         }
 
-        return $this->getMetadata();
+        return new Metadata($this->getName(), (null !== $code ? $code : $this->getName()), false, 'SonataMediaBundle', [
+            'class' => 'fa fa-picture-o',
+        ]);
     }
 
     private function buildElements(GalleryInterface $gallery): array

--- a/src/Block/GalleryBlockService.php
+++ b/src/Block/GalleryBlockService.php
@@ -318,6 +318,7 @@ class GalleryBlockService extends AbstractBlockService implements EditableBlockS
                 static::class,
             ), E_USER_DEPRECATED);
         }
+
         return $this->getMetadata();
     }
 

--- a/src/Block/GalleryBlockService.php
+++ b/src/Block/GalleryBlockService.php
@@ -243,7 +243,8 @@ class GalleryBlockService extends AbstractBlockService implements EditableBlockS
                 static::class,
             ), E_USER_DEPRECATED);
         }
-        $this->validate($errorElement,$block);
+
+        $this->validate($errorElement, $block);
     }
 
     public function validate(ErrorElement $errorElement, BlockInterface $block)

--- a/src/Block/GalleryBlockService.php
+++ b/src/Block/GalleryBlockService.php
@@ -23,6 +23,7 @@ use Sonata\BlockBundle\Meta\Metadata;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\Form\Type\ImmutableArrayType;
+use Sonata\Form\Validator\ErrorElement;
 use Sonata\MediaBundle\Model\GalleryInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Provider\Pool;
@@ -199,6 +200,10 @@ class GalleryBlockService extends AbstractBlockService
             ],
             'translation_domain' => 'SonataMediaBundle',
         ]);
+    }
+
+    public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
+    {
     }
 
     /**

--- a/src/Block/GalleryBlockService.php
+++ b/src/Block/GalleryBlockService.php
@@ -112,12 +112,9 @@ class GalleryBlockService extends AbstractBlockService
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
     {  
-       $this->buildEditForm($formMapper, $block);
+        $this->buildEditForm($formMapper, $block);
     }
 
     /**

--- a/src/Block/GalleryBlockService.php
+++ b/src/Block/GalleryBlockService.php
@@ -113,7 +113,7 @@ class GalleryBlockService extends AbstractBlockService
     }
 
     public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
-    {  
+    {
         $this->buildEditForm($formMapper, $block);
     }
 

--- a/src/Block/GalleryBlockService.php
+++ b/src/Block/GalleryBlockService.php
@@ -15,11 +15,13 @@ namespace Sonata\MediaBundle\Block;
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractBlockService;
+use Sonata\BlockBundle\Block\Service\EditableBlockService;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
 use Sonata\BlockBundle\Meta\Metadata;
+use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\Form\Type\ImmutableArrayType;
@@ -42,7 +44,7 @@ use Twig\Environment;
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class GalleryBlockService extends AbstractBlockService
+class GalleryBlockService extends AbstractBlockService implements EditableBlockService
 {
     /**
      * @var ManagerInterface
@@ -113,15 +115,12 @@ class GalleryBlockService extends AbstractBlockService
         ]);
     }
 
-    public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
+    public function configureCreateForm(FormMapper $formMapper, BlockInterface $block)
     {
-        $this->buildEditForm($formMapper, $block);
+        $this->configureEditForm($formMapper, $block);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
+    public function configureEditForm(FormMapper $formMapper, BlockInterface $block)
     {
         $contextChoices = [];
 
@@ -202,7 +201,30 @@ class GalleryBlockService extends AbstractBlockService
         ]);
     }
 
+    /**
+     * NEXT_MAJOR: delete it.
+     */
+    public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
+    {
+        $this->configureCreateForm($formMapper, $block);
+    }
+
+    /**
+     * NEXT_MAJOR: delete it.
+     */
+    public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
+    {
+        $this->configureEditForm($formMapper, $block);
+    }
+
+    /**
+     * NEXT_MAJOR: delete it.
+     */
     public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
+    {
+    }
+
+    public function validate(ErrorElement $errorElement, BlockInterface $block)
     {
     }
 
@@ -254,11 +276,19 @@ class GalleryBlockService extends AbstractBlockService
     /**
      * {@inheritdoc}
      */
-    public function getBlockMetadata($code = null)
+    public function getMetadata(): MetadataInterface
     {
-        return new Metadata($this->getName(), (null !== $code ? $code : $this->getName()), false, 'SonataMediaBundle', [
+        return new Metadata($this->getName(), null, null, 'SonataMediaBundle', [
             'class' => 'fa fa-picture-o',
         ]);
+    }
+
+    /**
+     * NEXT_MAJOR: delete it.
+     */
+    public function getBlockMetadata($code = null)
+    {
+        return $this->getMetadata();
     }
 
     private function buildElements(GalleryInterface $gallery): array

--- a/src/Block/GalleryBlockService.php
+++ b/src/Block/GalleryBlockService.php
@@ -210,7 +210,7 @@ class GalleryBlockService extends AbstractBlockService implements EditableBlockS
             @trigger_error(sprintf(
                 'Method %s() is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0. Use %s::configureCreateForm() instead.',
                 __METHOD__,
-                static::class,
+                static::class
             ), E_USER_DEPRECATED);
         }
         $this->configureCreateForm($formMapper, $block);
@@ -225,7 +225,7 @@ class GalleryBlockService extends AbstractBlockService implements EditableBlockS
             @trigger_error(sprintf(
                 'Method %s() is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0. Use %s::configureEditForm() instead.',
                 __METHOD__,
-                static::class,
+                static::class
             ), E_USER_DEPRECATED);
         }
         $this->configureEditForm($formMapper, $block);
@@ -240,7 +240,7 @@ class GalleryBlockService extends AbstractBlockService implements EditableBlockS
             @trigger_error(sprintf(
                 'Method %s() is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0. Use %s::validate() instead.',
                 __METHOD__,
-                static::class,
+                static::class
             ), E_USER_DEPRECATED);
         }
 
@@ -315,7 +315,7 @@ class GalleryBlockService extends AbstractBlockService implements EditableBlockS
             @trigger_error(sprintf(
                 'Method %s() is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0. Use %s::getMetadata() instead.',
                 __METHOD__,
-                static::class,
+                static::class
             ), E_USER_DEPRECATED);
         }
 

--- a/src/Block/GalleryListBlockService.php
+++ b/src/Block/GalleryListBlockService.php
@@ -128,10 +128,17 @@ class GalleryListBlockService extends AbstractBlockService implements EditableBl
     }
 
     /**
-     * NEXT_MAJOR: Remove this method. 
+     * NEXT_MAJOR: Remove this method.
      */
     public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[2] ?? null)) {
+            @trigger_error(sprintf(
+                'Method %s() is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0. Use %s::configureCreateForm() instead.',
+                __METHOD__,
+                static::class,
+            ), E_USER_DEPRECATED);
+        }
         $this->configureCreateForm($formMapper, $block);
     }
 
@@ -140,6 +147,13 @@ class GalleryListBlockService extends AbstractBlockService implements EditableBl
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[2] ?? null)) {
+            @trigger_error(sprintf(
+                'Method %s() is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0. Use %s::configureEditForm() instead.',
+                __METHOD__,
+                static::class,
+            ), E_USER_DEPRECATED);
+        }
         $this->configureEditForm($formMapper, $block);
     }
 
@@ -148,6 +162,14 @@ class GalleryListBlockService extends AbstractBlockService implements EditableBl
      */
     public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[2] ?? null)) {
+            @trigger_error(sprintf(
+                'Method %s() is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0. Use %s::validate() instead.',
+                __METHOD__,
+                static::class,
+            ), E_USER_DEPRECATED);
+        }
+        $this->validate($errorElement, $block);
     }
 
     public function validate(ErrorElement $errorElement, BlockInterface $block)
@@ -217,6 +239,13 @@ class GalleryListBlockService extends AbstractBlockService implements EditableBl
      */
     public function getBlockMetadata($code = null)
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[2] ?? null)) {
+            @trigger_error(sprintf(
+                'Method %s() is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0. Use %s::getMetadata() instead.',
+                __METHOD__,
+                static::class,
+            ), E_USER_DEPRECATED);
+        }
         return $this->getMetadata();
     }
 }

--- a/src/Block/GalleryListBlockService.php
+++ b/src/Block/GalleryListBlockService.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Block;
 
-use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractBlockService;
+use Sonata\BlockBundle\Block\Service\EditableBlockService;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
 use Sonata\BlockBundle\Meta\Metadata;
+use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\Form\Type\ImmutableArrayType;
 use Sonata\Form\Validator\ErrorElement;
@@ -33,7 +35,7 @@ use Twig\Environment;
 /**
  * @final since sonata-project/media-bundle 3.21.0
  */
-class GalleryListBlockService extends AbstractBlockService
+class GalleryListBlockService extends AbstractBlockService implements EditableBlockService
 {
     /**
      * @var GalleryManagerInterface
@@ -58,15 +60,12 @@ class GalleryListBlockService extends AbstractBlockService
         $this->pool = $pool;
     }
 
-    public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
+    public function configureCreateForm(FormMapper $formMapper, BlockInterface $block)
     {
-        $this->buildEditForm($formMapper, $block);
+        $this->configureEditForm($formMapper, $block);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
+    public function configureEditForm(FormMapper $formMapper, BlockInterface $block)
     {
         $contextChoices = [];
 
@@ -128,7 +127,30 @@ class GalleryListBlockService extends AbstractBlockService
         ]);
     }
 
+    /**
+     * NEXT_MAJOR: delete it.
+     */    
+    public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
+    {
+        $this->configureCreateForm($formMapper, $block);
+    }
+
+    /**
+     * NEXT_MAJOR: delete it.
+     */    
+    public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
+    {
+        $this->configureEditForm($formMapper, $block);
+    }
+
+    /**
+     * NEXT_MAJOR: delete it.
+     */    
     public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
+    {
+    }
+
+    public function validate(ErrorElement $errorElement, BlockInterface $block)
     {
     }
 
@@ -183,10 +205,18 @@ class GalleryListBlockService extends AbstractBlockService
     /**
      * {@inheritdoc}
      */
-    public function getBlockMetadata($code = null)
+    public function getMetadata(): MetadataInterface
     {
-        return new Metadata($this->getName(), (null !== $code ? $code : $this->getName()), false, 'SonataMediaBundle', [
+        return new Metadata($this->getName(), null, null, 'SonataMediaBundle', [
             'class' => 'fa fa-picture-o',
         ]);
+    }
+
+    /**
+     * NEXT_MAJOR: delete it.
+     */    
+    public function getBlockMetadata($code = null)
+    {
+        return $this->getMetadata(); 
     }
 }

--- a/src/Block/GalleryListBlockService.php
+++ b/src/Block/GalleryListBlockService.php
@@ -217,6 +217,6 @@ class GalleryListBlockService extends AbstractBlockService implements EditableBl
      */
     public function getBlockMetadata($code = null)
     {
-        return $this->getMetadata(); 
+        return $this->getMetadata();
     }
 }

--- a/src/Block/GalleryListBlockService.php
+++ b/src/Block/GalleryListBlockService.php
@@ -247,6 +247,8 @@ class GalleryListBlockService extends AbstractBlockService implements EditableBl
             ), E_USER_DEPRECATED);
         }
 
-        return $this->getMetadata();
+        return new Metadata($this->getName(), (null !== $code ? $code : $this->getName()), false, 'SonataMediaBundle', [
+            'class' => 'fa fa-picture-o',
+        ]);
     }
 }

--- a/src/Block/GalleryListBlockService.php
+++ b/src/Block/GalleryListBlockService.php
@@ -129,7 +129,7 @@ class GalleryListBlockService extends AbstractBlockService implements EditableBl
 
     /**
      * NEXT_MAJOR: delete it.
-     */    
+     */
     public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
     {
         $this->configureCreateForm($formMapper, $block);
@@ -137,7 +137,7 @@ class GalleryListBlockService extends AbstractBlockService implements EditableBl
 
     /**
      * NEXT_MAJOR: delete it.
-     */    
+     */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
         $this->configureEditForm($formMapper, $block);
@@ -145,7 +145,7 @@ class GalleryListBlockService extends AbstractBlockService implements EditableBl
 
     /**
      * NEXT_MAJOR: delete it.
-     */    
+     */
     public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
     {
     }
@@ -214,7 +214,7 @@ class GalleryListBlockService extends AbstractBlockService implements EditableBl
 
     /**
      * NEXT_MAJOR: delete it.
-     */    
+     */
     public function getBlockMetadata($code = null)
     {
         return $this->getMetadata(); 

--- a/src/Block/GalleryListBlockService.php
+++ b/src/Block/GalleryListBlockService.php
@@ -19,6 +19,7 @@ use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Sonata\BlockBundle\Meta\Metadata;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\Form\Type\ImmutableArrayType;
+use Sonata\Form\Validator\ErrorElement;
 use Sonata\MediaBundle\Model\GalleryManagerInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
@@ -125,6 +126,10 @@ class GalleryListBlockService extends AbstractBlockService
             ],
             'translation_domain' => 'SonataMediaBundle',
         ]);
+    }
+
+    public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
+    {
     }
 
     /**

--- a/src/Block/GalleryListBlockService.php
+++ b/src/Block/GalleryListBlockService.php
@@ -62,7 +62,7 @@ class GalleryListBlockService extends AbstractBlockService
      */
     public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
     {  
-       $this->buildEditForm($formMapper, $block);
+        $this->buildEditForm($formMapper, $block);
     }
 
     /**

--- a/src/Block/GalleryListBlockService.php
+++ b/src/Block/GalleryListBlockService.php
@@ -246,6 +246,7 @@ class GalleryListBlockService extends AbstractBlockService implements EditableBl
                 static::class,
             ), E_USER_DEPRECATED);
         }
+
         return $this->getMetadata();
     }
 }

--- a/src/Block/GalleryListBlockService.php
+++ b/src/Block/GalleryListBlockService.php
@@ -61,7 +61,7 @@ class GalleryListBlockService extends AbstractBlockService
      * {@inheritdoc}
      */
     public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
-    {  
+    {
         $this->buildEditForm($formMapper, $block);
     }
 

--- a/src/Block/GalleryListBlockService.php
+++ b/src/Block/GalleryListBlockService.php
@@ -57,9 +57,6 @@ class GalleryListBlockService extends AbstractBlockService
         $this->pool = $pool;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
     {
         $this->buildEditForm($formMapper, $block);

--- a/src/Block/GalleryListBlockService.php
+++ b/src/Block/GalleryListBlockService.php
@@ -136,7 +136,7 @@ class GalleryListBlockService extends AbstractBlockService implements EditableBl
             @trigger_error(sprintf(
                 'Method %s() is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0. Use %s::configureCreateForm() instead.',
                 __METHOD__,
-                static::class,
+                static::class
             ), E_USER_DEPRECATED);
         }
         $this->configureCreateForm($formMapper, $block);
@@ -151,7 +151,7 @@ class GalleryListBlockService extends AbstractBlockService implements EditableBl
             @trigger_error(sprintf(
                 'Method %s() is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0. Use %s::configureEditForm() instead.',
                 __METHOD__,
-                static::class,
+                static::class
             ), E_USER_DEPRECATED);
         }
         $this->configureEditForm($formMapper, $block);
@@ -166,7 +166,7 @@ class GalleryListBlockService extends AbstractBlockService implements EditableBl
             @trigger_error(sprintf(
                 'Method %s() is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0. Use %s::validate() instead.',
                 __METHOD__,
-                static::class,
+                static::class
             ), E_USER_DEPRECATED);
         }
         $this->validate($errorElement, $block);
@@ -243,7 +243,7 @@ class GalleryListBlockService extends AbstractBlockService implements EditableBl
             @trigger_error(sprintf(
                 'Method %s() is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0. Use %s::getMetadata() instead.',
                 __METHOD__,
-                static::class,
+                static::class
             ), E_USER_DEPRECATED);
         }
 

--- a/src/Block/GalleryListBlockService.php
+++ b/src/Block/GalleryListBlockService.php
@@ -128,7 +128,7 @@ class GalleryListBlockService extends AbstractBlockService implements EditableBl
     }
 
     /**
-     * NEXT_MAJOR: delete it.
+     * NEXT_MAJOR: Remove this method. 
      */
     public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
     {
@@ -136,7 +136,7 @@ class GalleryListBlockService extends AbstractBlockService implements EditableBl
     }
 
     /**
-     * NEXT_MAJOR: delete it.
+     * NEXT_MAJOR: Remove this method.
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
@@ -144,7 +144,7 @@ class GalleryListBlockService extends AbstractBlockService implements EditableBl
     }
 
     /**
-     * NEXT_MAJOR: delete it.
+     * NEXT_MAJOR: Remove this method.
      */
     public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
     {
@@ -213,7 +213,7 @@ class GalleryListBlockService extends AbstractBlockService implements EditableBl
     }
 
     /**
-     * NEXT_MAJOR: delete it.
+     * NEXT_MAJOR: Remove this method.
      */
     public function getBlockMetadata($code = null)
     {

--- a/src/Block/GalleryListBlockService.php
+++ b/src/Block/GalleryListBlockService.php
@@ -60,6 +60,14 @@ class GalleryListBlockService extends AbstractBlockService
     /**
      * {@inheritdoc}
      */
+    public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
+    {  
+       $this->buildEditForm($formMapper, $block);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
         $contextChoices = [];

--- a/src/Block/MediaBlockService.php
+++ b/src/Block/MediaBlockService.php
@@ -157,7 +157,7 @@ class MediaBlockService extends AbstractBlockService implements EditableBlockSer
     }
 
     /**
-     * NEXT_MAJOR: delete it.
+     * NEXT_MAJOR: Remove this method.
      */
     public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
     {
@@ -165,7 +165,7 @@ class MediaBlockService extends AbstractBlockService implements EditableBlockSer
     }
 
     /**
-     * NEXT_MAJOR: delete it.
+     * NEXT_MAJOR: Remove this method.
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
@@ -173,7 +173,7 @@ class MediaBlockService extends AbstractBlockService implements EditableBlockSer
     }
 
     /**
-     * NEXT_MAJOR: delete it.
+     * NEXT_MAJOR: Remove this method.
      */
     public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
     {
@@ -243,7 +243,7 @@ class MediaBlockService extends AbstractBlockService implements EditableBlockSer
     }
 
     /**
-     * NEXT_MAJOR: delete it.
+     * NEXT_MAJOR: Remove this method.
      */
     public function getBlockMetadata($code = null)
     {

--- a/src/Block/MediaBlockService.php
+++ b/src/Block/MediaBlockService.php
@@ -277,7 +277,9 @@ class MediaBlockService extends AbstractBlockService implements EditableBlockSer
             ), E_USER_DEPRECATED);
         }
 
-        return $this->getMetaData();
+        return new Metadata($this->getName(), (null !== $code ? $code : $this->getName()), false, 'SonataMediaBundle', [
+            'class' => 'fa fa-picture-o',
+        ]);
     }
 
     /**

--- a/src/Block/MediaBlockService.php
+++ b/src/Block/MediaBlockService.php
@@ -111,9 +111,6 @@ class MediaBlockService extends AbstractBlockService
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
     {
         $this->buildEditForm($formMapper, $block);

--- a/src/Block/MediaBlockService.php
+++ b/src/Block/MediaBlockService.php
@@ -18,6 +18,7 @@ use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractBlockService;
+use Sonata\BlockBundle\Block\Service\EditableBlockService;
 use Sonata\BlockBundle\Meta\Metadata;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\Doctrine\Model\ManagerInterface;
@@ -40,7 +41,7 @@ use Twig\Environment;
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class MediaBlockService extends AbstractBlockService
+class MediaBlockService extends AbstractBlockService implements EditableBlockService
 {
     /**
      * @var BaseMediaAdmin
@@ -112,15 +113,12 @@ class MediaBlockService extends AbstractBlockService
         ]);
     }
 
-    public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
+    public function configureCreateForm(FormMapper $formMapper, BlockInterface $block)
     {
-        $this->buildEditForm($formMapper, $block);
+        $this->configureEditForm($formMapper, $block);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
+    public function configureEditForm(FormMapper $formMapper, BlockInterface $block)
     {
         if (!$block->getSetting('mediaId') instanceof MediaInterface) {
             $this->load($block);
@@ -155,6 +153,22 @@ class MediaBlockService extends AbstractBlockService
             ],
             'translation_domain' => 'SonataMediaBundle',
         ]);
+    }
+
+    /**
+     * NEXT_MAJOR: delete it
+     */
+    public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
+    {
+        $this->configureCreateForm($formMapper, $block);
+    }
+
+    /**
+     * NEXT_MAJOR: delete it
+     */
+    public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
+    {
+        $this->configureEditForm($formMapper, $block);
     }
 
     public function validateBlock(ErrorElement $errorElement, BlockInterface $block)

--- a/src/Block/MediaBlockService.php
+++ b/src/Block/MediaBlockService.php
@@ -156,7 +156,7 @@ class MediaBlockService extends AbstractBlockService implements EditableBlockSer
     }
 
     /**
-     * NEXT_MAJOR: delete it
+     * NEXT_MAJOR: delete it.
      */
     public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
     {
@@ -164,7 +164,7 @@ class MediaBlockService extends AbstractBlockService implements EditableBlockSer
     }
 
     /**
-     * NEXT_MAJOR: delete it
+     * NEXT_MAJOR: delete it.
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {

--- a/src/Block/MediaBlockService.php
+++ b/src/Block/MediaBlockService.php
@@ -114,6 +114,14 @@ class MediaBlockService extends AbstractBlockService
     /**
      * {@inheritdoc}
      */
+    public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
+    {
+       $this->buildEditForm($formMapper, $block);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
         if (!$block->getSetting('mediaId') instanceof MediaInterface) {

--- a/src/Block/MediaBlockService.php
+++ b/src/Block/MediaBlockService.php
@@ -276,6 +276,7 @@ class MediaBlockService extends AbstractBlockService implements EditableBlockSer
                 static::class,
             ), E_USER_DEPRECATED);
         }
+
         return $this->getMetaData();
     }
 

--- a/src/Block/MediaBlockService.php
+++ b/src/Block/MediaBlockService.php
@@ -165,7 +165,7 @@ class MediaBlockService extends AbstractBlockService implements EditableBlockSer
             @trigger_error(sprintf(
                 'Method %s() is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0. Use %s::configureCreateForm() instead.',
                 __METHOD__,
-                static::class,
+                static::class
             ), E_USER_DEPRECATED);
         }
         $this->configureCreateForm($formMapper, $block);
@@ -180,7 +180,7 @@ class MediaBlockService extends AbstractBlockService implements EditableBlockSer
             @trigger_error(sprintf(
                 'Method %s() is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0. Use %s::configureEditForm() instead.',
                 __METHOD__,
-                static::class,
+                static::class
             ), E_USER_DEPRECATED);
         }
         $this->configureEditForm($formMapper, $block);
@@ -195,7 +195,7 @@ class MediaBlockService extends AbstractBlockService implements EditableBlockSer
             @trigger_error(sprintf(
                 'Method %s() is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0. Use %s::validate() instead.',
                 __METHOD__,
-                static::class,
+                static::class
             ), E_USER_DEPRECATED);
         }
         $this->validate($errorElement, $block);
@@ -273,7 +273,7 @@ class MediaBlockService extends AbstractBlockService implements EditableBlockSer
             @trigger_error(sprintf(
                 'Method %s() is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0. Use %s::getMetadata() instead.',
                 __METHOD__,
-                static::class,
+                static::class
             ), E_USER_DEPRECATED);
         }
 

--- a/src/Block/MediaBlockService.php
+++ b/src/Block/MediaBlockService.php
@@ -161,6 +161,13 @@ class MediaBlockService extends AbstractBlockService implements EditableBlockSer
      */
     public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[2] ?? null)) {
+            @trigger_error(sprintf(
+                'Method %s() is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0. Use %s::configureCreateForm() instead.',
+                __METHOD__,
+                static::class,
+            ), E_USER_DEPRECATED);
+        }
         $this->configureCreateForm($formMapper, $block);
     }
 
@@ -169,6 +176,13 @@ class MediaBlockService extends AbstractBlockService implements EditableBlockSer
      */
     public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[2] ?? null)) {
+            @trigger_error(sprintf(
+                'Method %s() is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0. Use %s::configureEditForm() instead.',
+                __METHOD__,
+                static::class,
+            ), E_USER_DEPRECATED);
+        }
         $this->configureEditForm($formMapper, $block);
     }
 
@@ -177,6 +191,14 @@ class MediaBlockService extends AbstractBlockService implements EditableBlockSer
      */
     public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[2] ?? null)) {
+            @trigger_error(sprintf(
+                'Method %s() is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0. Use %s::validate() instead.',
+                __METHOD__,
+                static::class,
+            ), E_USER_DEPRECATED);
+        }
+        $this->validate($errorElement, $block);
     }
 
     public function validate(ErrorElement $errorElement, BlockInterface $block)
@@ -247,6 +269,13 @@ class MediaBlockService extends AbstractBlockService implements EditableBlockSer
      */
     public function getBlockMetadata($code = null)
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[2] ?? null)) {
+            @trigger_error(sprintf(
+                'Method %s() is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0. Use %s::getMetadata() instead.',
+                __METHOD__,
+                static::class,
+            ), E_USER_DEPRECATED);
+        }
         return $this->getMetaData();
     }
 
@@ -280,7 +309,7 @@ class MediaBlockService extends AbstractBlockService implements EditableBlockSer
             'translation_domain' => 'SonataMediaBundle',
         ]);
         $fieldDescription->setAssociationAdmin($this->getMediaAdmin());
-        $fieldDescription->setAdmin($formMapper->getAdmin());
+        $fieldDescription->setAdmin($this->container->get('sonata.page.admin.block'));
         $fieldDescription->setOption('edit', 'list');
         $fieldDescription->setAssociationMapping([
             'fieldName' => 'media',

--- a/src/Block/MediaBlockService.php
+++ b/src/Block/MediaBlockService.php
@@ -116,7 +116,7 @@ class MediaBlockService extends AbstractBlockService
      */
     public function buildCreateForm(FormMapper $formMapper, BlockInterface $block)
     {
-       $this->buildEditForm($formMapper, $block);
+        $this->buildEditForm($formMapper, $block);
     }
 
     /**

--- a/src/Block/MediaBlockService.php
+++ b/src/Block/MediaBlockService.php
@@ -22,6 +22,7 @@ use Sonata\BlockBundle\Meta\Metadata;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\Form\Type\ImmutableArrayType;
+use Sonata\Form\Validator\ErrorElement;
 use Sonata\MediaBundle\Admin\BaseMediaAdmin;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Provider\Pool;
@@ -154,6 +155,10 @@ class MediaBlockService extends AbstractBlockService
             ],
             'translation_domain' => 'SonataMediaBundle',
         ]);
+    }
+
+    public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
+    {
     }
 
     /**

--- a/src/Block/MediaBlockService.php
+++ b/src/Block/MediaBlockService.php
@@ -14,12 +14,13 @@ declare(strict_types=1);
 namespace Sonata\MediaBundle\Block;
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
-use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Sonata\BlockBundle\Block\Service\EditableBlockService;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
 use Sonata\BlockBundle\Meta\Metadata;
+use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\Form\Type\ImmutableArrayType;
@@ -171,7 +172,14 @@ class MediaBlockService extends AbstractBlockService implements EditableBlockSer
         $this->configureEditForm($formMapper, $block);
     }
 
+    /**
+     * NEXT_MAJOR: delete it.
+     */
     public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
+    {
+    }
+
+    public function validate(ErrorElement $errorElement, BlockInterface $block)
     {
     }
 
@@ -227,14 +235,19 @@ class MediaBlockService extends AbstractBlockService implements EditableBlockSer
         $block->setSetting('mediaId', \is_object($block->getSetting('mediaId')) ? $block->getSetting('mediaId')->getId() : null);
     }
 
+    public function getMetadata(): MetadataInterface
+    {
+        return new Metadata($this->getName(), null, null, 'SonataMediaBundle', [
+            'class' => 'fa fa-picture-o',
+        ]);
+    }
+
     /**
-     * {@inheritdoc}
+     * NEXT_MAJOR: delete it.
      */
     public function getBlockMetadata($code = null)
     {
-        return new Metadata($this->getName(), (null !== $code ? $code : $this->getName()), false, 'SonataMediaBundle', [
-            'class' => 'fa fa-picture-o',
-        ]);
+        return $this->getMetaData();
     }
 
     /**


### PR DESCRIPTION
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


Closes #1731

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- prepare for BlockBundle 4.0 Support with `EditableBlockService`
### Fixed
- Added `GalleryBlockService::buildCreateForm` and `GalleryBlockService::validateBlock` to fix compatibility with PageBundle
- Added `GalleryListBlockService::buildCreateForm` and `GalleryListBlockService::validateBlock` to fix compatibility with PageBundle
- Added `MediaBlockService::buildCreateForm` and `MediaBlockService::validateBlock` to fix compatibility with PageBundle
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
