### PR TITLE
Enable autowiring for "sonata.media.manager.media" and "sonata.media.manager.gallery" services

### DIFF
--- a/src/Resources/config/doctrine_mongodb.xml
+++ b/src/Resources/config/doctrine_mongodb.xml
@@ -10,10 +10,12 @@
             <argument>%sonata.media.media.class%</argument>
             <argument type="service" id="doctrine_mongodb"/>
         </service>
+        <service id="Sonata\MediaBundle\Model\MediaManagerInterface" alias="sonata.media.manager.media" public="false"/>
         <service id="sonata.media.manager.gallery" class="%sonata.media.manager.gallery.class%" public="true">
             <argument>%sonata.media.gallery.class%</argument>
             <argument type="service" id="doctrine_mongodb"/>
         </service>
+        <service id="Sonata\MediaBundle\Model\GalleryManagerInterface" alias="sonata.media.manager.gallery" public="false"/>
         <!-- Path generator servive -->
         <service id="sonata.media.generator.default" class="Sonata\MediaBundle\Generator\UuidGenerator">
 

--- a/src/Resources/config/doctrine_orm.xml
+++ b/src/Resources/config/doctrine_orm.xml
@@ -9,10 +9,12 @@
             <argument>%sonata.media.media.class%</argument>
             <argument type="service" id="doctrine"/>
         </service>
+        <service id="Sonata\MediaBundle\Model\MediaManagerInterface" alias="sonata.media.manager.media" public="false"/>
         <service id="sonata.media.manager.gallery" class="%sonata.media.manager.gallery.class%" public="true">
             <argument>%sonata.media.gallery.class%</argument>
             <argument type="service" id="doctrine"/>
         </service>
+        <service id="Sonata\MediaBundle\Model\GalleryManagerInterface" alias="sonata.media.manager.gallery" public="false"/>
         <!-- Path generator service -->
         <service id="sonata.media.generator.default" class="Sonata\MediaBundle\Generator\IdGenerator">
 

--- a/src/Resources/config/doctrine_phpcr.xml
+++ b/src/Resources/config/doctrine_phpcr.xml
@@ -9,10 +9,12 @@
             <argument>%sonata.media.media.class%</argument>
             <argument type="service" id="doctrine_phpcr"/>
         </service>
+        <service id="Sonata\MediaBundle\Model\MediaManagerInterface" alias="sonata.media.manager.media" public="false"/>
         <service id="sonata.media.manager.gallery" class="%sonata.media.manager.gallery.class%" public="true">
             <argument>%sonata.media.gallery.class%</argument>
             <argument type="service" id="doctrine_phpcr"/>
         </service>
+        <service id="Sonata\MediaBundle\Model\GalleryManagerInterface" alias="sonata.media.manager.gallery" public="false"/>
         <!-- Path generator servive -->
         <service id="sonata.media.generator.default" class="Sonata\MediaBundle\Generator\PHPCRGenerator"/>
         <service id="sonata.media.doctrine.event_subscriber" class="Sonata\MediaBundle\Listener\PHPCR\MediaEventSubscriber">

--- a/src/Resources/config/no_driver.xml
+++ b/src/Resources/config/no_driver.xml
@@ -2,7 +2,9 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sonata.media.manager.media" class="Sonata\MediaBundle\Model\NoDriverManager" public="true"/>
+        <service id="Sonata\MediaBundle\Model\MediaManagerInterface" alias="sonata.media.manager.media" public="false"/>
         <service id="sonata.media.manager.gallery" class="Sonata\MediaBundle\Model\NoDriverManager" public="true"/>
+        <service id="Sonata\MediaBundle\Model\GalleryManagerInterface" alias="sonata.media.manager.gallery" public="false"/>
         <service id="sonata.media.generator.default" class="Sonata\MediaBundle\Generator\NoDriverGenerator"/>
     </services>
 </container>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Enable autowiring for "sonata.media.manager.media" and "sonata.media.manager.gallery" services.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added "Sonata\MediaBundle\Model\MediaManagerInterface" service alias in order to enable autowiring for "sonata.media.manager.media" service;
- Added "Sonata\MediaBundle\Model\GalleryManagerInterface" service alias in order to enable autowiring for "sonata.media.manager.gallery" service.
```