### PR TITLE
Rename GalleryItems

### DIFF
--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -221,7 +221,7 @@ Configure SonataMediaBundle to use the newly generated classes:
             class:
                 media: App\Application\Sonata\MediaBundle\Entity\Media
                 gallery: App\Application\Sonata\MediaBundle\Entity\Gallery
-                gallery_has_media: App\Application\Sonata\MediaBundle\Entity\GalleryHasMedia
+                gallery_item: App\Application\Sonata\MediaBundle\Entity\GalleryItem
 
 If you are not using auto-mapping in doctrine you will have to add it there
 too:

--- a/src/Admin/GalleryAdmin.php
+++ b/src/Admin/GalleryAdmin.php
@@ -54,7 +54,7 @@ class GalleryAdmin extends AbstractAdmin
 
     public function postUpdate($gallery)
     {
-        $gallery->reorderGalleryHasMedia();
+        $gallery->reorderGalleryItems();
     }
 
     public function getPersistentParameters()

--- a/src/Controller/Api/GalleryController.php
+++ b/src/Controller/Api/GalleryController.php
@@ -20,7 +20,7 @@ use FOS\RestBundle\Request\ParamFetcherInterface;
 use FOS\RestBundle\View\View as FOSRestView;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Sonata\DatagridBundle\Pager\PagerInterface;
-use Sonata\MediaBundle\Form\Type\ApiGalleryHasMediaType;
+use Sonata\MediaBundle\Form\Type\ApiGalleryItemType;
 use Sonata\MediaBundle\Form\Type\ApiGalleryType;
 use Sonata\MediaBundle\Model\GalleryInterface;
 use Sonata\MediaBundle\Model\GalleryItemInterface;
@@ -426,7 +426,7 @@ class GalleryController
      */
     protected function handleWriteGalleryItem(GalleryInterface $gallery, MediaInterface $media, ?GalleryItemInterface $galleryItem = null, Request $request)
     {
-        $form = $this->formFactory->createNamed(null, ApiGalleryHasMediaType::class, $galleryItem, [
+        $form = $this->formFactory->createNamed(null, ApiGalleryItemType::class, $galleryItem, [
             'csrf_protection' => false,
         ]);
 

--- a/src/Model/Gallery.php
+++ b/src/Model/Gallery.php
@@ -144,13 +144,13 @@ abstract class Gallery implements GalleryInterface, GalleryMediaCollectionInterf
     }
 
     /**
-     * Reorders $galleryHasMedia items based on their position.
+     * Reorders $galleryItems based on their position.
      */
-    public function reorderGalleryHasMedia()
+    public function reorderGalleryItems()
     {
-        if ($this->getGalleryHasMedias() && $this->getGalleryHasMedias() instanceof \IteratorAggregate) {
+        if ($this->getGalleryItems() && $this->getGalleryItems() instanceof \IteratorAggregate) {
             // reorder
-            $iterator = $this->getGalleryHasMedias()->getIterator();
+            $iterator = $this->getGalleryItems()->getIterator();
 
             $iterator->uasort(static function ($a, $b) {
                 if ($a->getPosition() === $b->getPosition()) {
@@ -160,7 +160,7 @@ abstract class Gallery implements GalleryInterface, GalleryMediaCollectionInterf
                 return $a->getPosition() > $b->getPosition() ? 1 : -1;
             });
 
-            $this->setGalleryHasMedias($iterator);
+            $this->setGalleryItems($iterator);
         }
     }
 }

--- a/src/Model/GalleryInterface.php
+++ b/src/Model/GalleryInterface.php
@@ -110,8 +110,7 @@ interface GalleryInterface
     public function getGalleryItems();
 
     /**
-     * @deprecated implement addGalleryHasMedia method instead, it will be provided with the next major release
-     * NEXT_MAJOR: remove this method
+     * @return void
      */
     public function addGalleryItem(GalleryItemInterface $galleryItem);
 }

--- a/src/Resources/translations/SonataMediaBundle.ca.xliff
+++ b/src/Resources/translations/SonataMediaBundle.ca.xliff
@@ -146,8 +146,8 @@
                 <source>form.label_default_format</source>
                 <target>Format</target>
             </trans-unit>
-            <trans-unit id="form.label_gallery_has_medias">
-                <source>form.label_gallery_has_medias</source>
+            <trans-unit id="form.label_gallery_items">
+                <source>form.label_gallery_items</source>
                 <target>Media</target>
             </trans-unit>
             <trans-unit id="form.label_author_name">

--- a/src/Resources/translations/SonataMediaBundle.cs.xliff
+++ b/src/Resources/translations/SonataMediaBundle.cs.xliff
@@ -146,8 +146,8 @@
                 <source>form.label_default_format</source>
                 <target>Formát</target>
             </trans-unit>
-            <trans-unit id="form.label_gallery_has_medias">
-                <source>form.label_gallery_has_medias</source>
+            <trans-unit id="form.label_gallery_items">
+                <source>form.label_gallery_items</source>
                 <target>Média</target>
             </trans-unit>
             <trans-unit id="form.label_author_name">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Rename `GalleryHasMedia` to `GalleryItems` 

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because https://github.com/sonata-project/SonataMediaBundle/pull/1775#issuecomment-667503650.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->