### PR TITLE
Fix StringExtension registration

### DIFF
--- a/src/DependencyInjection/Compiler/TwigStringExtensionCompilerPass.php
+++ b/src/DependencyInjection/Compiler/TwigStringExtensionCompilerPass.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Twig\Extra\String\StringExtension;
+
+final class TwigStringExtensionCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        foreach ($container->findTaggedServiceIds('twig.extension') as $id => $attributes) {
+            if (StringExtension::class === $container->getDefinition($id)->getClass()) {
+                return;
+            }
+        }
+
+        $definition = new Definition(StringExtension::class);
+        $definition->addTag('twig.extension');
+        $container->setDefinition(StringExtension::class, $definition);
+    }
+}

--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -23,7 +23,6 @@ use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Twig\Extra\String\StringExtension;
 
 /**
  * @final since sonata-project/media-bundle 3.21.0
@@ -123,8 +122,6 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
             $container->getDefinition('sonata.media.security.superadmin_strategy')
                 ->replaceArgument(2, $sonataRoles);
         }
-
-        $this->configureStringExtension($container);
 
         $this->configureFilesystemAdapter($container, $config);
         $this->configureCdnAdapter($container, $config);
@@ -552,15 +549,5 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
         }
 
         $container->setAlias('sonata.media.resizer.default', $config['resizers']['default']);
-    }
-
-    private function configureStringExtension(ContainerBuilder $container): void
-    {
-        if (!$container->hasDefinition('twig.extension.string') || !is_a($container->getDefinition('twig.extension.string')->getClass(), StringExtension::class)) {
-            $definition = new Definition(StringExtension::class);
-            $definition->addTag('twig.extension');
-
-            $container->setDefinition(StringExtension::class, $definition);
-        }
     }
 }

--- a/src/SonataMediaBundle.php
+++ b/src/SonataMediaBundle.php
@@ -17,6 +17,7 @@ use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\MediaBundle\DependencyInjection\Compiler\AddProviderCompilerPass;
 use Sonata\MediaBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass;
 use Sonata\MediaBundle\DependencyInjection\Compiler\ThumbnailCompilerPass;
+use Sonata\MediaBundle\DependencyInjection\Compiler\TwigStringExtensionCompilerPass;
 use Sonata\MediaBundle\Form\Type\ApiDoctrineMediaType;
 use Sonata\MediaBundle\Form\Type\ApiGalleryHasMediaType;
 use Sonata\MediaBundle\Form\Type\ApiGalleryType;
@@ -35,6 +36,7 @@ class SonataMediaBundle extends Bundle
         $container->addCompilerPass(new AddProviderCompilerPass());
         $container->addCompilerPass(new GlobalVariablesCompilerPass());
         $container->addCompilerPass(new ThumbnailCompilerPass());
+        $container->addCompilerPass(new TwigStringExtensionCompilerPass());
 
         $this->registerFormMapping();
     }

--- a/tests/DependencyInjection/Compiler/AddProviderCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddProviderCompilerPassTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+namespace Sonata\MediaBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\MediaBundle\DependencyInjection\Compiler\AddProviderCompilerPass;

--- a/tests/DependencyInjection/Compiler/ThumbnailCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ThumbnailCompilerPassTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+namespace Sonata\MediaBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\MediaBundle\DependencyInjection\Compiler\ThumbnailCompilerPass;

--- a/tests/DependencyInjection/Compiler/TwigStringExtensionCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/TwigStringExtensionCompilerPassTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sonata\MediaBundle\DependencyInjection\Compiler\TwigStringExtensionCompilerPass;
+use Symfony\Bundle\TwigBundle\DependencyInjection\Compiler\TwigEnvironmentPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Twig\Extra\String\StringExtension;
+
+class TwigStringExtensionCompilerPassTest extends AbstractCompilerPassTestCase
+{
+    public function testLoadTwigStringExtension(): void
+    {
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(StringExtension::class, 'twig.extension');
+    }
+
+    public function testLoadTwigStringExtensionWithExtraBundle(): void
+    {
+        $definition = new Definition(StringExtension::class);
+        $definition->addTag('twig.extension');
+        $this->container->setDefinition('twig.extension.string', $definition);
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag('twig.extension.string', 'twig.extension');
+        $this->assertContainerBuilderNotHasService(StringExtension::class);
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new TwigEnvironmentPass());
+        $container->addCompilerPass(new TwigStringExtensionCompilerPass());
+    }
+}

--- a/tests/DependencyInjection/SonataMediaExtensionTest.php
+++ b/tests/DependencyInjection/SonataMediaExtensionTest.php
@@ -23,7 +23,6 @@ use Sonata\MediaBundle\Resizer\SimpleResizer;
 use Sonata\MediaBundle\Resizer\SquareResizer;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
-use Twig\Extra\String\StringExtension;
 
 class SonataMediaExtensionTest extends AbstractExtensionTestCase
 {
@@ -266,13 +265,6 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
 
         $this->assertContainerBuilderHasService('sonata.media.pool');
         $this->assertContainerBuilderHasAlias('%sonata.media.pool.class%', 'sonata.media.pool');
-    }
-
-    public function testLoadTwigStringExtension(): void
-    {
-        $this->load();
-
-        $this->assertContainerBuilderHasServiceDefinitionWithTag(StringExtension::class, 'twig.extension');
     }
 
     protected function getMinimalConfiguration(): array


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
This PR contains:
- move StringExtension registration to Compiler pass and check all `twig.extension` service to avoid duplication
- improve tests
- fix previus broken checking
```php
... !is_a($container->getDefinition('twig.extension.string')->getClass(), StringExtension::class)) ...
// it is like this:   !is_a('Twig\Extra\String\StringExtension', StringExtension::class)) ...
```


<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

PATCH for non release #1756.
