### PR TITLE
Add missing interface to NoDriverManager

### DIFF
--- a/src/Model/NoDriverManager.php
+++ b/src/Model/NoDriverManager.php
@@ -20,7 +20,7 @@ use Sonata\MediaBundle\Exception\NoDriverException;
  *
  * @author Andrey F. Mindubaev <covex.mobile@gmail.com>
  */
-final class NoDriverManager implements GalleryManagerInterface
+final class NoDriverManager implements GalleryManagerInterface, MediaManagerInterface
 {
     public function getClass()
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Fixed booting up the kernel with missing driver:

```
  Argument 3 passed to Sonata\MediaBundle\Command\CleanMediaCommand::__construct() must be an instance of Sonata\MediaBundle\Model\MediaManagerInterface, instance of Sonata\MediaBundle\Model\NoDriverManager given, called in /tmp/5ef3861662fc16.00020653/app-bundle/var/cache/ContainerIHVZ2OA/getCleanMediaCommandService.php on line 9       
```

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Add missing `MediaManagerInterface` to `NoDriverManager`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
