### PR TITLE
endpoint configuration for s3 storage

### DIFF
--- a/docs/reference/amazon_s3.rst
+++ b/docs/reference/amazon_s3.rst
@@ -31,10 +31,11 @@ This is a sample config file to enable amazon S3 as a filesystem & provider:
                 accessKey:   '%s3_access_key%'
                 secretKey:   '%s3_secret_key%'
                 region:      '%s3_region%'
-                version:     '%s3_version%' # latest by default (cf. https://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/configuration.html#version)
+                version:     '%s3_version%' # latest by default (cf. https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_configuration.html#cfg-version)
+                endpoint:    '%s3_endpoint%' # null by default (cf. https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_configuration.html#endpoint)
                 sdk_version: '%s3_sdk_version%' # 2 by default
 
-.. note:: 
+.. note::
 
    This bundle is currently using KNP Gaufrette as S3 adapter and the default SDK used is version 2.
    Changes have been made in the bundle to allow you to use version 3, update `sdk_version` parameter for this.

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -238,6 +238,7 @@ class Configuration implements ConfigurationInterface
                                     ->end()
                                 ->end()
                                 ->scalarNode('region')->defaultValue('s3.amazonaws.com')->end()
+                                ->scalarNode('endpoint')->defaultNull()->end()
                                 ->scalarNode('version')->defaultValue('latest')->end()
                                 ->enumNode('sdk_version')
                                     ->values([2, 3])

--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -399,6 +399,10 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
                     'version' => $config['filesystem']['s3']['version'],
                 ];
 
+                if (isset($config['filesystem']['s3']['endpoint'])) {
+                    $arguments['endpoint'] = $config['filesystem']['s3']['endpoint'];
+                }
+
                 if (isset($config['filesystem']['s3']['secretKey'], $config['filesystem']['s3']['accessKey'])) {
                     $arguments['credentials'] = [
                         'secret' => $config['filesystem']['s3']['secretKey'],

--- a/tests/DependencyInjection/SonataMediaExtensionTest.php
+++ b/tests/DependencyInjection/SonataMediaExtensionTest.php
@@ -242,6 +242,7 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
                             'sdk_version' => 3,
                             'region' => 'region',
                             'version' => 'version',
+                            'endpoint' => 'endpoint',
                             'secretKey' => 'secret',
                             'accessKey' => 'access',
                         ],
@@ -250,6 +251,7 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
                 [
                     'region' => 'region',
                     'version' => 'version',
+                    'endpoint' => 'endpoint',
                     'credentials' => [
                         'secret' => 'secret',
                         'key' => 'access',


### PR DESCRIPTION
## Subject

Add endpoint configuration option for s3 filesystem.

I am targeting this branch, because these changes respect BC.

Closes #1773 https://github.com/sonata-project/SonataMediaBundle/pull/1706

## Changelog

```markdown
### Added
- Added configuration option filesystem.s3.endpoint
```