### PR TITLE
Leverage `Collection::exists()` from `Gallery::getGalleryHasMedias()`

### DIFF
--- a/src/Controller/Api/GalleryController.php
+++ b/src/Controller/Api/GalleryController.php
@@ -274,13 +274,14 @@ class GalleryController
     {
         $gallery = $this->getGallery($galleryId);
         $media = $this->getMedia($mediaId);
+        $galleryHasMediaExists = $gallery->getGalleryHasMedias()->exists(static function ($key, GalleryHasMediaInterface $element) use ($media): bool {
+            return $element->getMedia()->getId() === $media->getId();
+        });
 
-        foreach ($gallery->getGalleryHasMedias() as $galleryHasMedia) {
-            if ($galleryHasMedia->getMedia()->getId() === $media->getId()) {
-                return FOSRestView::create([
-                    'error' => sprintf('Gallery "%s" already has media "%s"', $galleryId, $mediaId),
-                ], 400);
-            }
+        if ($galleryHasMediaExists) {
+            return FOSRestView::create([
+                'error' => sprintf('Gallery "%s" already has media "%s"', $galleryId, $mediaId),
+            ], 400);
         }
 
         return $this->handleWriteGalleryhasmedia($gallery, $media, null, $request);

--- a/tests/Controller/Api/GalleryControllerTest.php
+++ b/tests/Controller/Api/GalleryControllerTest.php
@@ -88,8 +88,9 @@ class GalleryControllerTest extends TestCase
         $galleryHasMedia = $this->createMock(GalleryHasMediaInterface::class);
         $gallery = $this->createMock(GalleryInterface::class);
         $formFactory = $this->createMock(FormFactoryInterface::class);
+        $galleryHasMedias = new ArrayCollection([$galleryHasMedia]);
 
-        $gallery->expects($this->once())->method('getGalleryHasMedias')->willReturn([$galleryHasMedia]);
+        $gallery->expects($this->once())->method('getGalleryHasMedias')->willReturn($galleryHasMedias);
 
         $gManager->expects($this->once())->method('findOneBy')->willReturn($gallery);
 
@@ -97,7 +98,7 @@ class GalleryControllerTest extends TestCase
 
         $gController = new GalleryController($gManager, $mediaManager, $formFactory, 'test');
 
-        $this->assertSame([$galleryHasMedia], $gController->getGalleryGalleryhasmediasAction(1));
+        $this->assertSame($galleryHasMedias, $gController->getGalleryGalleryhasmediasAction(1));
     }
 
     public function testGetGalleryMediaAction(): void
@@ -109,7 +110,7 @@ class GalleryControllerTest extends TestCase
         $galleryHasMedia->expects($this->once())->method('getMedia')->willReturn($media);
 
         $gallery = $this->createMock(GalleryInterface::class);
-        $gallery->expects($this->once())->method('getGalleryHasMedias')->willReturn([$galleryHasMedia]);
+        $gallery->expects($this->once())->method('getGalleryHasMedias')->willReturn(new ArrayCollection([$galleryHasMedia]));
 
         $gManager = $this->createMock(GalleryManagerInterface::class);
         $gManager->expects($this->once())->method('findOneBy')->willReturn($gallery);
@@ -135,7 +136,7 @@ class GalleryControllerTest extends TestCase
         $galleryHasMedia->expects($this->once())->method('getMedia')->willReturn($media2);
 
         $gallery = $this->createMock(GalleryInterface::class);
-        $gallery->expects($this->once())->method('getGalleryHasMedias')->willReturn([$galleryHasMedia]);
+        $gallery->expects($this->once())->method('getGalleryHasMedias')->willReturn(new ArrayCollection([$galleryHasMedia]));
 
         $galleryManager = $this->createMock(GalleryManagerInterface::class);
         $galleryManager->expects($this->once())->method('findOneBy')->willReturn($gallery);
@@ -167,7 +168,7 @@ class GalleryControllerTest extends TestCase
         $galleryHasMedia->expects($this->once())->method('getMedia')->willReturn($media);
 
         $gallery = $this->createMock(GalleryInterface::class);
-        $gallery->expects($this->once())->method('getGalleryHasMedias')->willReturn([$galleryHasMedia]);
+        $gallery->expects($this->once())->method('getGalleryHasMedias')->willReturn(new ArrayCollection([$galleryHasMedia]));
 
         $galleryManager = $this->createMock(GalleryManagerInterface::class);
         $galleryManager->expects($this->once())->method('findOneBy')->willReturn($gallery);
@@ -196,7 +197,7 @@ class GalleryControllerTest extends TestCase
         $galleryHasMedia->expects($this->once())->method('getMedia')->willReturn($media);
 
         $gallery = $this->createMock(GalleryInterface::class);
-        $gallery->expects($this->once())->method('getGalleryHasMedias')->willReturn([$galleryHasMedia]);
+        $gallery->expects($this->once())->method('getGalleryHasMedias')->willReturn(new ArrayCollection([$galleryHasMedia]));
 
         $galleryManager = $this->createMock(GalleryManagerInterface::class);
         $galleryManager->expects($this->once())->method('findOneBy')->willReturn($gallery);
@@ -228,7 +229,7 @@ class GalleryControllerTest extends TestCase
         $galleryHasMedia->expects($this->once())->method('getMedia')->willReturn($media);
 
         $gallery = $this->createMock(GalleryInterface::class);
-        $gallery->expects($this->once())->method('getGalleryHasMedias')->willReturn([$galleryHasMedia]);
+        $gallery->expects($this->once())->method('getGalleryHasMedias')->willReturn(new ArrayCollection([$galleryHasMedia]));
 
         $galleryManager = $this->createMock(GalleryManagerInterface::class);
         $galleryManager->expects($this->once())->method('findOneBy')->willReturn($gallery);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Leverage `Collection::exists()` from `Gallery::getGalleryHasMedias()`.

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change is pedantic and respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->