### PR TITLE
Add french translation for image_too_small error message #1743

### DIFF
--- a/src/Resources/translations/SonataMediaBundle.fr.xliff
+++ b/src/Resources/translations/SonataMediaBundle.fr.xliff
@@ -571,6 +571,10 @@
                 <source>form.label_icon</source>
                 <target>Icône</target>
             </trans-unit>
+            <trans-unit id="error.image_too_small">
+                <source>error.image_too_small</source>
+                <target>Image trop petite, la taille minimum requise est de %min_width% x %min_height%.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
## Subject

Add missing french translation for image_too_small error message #1743

I am targeting this branch, because these changes respect BC.

This message added with #1743 is only present in `en` and `de` translation files but I'm only able to translate it in french.
