### PR TITLE
Add support for Twig 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "symfony/twig-bundle": "^4.4",
         "symfony/validator": "^4.4 || ^5.1",
         "twig/string-extra": "^3.0",
-        "twig/twig": "^2.12.1"
+        "twig/twig": "^2.12.1 || ^3.0"
     },
     "conflict": {
         "doctrine/dbal": "<2.6.0",

--- a/src/Twig/Extension/MediaExtension.php
+++ b/src/Twig/Extension/MediaExtension.php
@@ -21,12 +21,11 @@ use Sonata\MediaBundle\Twig\TokenParser\PathTokenParser;
 use Sonata\MediaBundle\Twig\TokenParser\ThumbnailTokenParser;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
-use Twig\Extension\InitRuntimeInterface;
 
 /**
  * @final since sonata-project/media-bundle 3.21.0
  */
-class MediaExtension extends AbstractExtension implements InitRuntimeInterface
+class MediaExtension extends AbstractExtension
 {
     /**
      * @var Pool
@@ -43,11 +42,6 @@ class MediaExtension extends AbstractExtension implements InitRuntimeInterface
      */
     protected $mediaManager;
 
-    /**
-     * @var Environment
-     */
-    protected $environment;
-
     public function __construct(Pool $mediaService, ManagerInterface $mediaManager)
     {
         $this->mediaService = $mediaService;
@@ -63,11 +57,6 @@ class MediaExtension extends AbstractExtension implements InitRuntimeInterface
         ];
     }
 
-    public function initRuntime(Environment $environment)
-    {
-        $this->environment = $environment;
-    }
-
     /**
      * @param MediaInterface $media
      * @param string         $format
@@ -75,7 +64,7 @@ class MediaExtension extends AbstractExtension implements InitRuntimeInterface
      *
      * @return string
      */
-    public function media($media, $format, $options = [])
+    public function media(Environment $environment, $media, $format, $options = [])
     {
         $media = $this->getMedia($media);
 
@@ -91,7 +80,7 @@ class MediaExtension extends AbstractExtension implements InitRuntimeInterface
 
         $options = $provider->getHelperProperties($media, $format, $options);
 
-        return $this->render($provider->getTemplate('helper_view'), [
+        return $this->render($environment, $provider->getTemplate('helper_view'), [
             'media' => $media,
             'format' => $format,
             'options' => $options,
@@ -107,7 +96,7 @@ class MediaExtension extends AbstractExtension implements InitRuntimeInterface
      *
      * @return string
      */
-    public function thumbnail($media, $format, $options = [])
+    public function thumbnail(Environment $environment, $media, $format, $options = [])
     {
         $media = $this->getMedia($media);
 
@@ -138,7 +127,7 @@ class MediaExtension extends AbstractExtension implements InitRuntimeInterface
 
         $options['src'] = $provider->generatePublicUrl($media, $format);
 
-        return $this->render($provider->getTemplate('helper_thumbnail'), [
+        return $this->render($environment, $provider->getTemplate('helper_thumbnail'), [
             'media' => $media,
             'options' => $options,
         ]);
@@ -149,10 +138,10 @@ class MediaExtension extends AbstractExtension implements InitRuntimeInterface
      *
      * @return mixed
      */
-    public function render($template, array $parameters = [])
+    public function render(Environment $environment, $template, array $parameters = [])
     {
         if (!isset($this->resources[$template])) {
-            $this->resources[$template] = $this->environment->loadTemplate($template);
+            $this->resources[$template] = $environment->load($template);
         }
 
         return $this->resources[$template]->render($parameters);

--- a/src/Twig/Node/MediaNode.php
+++ b/src/Twig/Node/MediaNode.php
@@ -43,7 +43,7 @@ class MediaNode extends Node
     {
         $compiler
             ->addDebugInfo($this)
-            ->write(sprintf("echo \$this->env->getExtension('%s')->media(", $this->extensionName))
+            ->write(sprintf("echo \$this->env->getExtension('%s')->media(\$this->env, ", $this->extensionName))
             ->subcompile($this->getNode('media'))
             ->raw(', ')
             ->subcompile($this->getNode('format'))

--- a/src/Twig/Node/PathNode.php
+++ b/src/Twig/Node/PathNode.php
@@ -43,7 +43,7 @@ class PathNode extends Node
     {
         $compiler
             ->addDebugInfo($this)
-            ->write(sprintf("echo \$this->env->getExtension('%s')->path(", $this->extensionName))
+            ->write(sprintf("echo \$this->env->getExtension('%s')->path(\$this->env, ", $this->extensionName))
             ->subcompile($this->getNode('media'))
             ->raw(', ')
             ->subcompile($this->getNode('format'))

--- a/src/Twig/Node/ThumbnailNode.php
+++ b/src/Twig/Node/ThumbnailNode.php
@@ -43,7 +43,7 @@ class ThumbnailNode extends Node
     {
         $compiler
             ->addDebugInfo($this)
-            ->write(sprintf("echo \$this->env->getExtension('%s')->thumbnail(", $this->extensionName))
+            ->write(sprintf("echo \$this->env->getExtension('%s')->thumbnail(\$this->env, ", $this->extensionName))
             ->subcompile($this->getNode('media'))
             ->raw(', ')
             ->subcompile($this->getNode('format'))

--- a/tests/Twig/Extension/MediaExtensionTest.php
+++ b/tests/Twig/Extension/MediaExtensionTest.php
@@ -20,6 +20,7 @@ use Sonata\MediaBundle\Provider\Pool;
 use Sonata\MediaBundle\Twig\Extension\MediaExtension;
 use Twig\Environment;
 use Twig\Template;
+use Twig\TemplateWrapper;
 
 /**
  * @author Geza Buza <bghome@gmail.com>
@@ -49,7 +50,6 @@ class MediaExtensionTest extends TestCase
     public function testThumbnailHasAllNecessaryAttributes(): void
     {
         $mediaExtension = new MediaExtension($this->getMediaService(), $this->getMediaManager());
-        $mediaExtension->initRuntime($this->getEnvironment());
 
         $media = $this->getMedia();
         $format = 'png';
@@ -76,9 +76,10 @@ class MediaExtensionTest extends TestCase
                         ],
                     ]
                 )
-            );
+            )
+            ->willReturn('');
 
-        $mediaExtension->thumbnail($media, $format, $options);
+        $mediaExtension->thumbnail($this->getEnvironment(), $media, $format, $options);
     }
 
     public function getMediaService(): Pool
@@ -118,7 +119,9 @@ class MediaExtensionTest extends TestCase
     {
         if (null === $this->environment) {
             $this->environment = $this->createMock(Environment::class);
-            $this->environment->method('loadTemplate')->willReturn($this->getTemplate());
+            $this->environment->method('load')->willReturnCallback(function () {
+                return new TemplateWrapper($this->getEnvironment(), $this->getTemplate());
+            });
         }
 
         return $this->environment;


### PR DESCRIPTION
## Subject

It seems Twig 3 support can be enabled without other changes.

I am targeting this branch, because using Twig 3 is backwards compatible.

## Changelog

```markdown
### Added
- Added support for Twig 3.
```

TODO:

* [ ] Update nelmio/api-doc-bundle to ^3.0 (perhaps wait until #1801 is merged).
* [ ] Check if changes in the Twig/Node directory work in practice.