### PR TITLE
Update Swagger definition in order to be compatible with string identifier

### DIFF
--- a/src/Controller/Api/GalleryController.php
+++ b/src/Controller/Api/GalleryController.php
@@ -456,7 +456,6 @@ class GalleryController
     /**
      * Retrieves media with identifier $id or throws an exception if it doesn't exist.
      *
-     *
      * @param string $id Media identifier
      *
      * @throws NotFoundHttpException

--- a/src/Controller/Api/GalleryController.php
+++ b/src/Controller/Api/GalleryController.php
@@ -118,7 +118,7 @@ class GalleryController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Gallery identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Gallery identifier"}
      *  },
      *  output={"class"="sonata_media_api_form_gallery", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -129,7 +129,7 @@ class GalleryController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Gallery identifier
      *
      * @return GalleryInterface
      */
@@ -143,7 +143,7 @@ class GalleryController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Gallery identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Gallery identifier"}
      *  },
      *  output={"class"="Sonata\MediaBundle\Model\Media", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -154,7 +154,7 @@ class GalleryController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Gallery identifier
      *
      * @return MediaInterface[]
      */
@@ -175,7 +175,7 @@ class GalleryController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Gallery identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Gallery identifier"}
      *  },
      *  output={"class"="Sonata\MediaBundle\Model\GalleryHasMedia", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -186,7 +186,7 @@ class GalleryController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string $id Gallery identifier
      *
      * @return GalleryHasMediaInterface[]
      */
@@ -223,7 +223,7 @@ class GalleryController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Gallery identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Gallery identifier"}
      *  },
      *  input={"class"="sonata_media_api_form_gallery", "name"="", "groups"={"sonata_api_write"}},
      *  output={"class"="sonata_media_api_form_gallery", "groups"={"sonata_api_read"}},
@@ -234,7 +234,7 @@ class GalleryController
      *  }
      * )
      *
-     * @param int     $id      User identifier
+     * @param string  $id      Gallery identifier
      * @param Request $request Symfony request
      *
      * @throws NotFoundHttpException
@@ -251,8 +251,8 @@ class GalleryController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="galleryId", "dataType"="integer", "requirement"="\d+", "description"="Gallery identifier"},
-     *      {"name"="mediaId", "dataType"="integer", "requirement"="\d+", "description"="Medium identifier"}
+     *      {"name"="galleryId", "dataType"="string", "description"="Gallery identifier"},
+     *      {"name"="mediaId", "dataType"="string", "description"="Medium identifier"}
      *  },
      *  input={"class"="sonata_media_api_form_gallery_has_media", "name"="", "groups"={"sonata_api_write"}},
      *  output={"class"="sonata_media_api_form_gallery", "groups"={"sonata_api_read"}},
@@ -262,8 +262,8 @@ class GalleryController
      *  }
      * )
      *
-     * @param int     $galleryId Gallery identifier
-     * @param int     $mediaId   Medium identifier
+     * @param string  $galleryId Gallery identifier
+     * @param string  $mediaId   Medium identifier
      * @param Request $request   Symfony request
      *
      * @throws NotFoundHttpException
@@ -291,8 +291,8 @@ class GalleryController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="galleryId", "dataType"="integer", "requirement"="\d+", "description"="Gallery identifier"},
-     *      {"name"="mediaId", "dataType"="integer", "requirement"="\d+", "description"="Medium identifier"}
+     *      {"name"="galleryId", "dataType"="string", "description"="Gallery identifier"},
+     *      {"name"="mediaId", "dataType"="string", "description"="Medium identifier"}
      *  },
      *  input={"class"="sonata_media_api_form_gallery_has_media", "name"="", "groups"={"sonata_api_write"}},
      *  output={"class"="sonata_media_api_form_gallery", "groups"={"sonata_api_read"}},
@@ -302,8 +302,8 @@ class GalleryController
      *  }
      * )
      *
-     * @param int     $galleryId Gallery identifier
-     * @param int     $mediaId   Medium identifier
+     * @param string  $galleryId Gallery identifier
+     * @param string  $mediaId   Medium identifier
      * @param Request $request   Symfony request
      *
      * @throws NotFoundHttpException
@@ -329,8 +329,8 @@ class GalleryController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="galleryId", "dataType"="integer", "requirement"="\d+", "description"="Gallery identifier"},
-     *      {"name"="mediaId", "dataType"="integer", "requirement"="\d+", "description"="Medium identifier"}
+     *      {"name"="galleryId", "dataType"="string", "description"="Gallery identifier"},
+     *      {"name"="mediaId", "dataType"="string", "description"="Medium identifier"}
      *  },
      *  statusCodes={
      *      200="Returned when medium is successfully deleted from gallery",
@@ -339,8 +339,8 @@ class GalleryController
      *  }
      * )
      *
-     * @param int $galleryId Gallery identifier
-     * @param int $mediaId   Media identifier
+     * @param string $galleryId Gallery identifier
+     * @param string $mediaId   Media identifier
      *
      * @throws NotFoundHttpException
      *
@@ -370,7 +370,7 @@ class GalleryController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Gallery identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Gallery identifier"}
      *  },
      *  statusCodes={
      *      200="Returned when gallery is successfully deleted",
@@ -379,7 +379,7 @@ class GalleryController
      *  }
      * )
      *
-     * @param int $id Gallery identifier
+     * @param string $id Gallery identifier
      *
      * @throws NotFoundHttpException
      *
@@ -435,6 +435,9 @@ class GalleryController
     /**
      * Retrieves gallery with identifier $id or throws an exception if it doesn't exist.
      *
+     *
+     * @param string $id Gallery identifier
+     *
      * @throws NotFoundHttpException
      *
      * @return GalleryInterface
@@ -452,6 +455,9 @@ class GalleryController
 
     /**
      * Retrieves media with identifier $id or throws an exception if it doesn't exist.
+     *
+     *
+     * @param string $id Media identifier
      *
      * @throws NotFoundHttpException
      *
@@ -487,8 +493,8 @@ class GalleryController
     /**
      * Write a Gallery, this method is used by both POST and PUT action methods.
      *
-     * @param Request  $request Symfony request
-     * @param int|null $id      Gallery identifier
+     * @param Request     $request Symfony request
+     * @param string|null $id      Gallery identifier
      *
      * @return Rest\View|FormInterface
      */

--- a/src/Controller/Api/GalleryController.php
+++ b/src/Controller/Api/GalleryController.php
@@ -435,7 +435,6 @@ class GalleryController
     /**
      * Retrieves gallery with identifier $id or throws an exception if it doesn't exist.
      *
-     *
      * @param string $id Gallery identifier
      *
      * @throws NotFoundHttpException

--- a/src/Controller/Api/MediaController.php
+++ b/src/Controller/Api/MediaController.php
@@ -72,7 +72,7 @@ class MediaController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Medium identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Medium identifier"}
      *  },
      *  output={"class"="Sonata\MediaBundle\Model\Media", "groups"={"sonata_api_read"}},
      *  statusCodes={
@@ -83,7 +83,7 @@ class MediaController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param int $id Medium identifier
+     * @param string $id Medium identifier
      *
      * @return MediaInterface
      */
@@ -140,7 +140,7 @@ class MediaController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Medium identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Medium identifier"}
      *  },
      *  statusCodes={
      *      200="Returned when successful",
@@ -148,7 +148,7 @@ class MediaController
      *  }
      * )
      *
-     * @param $id
+     * @param string $id Medium identifier
      *
      * @return array
      */
@@ -175,7 +175,7 @@ class MediaController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Medium identifier"},
+     *      {"name"="id", "dataType"="string", "description"="Medium identifier"},
      *      {"name"="format", "dataType"="string", "description"="Medium format"}
      *  },
      *  statusCodes={
@@ -184,7 +184,7 @@ class MediaController
      *  }
      * )
      *
-     * @param int    $id     Medium identifier
+     * @param string $id     Medium identifier
      * @param string $format Format
      *
      * @return Response
@@ -207,7 +207,7 @@ class MediaController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Medium identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Medium identifier"}
      *  },
      *  statusCodes={
      *      200="Returned when medium is successfully deleted",
@@ -216,7 +216,7 @@ class MediaController
      *  }
      * )
      *
-     * @param int $id Medium identifier
+     * @param string $id Medium identifier
      *
      * @throws NotFoundHttpException
      *
@@ -239,7 +239,7 @@ class MediaController
      *
      * @ApiDoc(
      *  requirements={
-     *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="Medium identifier"}
+     *      {"name"="id", "dataType"="string", "description"="Medium identifier"}
      *  },
      *  input={"class"="sonata_media_api_form_media", "name"="", "groups"={"sonata_api_write"}},
      *  output={"class"="Sonata\MediaBundle\Model\Media", "groups"={"sonata_api_read"}},
@@ -250,7 +250,7 @@ class MediaController
      *  }
      * )
      *
-     * @param int     $id      Medium identifier
+     * @param string  $id      Medium identifier
      * @param Request $request Symfony request
      *
      * @throws NotFoundHttpException
@@ -326,7 +326,7 @@ class MediaController
      *
      * @Rest\View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param $id
+     * @param string  $id      Medium identifier
      * @param Request $request Symfony request
      *
      * @throws NotFoundHttpException
@@ -347,7 +347,7 @@ class MediaController
     /**
      * Retrieves media with identifier $id or throws an exception if not found.
      *
-     * @param int $id Media identifier
+     * @param string $id Media identifier
      *
      * @throws AccessDeniedException
      * @throws NotFoundHttpException


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Update OpenAPI (Swagger) definition in order to be compatible with string identifiers (like UUIDs).

These changes are consistent with the API narrowing made at sonata-project/admin-bundle (see AdminInterface::id()).

I am targeting this branch, because these changes respect BC.

Part of https://github.com/sonata-project/dev-kit/issues/778

Based on: https://github.com/sonata-project/SonataUserBundle/pull/1198

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Removed requirements that were only allowing integers for model identifiers at Open API definitions.
### Fixed
- Fixed support for string model identifiers at Open API definitions.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
