### PR TITLE
Remove unicode escape in json example

### DIFF
--- a/docs/reference/creating_a_provider_class.rst
+++ b/docs/reference/creating_a_provider_class.rst
@@ -59,7 +59,7 @@ Take this video, for example:
      "version":"1.0",
      "provider_name":"Vimeo",
      "provider_url":"http:\/\/vimeo.com\/",
-     "title":"Blinky\u2122",
+     "title":"Blinky",
      "author_name":"Ruairi Robinson",
      "author_url":"http:\/\/vimeo.com\/ruairirobinson",
      "is_plus":"1",


### PR DESCRIPTION
## Subject

The docs build fails, it seems the same issue as reported here: https://github.com/sphinx-doc/sphinx/issues/8210

Let's just remove the unicode escape because it doesn't matter.

I am targeting this branch, because it's a docs change.
