### PR TITLE
Replace truncate filter with u filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,8 @@
         "symfony/twig-bridge": "^4.3",
         "symfony/twig-bundle": "^4.3",
         "symfony/validator": "^4.3",
-        "twig/twig": "^2.10"
+        "twig/string-extra": "^3.0",
+        "twig/twig": "^2.12.1"
     },
     "conflict": {
         "doctrine/dbal": "<2.6.0",
@@ -99,7 +100,8 @@
         "sonata-project/notification-bundle": "If you want to generate thumbnails asynchronously.",
         "sonata-project/seo-bundle": "^2.1",
         "symfony/monolog-bundle": "If you want to log exceptions produced when dealing with images.",
-        "tilleuls/ckeditor-sonata-media-bundle": "^1.0"
+        "tilleuls/ckeditor-sonata-media-bundle": "^1.0",
+        "twig/extra-bundle": "Auto configures the Twig Intl extension"
     },
     "config": {
         "sort-packages": true

--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -64,6 +64,7 @@ Register these bundles in your ``bundles.php`` file::
         Sonata\MediaBundle\SonataMediaBundle::class => ['all' => true],
         Sonata\EasyExtendsBundle\SonataEasyExtendsBundle::class => ['all' => true],
         JMS\SerializerBundle\JMSSerializerBundle::class => ['all' => true],
+        Twig\Extra\TwigExtraBundle\TwigExtraBundle::class => ['all' => true],
     ];
 
 Next, add the correct routing files:

--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -23,6 +23,7 @@ use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Twig\Extra\String\StringExtension;
 
 /**
  * @final since sonata-project/media-bundle 3.21.0
@@ -122,6 +123,8 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
             $container->getDefinition('sonata.media.security.superadmin_strategy')
                 ->replaceArgument(2, $sonataRoles);
         }
+
+        $this->configureStringExtension($container);
 
         $this->configureFilesystemAdapter($container, $config);
         $this->configureCdnAdapter($container, $config);
@@ -549,5 +552,15 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
         }
 
         $container->setAlias('sonata.media.resizer.default', $config['resizers']['default']);
+    }
+
+    private function configureStringExtension(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('twig.extension.string') || !is_a($container->getDefinition('twig.extension.string')->getClass(), StringExtension::class)) {
+            $definition = new Definition(StringExtension::class);
+            $definition->addTag('twig.extension');
+
+            $container->setDefinition(StringExtension::class, $definition);
+        }
     }
 }

--- a/src/Resources/views/MediaAdmin/list_outer_rows_mosaic.html.twig
+++ b/src/Resources/views/MediaAdmin/list_outer_rows_mosaic.html.twig
@@ -41,10 +41,10 @@ file that was distributed with this source code.
 
 {% block sonata_mosaic_description %}
     {% if admin.isGranted('EDIT', object) and admin.hasRoute('edit') %}
-        <a class="mosaic-inner-link" href="{{ admin.generateUrl('edit', {'id' : object|sonata_urlsafeid }) }}">{{ meta.title|truncate(40) }}</a>
+        <a class="mosaic-inner-link" href="{{ admin.generateUrl('edit', {'id' : object|sonata_urlsafeid }) }}">{{ meta.title|u.truncate(40) }}</a>
     {% elseif admin.isGranted('SHOW', object) and admin.hasRoute('show') %}
-        <a class="mosaic-inner-link" href="{{ admin.generateUrl('show', {'id' : object|sonata_urlsafeid }) }}">{{ meta.title|truncate(40) }}</a>
+        <a class="mosaic-inner-link" href="{{ admin.generateUrl('show', {'id' : object|sonata_urlsafeid }) }}">{{ meta.title|u.truncate(40) }}</a>
     {% else %}
-        {{ meta.title|truncate(40) }}
+        {{ meta.title|u.truncate(40) }}
     {% endif %}
 {% endblock %}

--- a/tests/DependencyInjection/SonataMediaExtensionTest.php
+++ b/tests/DependencyInjection/SonataMediaExtensionTest.php
@@ -23,6 +23,7 @@ use Sonata\MediaBundle\Resizer\SimpleResizer;
 use Sonata\MediaBundle\Resizer\SquareResizer;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+use Twig\Extra\String\StringExtension;
 
 class SonataMediaExtensionTest extends AbstractExtensionTestCase
 {
@@ -265,6 +266,13 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
 
         $this->assertContainerBuilderHasService('sonata.media.pool');
         $this->assertContainerBuilderHasAlias('%sonata.media.pool.class%', 'sonata.media.pool');
+    }
+
+    public function testLoadTwigStringExtension(): void
+    {
+        $this->load();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(StringExtension::class, 'twig.extension');
     }
 
     protected function getMinimalConfiguration(): array


### PR DESCRIPTION
## Subject

This bundle was using `truncate` filter without explicitly require `twig/extensions`, with this PR it uses `u` filter.

~I added `twig/extra-bundle` to autoload the Twig extension and a fallback in case Flex is not used.~

Ref: https://github.com/sonata-project/SonataAdminBundle/pull/6132

I am targeting this branch, because these changes are BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `twig/string-extra` dependency.
### Changed
- Changed use of `truncate` filter with `u` filter.
```
