### PR TITLE
Use ImageProviderInterface instead of ImageProvider for contructor's …

### DIFF
--- a/src/Provider/ImageProvider.php
+++ b/src/Provider/ImageProvider.php
@@ -26,7 +26,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 /**
  * @final since sonata-project/media-bundle 3.21.0
  */
-class ImageProvider extends FileProvider
+class ImageProvider extends FileProvider implements ImageProviderInterface
 {
     /**
      * @var ImagineInterface

--- a/src/Provider/ImageProviderInterface.php
+++ b/src/Provider/ImageProviderInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Provider;
+
+interface ImageProviderInterface extends FileProviderInterface
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function getFormatsForContext(string $context): array;
+}

--- a/src/Resources/config/provider.xml
+++ b/src/Resources/config/provider.xml
@@ -117,7 +117,10 @@
         <service id="sonata.media.http.buzz_client" class="Sonata\MediaBundle\Client\BuzzClient">
             <argument type="service" id="sonata.media.buzz.browser"/>
         </service>
-        <service id="%sonata.media.provider.image.class%" alias="sonata.media.provider.image"/>
+        <service id="%sonata.media.provider.image.class%" alias="sonata.media.provider.image">
+            <deprecated>The "%alias_id%" service alias is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0. Use "Sonata\MediaBundle\Provider\ImageProviderInterface" instead.</deprecated>
+        </service>
+        <service id="Sonata\MediaBundle\Provider\ImageProviderInterface" alias="sonata.media.provider.image"/>
         <service id="%sonata.media.provider.file.class%" alias="sonata.media.provider.file"/>
         <service id="%sonata.media.provider.youtube.class%" alias="sonata.media.provider.youtube"/>
         <service id="%sonata.media.provider.dailymotion.class%" alias="sonata.media.provider.dailymotion"/>

--- a/src/Validator/Constraints/ImageUploadDimensionValidator.php
+++ b/src/Validator/Constraints/ImageUploadDimensionValidator.php
@@ -15,7 +15,7 @@ namespace Sonata\MediaBundle\Validator\Constraints;
 
 use Imagine\Image\ImagineInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
-use Sonata\MediaBundle\Provider\ImageProvider;
+use Sonata\MediaBundle\Provider\ImageProviderInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -28,11 +28,11 @@ final class ImageUploadDimensionValidator extends ConstraintValidator
     private $imagineAdapter;
 
     /**
-     * @var ImageProvider
+     * @var ImageProviderInterface
      */
     private $imageProvider;
 
-    public function __construct(ImagineInterface $imagineAdapter, ImageProvider $imageProvider)
+    public function __construct(ImagineInterface $imagineAdapter, ImageProviderInterface $imageProvider)
     {
         $this->imagineAdapter = $imagineAdapter;
         $this->imageProvider = $imageProvider;

--- a/tests/Metadata/ProxyMetadataBuilderTest.php
+++ b/tests/Metadata/ProxyMetadataBuilderTest.php
@@ -69,7 +69,7 @@ final class ProxyMetadataBuilderTest extends TestCase
         $filesystem = $this->createStub(Filesystem::class);
         $filesystem->method('getAdapter')->willReturn($adapter);
 
-        $provider = $this->createStub(MediaProviderInterface::class);
+        $provider = $this->createMock(MediaProviderInterface::class);
         $provider->method('getFilesystem')->willReturn($filesystem);
 
         $media = $this->createStub(MediaInterface::class);
@@ -108,7 +108,7 @@ final class ProxyMetadataBuilderTest extends TestCase
         $filesystem = $this->createStub(Filesystem::class);
         $filesystem->method('getAdapter')->willReturn($adapter);
 
-        $provider = $this->createStub(MediaProviderInterface::class);
+        $provider = $this->createMock(MediaProviderInterface::class);
         $provider->method('getFilesystem')->willReturn($filesystem);
 
         $media = $this->createStub(MediaInterface::class);
@@ -147,7 +147,7 @@ final class ProxyMetadataBuilderTest extends TestCase
         $filesystem = $this->createStub(Filesystem::class);
         $filesystem->method('getAdapter')->willReturn($adapter);
 
-        $provider = $this->createStub(MediaProviderInterface::class);
+        $provider = $this->createMock(MediaProviderInterface::class);
         $provider->method('getFilesystem')->willReturn($filesystem);
 
         $media = $this->createStub(MediaInterface::class);
@@ -209,7 +209,7 @@ final class ProxyMetadataBuilderTest extends TestCase
         $filesystem = $this->createStub(Filesystem::class);
         $filesystem->method('getAdapter')->willReturn($adapter);
 
-        $provider = $this->createStub(MediaProviderInterface::class);
+        $provider = $this->createMock(MediaProviderInterface::class);
         $provider->method('getFilesystem')->willReturn($filesystem);
 
         $media = $this->createStub(MediaInterface::class);
@@ -250,7 +250,7 @@ final class ProxyMetadataBuilderTest extends TestCase
         $filesystem = $this->createStub(Filesystem::class);
         $filesystem->method('getAdapter')->willReturn($adapter);
 
-        $provider = $this->createStub(MediaProviderInterface::class);
+        $provider = $this->createMock(MediaProviderInterface::class);
         $provider->method('getFilesystem')->willReturn($filesystem);
 
         $media = $this->createStub(MediaInterface::class);


### PR DESCRIPTION
…signature

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject



I need to use my own ImageProvider and FileProvider for differents reasons.
Since these base providers are final classes (or declared as final) I can't extend them anymore.

Here my config : 
```
parameters:
  sonata.media.provider.image.class: App\Media\Provider\ImageProvider
  sonata.media.manager.media.class:  App\Manager\MediaManager
  sonata.media.provider.file.class: App\Media\Provider\FileProvider
```

  
Since the introduction of ImageUploadDimension validator I can't upload any new media, because the signature of the constructor expects an Sonata\MediaBundle\Provider\ImageProvider.

So I changed the constructor's signature to take an ImageProviderInterface instead. 

My provider can implement this interface as Sonata\MediaBundle\ImageProvide

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
 

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
--> 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added ImageProviderInterface


### Deprecated
 - Deprecations about the "sonata.media.provider.image" service alias,use "Sonata\MediaBundle\Provider\ImageProviderInterface" instead.

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
