### PR TITLE
Fix TwigStringExtensionCompilerPass priority

### DIFF
--- a/src/SonataMediaBundle.php
+++ b/src/SonataMediaBundle.php
@@ -23,6 +23,7 @@ use Sonata\MediaBundle\Form\Type\ApiGalleryHasMediaType;
 use Sonata\MediaBundle\Form\Type\ApiGalleryType;
 use Sonata\MediaBundle\Form\Type\ApiMediaType;
 use Sonata\MediaBundle\Form\Type\MediaType;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -36,7 +37,7 @@ class SonataMediaBundle extends Bundle
         $container->addCompilerPass(new AddProviderCompilerPass());
         $container->addCompilerPass(new GlobalVariablesCompilerPass());
         $container->addCompilerPass(new ThumbnailCompilerPass());
-        $container->addCompilerPass(new TwigStringExtensionCompilerPass());
+        $container->addCompilerPass(new TwigStringExtensionCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
 
         $this->registerFormMapping();
     }

--- a/tests/App/Controller/TruncateController.php
+++ b/tests/App/Controller/TruncateController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+
+final class TruncateController extends AbstractController
+{
+    public function test(): Response
+    {
+        return $this->render('truncate_test.html.twig');
+    }
+}

--- a/tests/App/Resources/views/truncate_test.html.twig
+++ b/tests/App/Resources/views/truncate_test.html.twig
@@ -1,0 +1,3 @@
+{% spaceless %}
+    {{ 'test for u.truncate'|u.truncate(4) }}
+{% endspaceless %}

--- a/tests/App/routes.yml
+++ b/tests/App/routes.yml
@@ -2,3 +2,7 @@ sonata_api_media:
     type: rest
     prefix: /api
     resource: "@SonataMediaBundle/Resources/config/routing/api.xml"
+
+test_page:
+    path: /u_truncate_test
+    controller: Sonata\MediaBundle\Tests\App\Controller\TruncateController:test

--- a/tests/Functional/Controller/TruncateControllerTest.php
+++ b/tests/Functional/Controller/TruncateControllerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\Functional\Controller;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\MediaBundle\Tests\App\AppKernel;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class TruncateControllerTest extends TestCase
+{
+    public function testTruncate(): void
+    {
+        $client = new KernelBrowser(new AppKernel());
+        $client->request(Request::METHOD_GET, '/u_truncate_test');
+
+        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $this->assertSame('test', $client->getResponse()->getContent());
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
This PR fix case when TwigStringExtensionCompilerPass is build after TwigEnvironmentPass - then u filter is not registred.


<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is PATCH.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Changelog is not require. It is fix for non release PR #1758 and #1756.