### PR TITLE
Fix support for "aws/aws-sdk-php:^3.0"

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,19 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.x to 3.x
+=======================
+
+### Configuration node "sonata_media.filesystem.s3.sdk_version"
+
+The configuration node "sonata_media.filesystem.s3.sdk_version" is deprecated. The
+version of aws/aws-sdk-php is automatically inferred from the installed package.
+
+### Configuration node "sonata_media.cdn.cloudfront"
+
+The configuration nodes "sonata_media.cdn.cloudfront.region" and "sonata_media.cdn.cloudfront.version"
+are required when aws/aws-sdk-php 3.x is installed.
+
 UPGRADE FROM 3.25 to 3.26
 =========================
 

--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
         "symfony/monolog-bundle": "<2.4"
     },
     "require-dev": {
-        "aws/aws-sdk-php": "^2.8",
+        "aws/aws-sdk-php": "^2.8 || ^3.0",
         "friendsofsymfony/rest-bundle": "^2.6 || ^3.0",
         "jackalope/jackalope-doctrine-dbal": "^1.1",
         "liip/imagine-bundle": "^1.9 || ^2.0",

--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -77,6 +77,8 @@ Full configuration options:
                 distribution_id:
                 key:
                 secret:
+                region:
+                version:
 
             fallback:
                 master:     sonata.media.cdn.panther
@@ -103,6 +105,7 @@ Full configuration options:
                 secretKey:
                 create:         false
                 region:         s3.amazonaws.com # change if not using US Standard region
+                version:        2006-03-01 # change according the API version you are using
                 storage:        standard # can be one of: standard or reduced
                 acl:            public # can be one of: public, private, open, auth_read, owner_read, owner_full_control
                 encryption:     aes256 # can be aes256 or not set

--- a/docs/reference/amazon_s3.rst
+++ b/docs/reference/amazon_s3.rst
@@ -1,7 +1,7 @@
 Amazon S3
 =========
 
-In order to use Amazon S3, you will need to require the following library:
+In order to use Amazon S3, you will need to require the following package:
 
 .. code-block:: bash
 
@@ -10,7 +10,7 @@ In order to use Amazon S3, you will need to require the following library:
 Configuration
 -------------
 
-This is a sample config file to enable amazon S3 as a filesystem & provider:
+This is a sample configuration to enable amazon S3 as a filesystem and provider:
 
 .. code-block:: yaml
 
@@ -27,15 +27,18 @@ This is a sample config file to enable amazon S3 as a filesystem & provider:
 
         filesystem:
             s3:
-                bucket:      '%s3_bucket_name%'
-                accessKey:   '%s3_access_key%'
-                secretKey:   '%s3_secret_key%'
-                region:      '%s3_region%'
-                version:     '%s3_version%' # latest by default (cf. https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_configuration.html#cfg-version)
-                endpoint:    '%s3_endpoint%' # null by default (cf. https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_configuration.html#endpoint)
-                sdk_version: '%s3_sdk_version%' # 2 by default
+                bucket: '%s3_bucket_name%'
+                accessKey: '%s3_access_key%'
+                secretKey: '%s3_secret_key%'
+                region: '%s3_region%'
+                version: '%s3_version%' # defaults to "latest" (cf. https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_configuration.html#cfg-version)
+                endpoint: '%s3_endpoint%' # defaults to null (cf. https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_configuration.html#endpoint)
 
 .. note::
 
-   This bundle is currently using KNP Gaufrette as S3 adapter and the default SDK used is version 2.
-   Changes have been made in the bundle to allow you to use version 3, update `sdk_version` parameter for this.
+    This bundle is currently using KNP Gaufrette as S3 adapter.
+
+.. note::
+
+    Using "latest" for "sonata_media.filesystem.s3.version" in a production environment is not recommended
+    because pulling in a new minor version of the SDK that includes an API update could break your production application.

--- a/src/CDN/CloudFront.php
+++ b/src/CDN/CloudFront.php
@@ -15,6 +15,7 @@ namespace Sonata\MediaBundle\CDN;
 
 use Aws\CloudFront\CloudFrontClient;
 use Aws\CloudFront\Exception\CloudFrontException;
+use Aws\Sdk;
 
 /**
  * From http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html.
@@ -77,17 +78,55 @@ class CloudFront implements CDNInterface
     protected $client;
 
     /**
+     * @var string
+     */
+    private $region;
+
+    /**
+     * @var string
+     */
+    private $version;
+
+    /**
+     * @todo: Make mandatory argument 5 and 6 when support for aws/aws-sdk-php < 3.0 is dropped.
+     *
      * @param string $path
      * @param string $key
      * @param string $secret
      * @param string $distributionId
      */
-    public function __construct($path, $key, $secret, $distributionId)
-    {
+    public function __construct(
+        $path,
+        $key,
+        $secret,
+        $distributionId,
+        ?string $region = null,
+        ?string $version = null
+    ) {
         $this->path = $path;
         $this->key = $key;
         $this->secret = $secret;
         $this->distributionId = $distributionId;
+
+        // @todo: Remove the following conditional block when support for aws/aws-sdk-php < 3.0 is dropped.
+        if (class_exists(Sdk::class)) {
+            if (null === $region) {
+                throw new \TypeError(sprintf(
+                    'Argument 5 for "%s()" is required and can not be null when aws/aws-sdk-php >= 3.0 is installed.',
+                    __METHOD__
+                ));
+            }
+
+            if (null === $version) {
+                throw new \TypeError(sprintf(
+                    'Argument 6 for "%s()" is required and can not be null when aws/aws-sdk-php >= 3.0 is installed.',
+                    __METHOD__
+                ));
+            }
+        }
+
+        $this->region = $region;
+        $this->version = $region;
     }
 
     public function getPath($relativePath, $isFlushable = false)
@@ -121,15 +160,29 @@ class CloudFront implements CDNInterface
             return '/'.ltrim($path, '/');
         }, $paths);
 
+        $invalidationBatch = [
+            'Paths' => [
+                'Quantity' => \count($normalizedPaths),
+                'Items' => $normalizedPaths,
+            ],
+            'CallerReference' => $this->getCallerReference($normalizedPaths),
+        ];
+
+        $arguments = [
+            'DistributionId' => $this->distributionId,
+        ];
+
+        // @todo: Remove the following check and the `else` block when support for aws/aws-sdk-php < 3.0 is dropped.
+        if (class_exists(Sdk::class)) {
+            // AWS v3.x.
+            $arguments += ['InvalidationBatch' => $invalidationBatch];
+        } else {
+            // AWS v2.x.
+            $arguments += $invalidationBatch;
+        }
+
         try {
-            $result = $this->getClient()->createInvalidation([
-                'DistributionId' => $this->distributionId,
-                'Paths' => [
-                    'Quantity' => \count($normalizedPaths),
-                    'Items' => $normalizedPaths,
-                ],
-                'CallerReference' => $this->getCallerReference($normalizedPaths),
-            ]);
+            $result = $this->getClient()->createInvalidation($arguments);
 
             if (!\in_array($status = $result->get('Status'), ['Completed', 'InProgress'], true)) {
                 throw new \RuntimeException('Unable to flush : '.$status);
@@ -198,13 +251,33 @@ class CloudFront implements CDNInterface
         return md5(implode(',', $paths));
     }
 
+    /**
+     * @todo: Inject client through DI.
+     */
     private function getClient(): CloudFrontClient
     {
         if (!$this->client) {
-            $this->client = CloudFrontClient::factory([
-                'key' => $this->key,
-                'secret' => $this->secret,
-            ]);
+            if (null !== $this->region) {
+                $config['region'] = $this->region;
+            }
+
+            if (null !== $this->version) {
+                $config['version'] = $this->version;
+            }
+
+            $credentials = [
+                'key' => $this->region,
+                'secret' => $this->version,
+            ];
+
+            // @todo: Remove the following check and the `else` block when support for aws/aws-sdk-php < 3.0 is dropped.
+            if (class_exists(Sdk::class)) {
+                // AWS v3.x.
+                $this->client = new CloudFrontClient($config + ['credentials' => $credentials]);
+            } else {
+                // AWS v2.x.
+                $this->client = CloudFrontClient::factory($config + $credentials);
+            }
         }
 
         return $this->client;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\DependencyInjection;
 
+use Aws\Sdk;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -154,17 +156,7 @@ class Configuration implements ConfigurationInterface
                             ->end()
                         ->end()
 
-                        ->arrayNode('cloudfront')
-                            ->children()
-                                ->scalarNode('path')
-                                    ->info('e.g. http://xxxxxxxxxxxxxx.cloudfront.net/uploads/media')
-                                    ->isRequired()
-                                ->end()
-                                ->scalarNode('distribution_id')->isRequired()->end()
-                                ->scalarNode('key')->isRequired()->end()
-                                ->scalarNode('secret')->isRequired()->end()
-                            ->end()
-                        ->end()
+                        ->append($this->getCloudFrontCdnSection())
 
                         ->arrayNode('fallback')
                             ->children()
@@ -176,6 +168,49 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end()
         ;
+    }
+
+    /**
+     * @todo: Remove this method when support for aws/aws-sdk-php < 3.0 is dropped
+     * and move the corresponding logic to `addCdnSection()`.
+     */
+    private function getCloudFrontCdnSection(): NodeDefinition
+    {
+        $treeBuilder = new TreeBuilder('cloudfront');
+
+        if (class_exists(Sdk::class)) {
+            // aws/aws-sdk-php >= 3.0
+            $node = $treeBuilder->getRootNode()
+                ->children()
+                    ->scalarNode('path')
+                        ->info('e.g. http://xxxxxxxxxxxxxx.cloudfront.net/uploads/media')
+                        ->isRequired()
+                    ->end()
+                    ->scalarNode('distribution_id')->isRequired()->end()
+                    ->scalarNode('key')->isRequired()->end()
+                    ->scalarNode('secret')->isRequired()->end()
+                    ->scalarNode('region')->isRequired()->end()
+                    ->scalarNode('version')->isRequired()->end()
+                ->end()
+            ;
+        } else {
+            // aws/aws-sdk-php < 3.0
+            $node = $treeBuilder->getRootNode()
+                ->children()
+                    ->scalarNode('path')
+                        ->info('e.g. http://xxxxxxxxxxxxxx.cloudfront.net/uploads/media')
+                        ->isRequired()
+                    ->end()
+                    ->scalarNode('distribution_id')->isRequired()->end()
+                    ->scalarNode('key')->isRequired()->end()
+                    ->scalarNode('secret')->isRequired()->end()
+                    ->scalarNode('region')->end()
+                    ->scalarNode('version')->end()
+                ->end()
+            ;
+        }
+
+        return $node;
     }
 
     private function addFilesystemSection(ArrayNodeDefinition $node): void
@@ -236,10 +271,39 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                                 ->scalarNode('region')->defaultValue('s3.amazonaws.com')->end()
                                 ->scalarNode('endpoint')->defaultNull()->end()
-                                ->scalarNode('version')->defaultValue('latest')->end()
+                                ->scalarNode('version')
+                                    ->info(
+                                        'Using "latest" in a production application is not recommended because pulling in a new minor version of the SDK'
+                                        .' that includes an API update could break your production application.'
+                                        .' See https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_configuration.html#cfg-version.'
+                                    )
+                                    ->defaultValue('latest')
+                                ->end()
                                 ->enumNode('sdk_version')
+                                    ->setDeprecated(...$this->getBackwardCompatibleArgumentsForSetDeprecated(
+                                        'The node "%node%" is deprecated and will be removed in version 4.0'
+                                        .' since the version for aws/aws-sdk-php is inferred automatically.',
+                                        '3.x'
+                                    ))
+                                    ->beforeNormalization()
+                                        ->ifString()
+                                        ->then(static function (string $v): int {
+                                            return (int) $v;
+                                        })
+                                    ->end()
+                                    ->validate()
+                                        ->ifTrue(static function (int $v): bool {
+                                            return 2 === $v && class_exists(Sdk::class);
+                                        })
+                                        ->thenInvalid('Can not use %s for "sdk_version" since the installed version of aws/aws-sdk-php is not 2.x.')
+                                    ->end()
+                                    ->validate()
+                                        ->ifTrue(static function (int $v): bool {
+                                            return 3 === $v && !class_exists(Sdk::class);
+                                        })
+                                        ->thenInvalid('Can not use %s for "sdk_version" since the installed version of aws/aws-sdk-php is not 3.x.')
+                                    ->end()
                                     ->values([2, 3])
-                                    ->defaultValue(2)
                                 ->end()
                                 ->arrayNode('meta')
                                     ->useAttributeAsKey('name')
@@ -508,5 +572,26 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end()
         ;
+    }
+
+    /**
+     * Returns the correct deprecation arguments as an array for `setDeprecated()`.
+     *
+     * symfony/config 5.1 introduces a deprecation notice when calling
+     * `setDeprecation()` with less than 3 arguments and the `getDeprecation()` method was
+     * introduced at the same time. By checking if `getDeprecation()` exists,
+     * we can determine the correct parameter count to use when calling `setDeprecated()`.
+     */
+    private function getBackwardCompatibleArgumentsForSetDeprecated(string $message, string $version): array
+    {
+        if (method_exists(BaseNode::class, 'getDeprecation')) {
+            return [
+                'sonata-project/media-bundle',
+                $version,
+                $message,
+            ];
+        }
+
+        return [$message];
     }
 }

--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\DependencyInjection;
 
+use Aws\S3\S3Client;
+use Aws\Sdk;
 use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\Doctrine\Mapper\Builder\OptionsBuilder;
 use Sonata\Doctrine\Mapper\DoctrineCollector;
@@ -339,6 +341,18 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
                 ->replaceArgument(2, $config['cdn']['cloudfront']['secret'])
                 ->replaceArgument(3, $config['cdn']['cloudfront']['distribution_id'])
             ;
+
+            if (isset($config['cdn']['cloudfront']['region'])) {
+                // @todo: Perform this replacenent unconditionally when support for aws/aws-sdk-php < 3.0 is dropped.
+                $container->getDefinition('sonata.media.cdn.cloudfront')
+                    ->replaceArgument(4, $config['cdn']['cloudfront']['region']);
+            }
+
+            if (isset($config['cdn']['cloudfront']['version'])) {
+                // @todo: Perform this replacenent unconditionally when support for aws/aws-sdk-php < 3.0 is dropped.
+                $container->getDefinition('sonata.media.cdn.cloudfront')
+                    ->replaceArgument(5, $config['cdn']['cloudfront']['version']);
+            }
         } else {
             $container->removeDefinition('sonata.media.cdn.cloudfront');
         }
@@ -389,6 +403,23 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
 
         // add the default configuration for the S3 filesystem
         if ($container->hasDefinition('sonata.media.adapter.filesystem.s3') && isset($config['filesystem']['s3'])) {
+            // @todo: Remove the following conditional block when support for aws/aws-sdk-php < 3.0 is dropped.
+            if (isset($config['filesystem']['s3']['sdk_version'])) {
+                if (3 === $config['filesystem']['s3']['sdk_version'] && !class_exists(Sdk::class)) {
+                    throw new \UnexpectedValueException(
+                        'The configuration "sonata_media.filesystem.s3.sdk_version" can not contain the value 3 since'.
+                        ' the installed version of aws/aws-sdk-php is not 3.x.'
+                    );
+                }
+
+                if (2 === $config['filesystem']['s3']['sdk_version'] && class_exists(Sdk::class)) {
+                    throw new \UnexpectedValueException(
+                        'The configuration "sonata_media.filesystem.s3.sdk_version" can not contain the value 2 since'.
+                        ' the installed version of aws/aws-sdk-php is not 2.x.'
+                    );
+                }
+            }
+
             $container->getDefinition('sonata.media.adapter.filesystem.s3')
                 ->replaceArgument(0, new Reference('sonata.media.adapter.service.s3'))
                 ->replaceArgument(1, $config['filesystem']['s3']['bucket'])
@@ -405,7 +436,8 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
                 ])
             ;
 
-            if (3 === $config['filesystem']['s3']['sdk_version']) {
+            // @todo: Remove the following check and the `else` block when support for aws/aws-sdk-php < 3.0 is dropped.
+            if (class_exists(Sdk::class)) {
                 $arguments = [
                     'region' => $config['filesystem']['s3']['region'],
                     'version' => $config['filesystem']['s3']['version'],
@@ -421,18 +453,30 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
                         'key' => $config['filesystem']['s3']['accessKey'],
                     ];
                 }
+            } else {
+                $arguments = [];
+
+                if (isset($config['filesystem']['s3']['region'])) {
+                    $arguments['region'] = $config['filesystem']['s3']['region'];
+                }
+
+                if (isset($config['filesystem']['s3']['version'])) {
+                    $arguments['version'] = $config['filesystem']['s3']['version'];
+                }
+
+                if (isset($config['filesystem']['s3']['endpoint'])) {
+                    $arguments['endpoint'] = $config['filesystem']['s3']['endpoint'];
+                }
+
+                $arguments['secret'] = $config['filesystem']['s3']['secretKey'];
+                $arguments['key'] = $config['filesystem']['s3']['accessKey'];
 
                 $container->getDefinition('sonata.media.adapter.service.s3')
-                    ->replaceArgument(0, $arguments)
-                ;
-            } else {
-                $container->getDefinition('sonata.media.adapter.service.s3')
-                    ->replaceArgument(0, [
-                        'secret' => $config['filesystem']['s3']['secretKey'],
-                        'key' => $config['filesystem']['s3']['accessKey'],
-                    ])
-                ;
+                    ->setFactory([S3Client::class, 'factory']);
             }
+
+            $container->getDefinition('sonata.media.adapter.service.s3')
+                ->replaceArgument(0, $arguments);
         } else {
             $container->removeDefinition('sonata.media.adapter.filesystem.s3');
             $container->removeDefinition('sonata.media.filesystem.s3');

--- a/src/Resources/config/gaufrette.xml
+++ b/src/Resources/config/gaufrette.xml
@@ -10,7 +10,6 @@
         <service id="sonata.media.adapter.filesystem.local" class="Sonata\MediaBundle\Filesystem\Local"/>
         <service id="sonata.media.adapter.filesystem.ftp" class="Gaufrette\Adapter\Ftp"/>
         <service id="sonata.media.adapter.service.s3" class="Aws\S3\S3Client">
-            <factory class="Aws\S3\S3Client" method="factory"/>
             <argument type="collection"/>
         </service>
         <service id="sonata.media.adapter.filesystem.s3" class="Gaufrette\Adapter\AwsS3">

--- a/src/Resources/config/media.xml
+++ b/src/Resources/config/media.xml
@@ -23,6 +23,8 @@
             <argument/>
             <argument/>
             <argument/>
+            <argument/>
+            <argument/>
         </service>
         <service id="sonata.media.cdn.fallback" class="Sonata\MediaBundle\CDN\Fallback">
             <argument/>

--- a/tests/App/config.yml
+++ b/tests/App/config.yml
@@ -36,11 +36,26 @@ sonata_media:
     cdn:
         server:
             path: /uploads/media
+        cloudfront:
+            distribution_id: abc
+            path: /awscdn/media
+            key: xxxxxx
+            secret: 53cr37
+            region: us-east-1
+            version: 2020-05-31
 
     filesystem:
         local:
             directory: "%kernel.root_dir%/../public/uploads/media"
             create: false
+
+        s3:
+            bucket: my-bucket
+            accessKey: xxxxxx
+            secretKey: xxxxxx
+            region: s3.amazonaws.com
+            version: 2006-03-01
+            endpoint: null
 
 fos_rest:
     param_fetcher_listener: true

--- a/tests/CDN/CloudFrontTest.php
+++ b/tests/CDN/CloudFrontTest.php
@@ -14,13 +14,14 @@ declare(strict_types=1);
 namespace Sonata\MediaBundle\Tests\CDN;
 
 use Aws\CloudFront\CloudFrontClient;
+use Aws\Sdk;
 use PHPUnit\Framework\TestCase;
 use Sonata\MediaBundle\CDN\CloudFront;
 
 /**
  * @author Javier Spagnoletti <phansys@gmail.com>
  */
-class CloudFrontTest extends TestCase
+final class CloudFrontTest extends TestCase
 {
     /**
      * @group legacy
@@ -32,7 +33,7 @@ class CloudFrontTest extends TestCase
         $client->expects($this->exactly(3))->method('createInvalidation')->willReturn(new CloudFrontResultSpy());
 
         $cloudFront = $this->getMockBuilder(CloudFront::class)
-            ->setConstructorArgs(['/foo', 'secret', 'key', 'xxxxxxxxxxxxxx'])
+            ->setConstructorArgs(['/foo', 'secret', 'key', 'xxxxxxxxxxxxxx', 'us-west-1', '2020-05-31'])
             ->onlyMethods([])
             ->getMock();
         $cloudFront->setClient($client);
@@ -51,16 +52,84 @@ class CloudFrontTest extends TestCase
      */
     public function testLegacyException(): void
     {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Unable to flush : ');
         $client = $this->createMock(CloudFrontClientSpy::class);
         $client->expects($this->once())->method('createInvalidation')->willReturn(new CloudFrontResultSpy(true));
+        $cloudFront = $this->getMockBuilder(CloudFront::class)
+            ->setConstructorArgs(['/foo', 'secret', 'key', 'xxxxxxxxxxxxxx', 'us-west-1', '2020-05-31'])
+            ->onlyMethods([])
+            ->getMock();
+        $cloudFront->setClient($client);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unable to flush : ');
+
+        $cloudFront->flushPaths(['boom']);
+    }
+
+    /**
+     * @todo: Remove this method when support for aws/aws-sdk-php < 3.0 is dropped.
+     *
+     * @dataProvider cloudFrontWithMissingArgumentsProvider
+     *
+     * @group legacy
+     */
+    public function testCloudFrontWithMissingArguments(string $expectedExceptionMessage, string $path, string $secret, string $key, string $distributionId, ?string $region = null, ?string $version = null): void
+    {
+        if (!class_exists(Sdk::class)) {
+            $this->markTestSkipped('This test requires aws/aws-sdk-php 3.x.');
+        }
+
+        $client = $this->createMock(CloudFrontClientSpy::class);
+
+        $client->expects($this->never())->method('createInvalidation')->willReturn(new CloudFrontResultSpy());
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
+        new CloudFront($path, $secret, $key, $distributionId, $region, $version);
+    }
+
+    public function cloudFrontWithMissingArgumentsProvider(): iterable
+    {
+        yield 'missing_argument_5' => [
+            'Argument 5 for "Sonata\MediaBundle\CDN\CloudFront::__construct()" is required and can not be null when aws/aws-sdk-php >= 3.0 is installed.',
+            '/foo', 'secret', 'key', 'xxxxxxxxxxxxxx',
+        ];
+
+        yield 'missing_argument_6' => [
+            'Argument 6 for "Sonata\MediaBundle\CDN\CloudFront::__construct()" is required and can not be null when aws/aws-sdk-php >= 3.0 is installed.',
+            '/foo', 'secret', 'key', 'xxxxxxxxxxxxxx', 'eu-west-3',
+        ];
+    }
+
+    /**
+     * @todo: Remove this method when support for aws/aws-sdk-php < 3.0 is dropped.
+     *
+     * @group legacy
+     */
+    public function testCloudFrontWithSdkV2(): void
+    {
+        if (class_exists(Sdk::class)) {
+            $this->markTestSkipped('This test requires aws/aws-sdk-php 2.x.');
+        }
+
+        $client = $this->createMock(CloudFrontClientSpy::class);
+
+        $client->expects($this->exactly(3))->method('createInvalidation')->willReturn(new CloudFrontResultSpy());
+
         $cloudFront = $this->getMockBuilder(CloudFront::class)
             ->setConstructorArgs(['/foo', 'secret', 'key', 'xxxxxxxxxxxxxx'])
             ->onlyMethods([])
             ->getMock();
         $cloudFront->setClient($client);
-        $cloudFront->flushPaths(['boom']);
+
+        $this->assertSame('/foo/bar.jpg', $cloudFront->getPath('bar.jpg', true));
+
+        $path = '/mypath/file.jpg';
+
+        $cloudFront->flushByString($path);
+        $cloudFront->flush($path);
+        $cloudFront->flushPaths([$path]);
     }
 }
 

--- a/tests/DependencyInjection/SonataMediaExtensionTest.php
+++ b/tests/DependencyInjection/SonataMediaExtensionTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Tests\DependencyInjection;
 
+use Aws\Sdk;
 use Imagine\Gd\Imagine as GdImagine;
 use Imagine\Gmagick\Imagine as GmagicImagine;
 use Imagine\Imagick\Imagine as ImagicImagine;
@@ -201,60 +202,278 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
     }
 
     /**
-     * @dataProvider dataFilesystemConfiguration
+     * @dataProvider dataFilesystemConfigurationAwsV3
      */
-    public function testLoadWithFilesystemConfiguration(array $configs, array $args): void
+    public function testLoadWithFilesystemConfigurationV3(array $expected, array $configs): void
     {
+        if (!class_exists(Sdk::class)) {
+            $this->markTestSkipped('This test requires aws/aws-sdk-php 3.x.');
+        }
+
         $this->load($configs);
 
         $this->assertSame(
-            $this->container->getDefinition('sonata.media.adapter.service.s3')->getArgument(0),
-            $args
+            $expected,
+            $this->container->getDefinition('sonata.media.adapter.service.s3')->getArgument(0)
         );
     }
 
-    public function dataFilesystemConfiguration(): array
+    public function dataFilesystemConfigurationAwsV3(): iterable
     {
-        return [
+        yield [
             [
-                [
-                    'filesystem' => [
-                        's3' => [
-                            'bucket' => 'bucket_name',
-                            'sdk_version' => 3,
-                            'region' => 'region',
-                            'version' => 'version',
-                            'secretKey' => null,
-                            'accessKey' => null,
-                        ],
-                    ],
-                ],
-                [
-                    'region' => 'region',
-                    'version' => 'version',
+                'region' => 'region',
+                'version' => 'version',
+                'credentials' => [
+                    'secret' => 'secret',
+                    'key' => 'access',
                 ],
             ],
             [
-                [
-                    'filesystem' => [
-                        's3' => [
-                            'bucket' => 'bucket_name',
-                            'sdk_version' => 3,
-                            'region' => 'region',
-                            'version' => 'version',
-                            'endpoint' => 'endpoint',
-                            'secretKey' => 'secret',
-                            'accessKey' => 'access',
-                        ],
+                'filesystem' => [
+                    's3' => [
+                        'bucket' => 'bucket_name',
+                        'region' => 'region',
+                        'version' => 'version',
+                        'secretKey' => 'secret',
+                        'accessKey' => 'access',
                     ],
                 ],
-                [
-                    'region' => 'region',
-                    'version' => 'version',
-                    'endpoint' => 'endpoint',
-                    'credentials' => [
-                        'secret' => 'secret',
-                        'key' => 'access',
+            ],
+        ];
+
+        yield [
+            [
+                'region' => 'region',
+                'version' => 'version',
+                'endpoint' => 'endpoint',
+                'credentials' => [
+                    'secret' => 'secret',
+                    'key' => 'access',
+                ],
+            ],
+            [
+                'filesystem' => [
+                    's3' => [
+                        'bucket' => 'bucket_name',
+                        // NEXT_MAJOR: Remove the "sdk_version" node.
+                        'sdk_version' => 3,
+                        'region' => 'region',
+                        'version' => 'version',
+                        'endpoint' => 'endpoint',
+                        'secretKey' => 'secret',
+                        'accessKey' => 'access',
+                    ],
+                ],
+            ],
+        ];
+
+        yield [
+            [
+                'region' => 's3.amazonaws.com',
+                'version' => 'latest',
+                'credentials' => [
+                    'secret' => 'secret',
+                    'key' => 'access',
+                ],
+            ],
+            [
+                'filesystem' => [
+                    's3' => [
+                        'bucket' => 'bucket_name',
+                        'secretKey' => 'secret',
+                        'accessKey' => 'access',
+                    ],
+                ],
+            ],
+        ];
+
+        yield [
+            [
+                'region' => 's3.amazonaws.com',
+                'version' => null,
+                'credentials' => [
+                    'secret' => 'secret',
+                    'key' => 'access',
+                ],
+            ],
+            [
+                'filesystem' => [
+                    's3' => [
+                        'bucket' => 'bucket_name',
+                        'version' => null,
+                        'secretKey' => 'secret',
+                        'accessKey' => 'access',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @todo: Remove this test when support for aws/aws-sdk-php < 3.0 is dropped.
+     *
+     * @dataProvider dataFilesystemConfigurationAwsV2
+     */
+    public function testLoadWithFilesystemConfigurationV2(array $expected, array $configs): void
+    {
+        if (class_exists(Sdk::class)) {
+            $this->markTestSkipped('This test requires aws/aws-sdk-php 2.x.');
+        }
+
+        $this->load($configs);
+
+        $this->assertSame(
+            $expected,
+            $this->container->getDefinition('sonata.media.adapter.service.s3')->getArgument(0)
+        );
+    }
+
+    public function dataFilesystemConfigurationAwsV2(): iterable
+    {
+        yield [
+            [
+                'region' => 'region',
+                'version' => 'version',
+                'secret' => 'secret',
+                'key' => 'access',
+            ],
+            [
+                'filesystem' => [
+                    's3' => [
+                        'bucket' => 'bucket_name',
+                        'region' => 'region',
+                        'version' => 'version',
+                        'secretKey' => 'secret',
+                        'accessKey' => 'access',
+                    ],
+                ],
+            ],
+        ];
+
+        // NEXT_MAJOR: Remove the following dataset.
+        yield [
+            [
+                'region' => 'region',
+                'version' => 'version',
+                'secret' => 'secret',
+                'key' => 'access',
+            ],
+            [
+                'filesystem' => [
+                    's3' => [
+                        'bucket' => 'bucket_name',
+                        'sdk_version' => 2,
+                        'region' => 'region',
+                        'version' => 'version',
+                        'secretKey' => 'secret',
+                        'accessKey' => 'access',
+                    ],
+                ],
+            ],
+        ];
+
+        yield [
+            [
+                'region' => 'region',
+                'version' => 'version',
+                'endpoint' => 'endpoint',
+                'secret' => 'secret',
+                'key' => 'access',
+            ],
+            [
+                'filesystem' => [
+                    's3' => [
+                        'bucket' => 'bucket_name',
+                        'sdk_version' => 2,
+                        'region' => 'region',
+                        'version' => 'version',
+                        'endpoint' => 'endpoint',
+                        'secretKey' => 'secret',
+                        'accessKey' => 'access',
+                    ],
+                ],
+            ],
+        ];
+
+        yield [
+            [
+                'endpoint' => 'endpoint',
+                'secret' => 'secret',
+                'key' => 'access',
+            ],
+            [
+                'filesystem' => [
+                    's3' => [
+                        'bucket' => 'bucket_name',
+                        'sdk_version' => 2,
+                        'region' => null,
+                        'version' => null,
+                        'endpoint' => 'endpoint',
+                        'secretKey' => 'secret',
+                        'accessKey' => 'access',
+                    ],
+                ],
+            ],
+        ];
+
+        yield [
+            [
+                'region' => 's3.amazonaws.com',
+                'endpoint' => 'endpoint',
+                'secret' => 'secret',
+                'key' => 'access',
+            ],
+            [
+                'filesystem' => [
+                    's3' => [
+                        'bucket' => 'bucket_name',
+                        'sdk_version' => 2,
+                        'version' => null,
+                        'endpoint' => 'endpoint',
+                        'secretKey' => 'secret',
+                        'accessKey' => 'access',
+                    ],
+                ],
+            ],
+        ];
+
+        yield [
+            [
+                'region' => 's3.amazonaws.com',
+                'version' => 'latest',
+                'endpoint' => 'endpoint',
+                'secret' => 'secret',
+                'key' => 'access',
+            ],
+            [
+                'filesystem' => [
+                    's3' => [
+                        'bucket' => 'bucket_name',
+                        'sdk_version' => 2,
+                        'endpoint' => 'endpoint',
+                        'secretKey' => 'secret',
+                        'accessKey' => 'access',
+                    ],
+                ],
+            ],
+        ];
+
+        yield [
+            [
+                'region' => 's3.amazonaws.com',
+                'version' => 'latest',
+                'endpoint' => 'endpoint',
+                'secret' => 'secret',
+                'key' => 'access',
+            ],
+            [
+                'filesystem' => [
+                    's3' => [
+                        'bucket' => 'bucket_name',
+                        'endpoint' => 'endpoint',
+                        'secretKey' => 'secret',
+                        'accessKey' => 'access',
                     ],
                 ],
             ],

--- a/tests/Metadata/AmazonMetadataBuilderTest.php
+++ b/tests/Metadata/AmazonMetadataBuilderTest.php
@@ -18,35 +18,39 @@ use PHPUnit\Framework\TestCase;
 use Sonata\MediaBundle\Metadata\AmazonMetadataBuilder;
 use Sonata\MediaBundle\Model\MediaInterface;
 
-class AmazonMetadataBuilderTest extends TestCase
+final class AmazonMetadataBuilderTest extends TestCase
 {
-    public function testAmazon(): void
+    /**
+     * @dataProvider provider
+     */
+    public function testAmazon(array $settings, array $expected): void
     {
-        $media = $this->createMock(MediaInterface::class);
+        $media = $this->createStub(MediaInterface::class);
         $filename = '/test/folder/testfile.png';
 
-        foreach ($this->provider() as $provider) {
-            [$a, $b] = $provider;
-            $amazonmetadatabuilder = new AmazonMetadataBuilder($a);
-            $this->assertSame($b, $amazonmetadatabuilder->get($media, $filename));
-        }
+        $amazonmetadatabuilder = new AmazonMetadataBuilder($settings);
+        $this->assertSame($expected, $amazonmetadatabuilder->get($media, $filename));
     }
 
-    public function provider(): array
+    public function provider(): iterable
     {
-        return [
-            [['acl' => 'private'], ['ACL' => AmazonMetadataBuilder::PRIVATE_ACCESS, 'contentType' => 'image/png']],
-            [['acl' => 'public'], ['ACL' => AmazonMetadataBuilder::PUBLIC_READ, 'contentType' => 'image/png']],
-            [['acl' => 'open'], ['ACL' => AmazonMetadataBuilder::PUBLIC_READ_WRITE, 'contentType' => 'image/png']],
-            [['acl' => 'auth_read'], ['ACL' => AmazonMetadataBuilder::AUTHENTICATED_READ, 'contentType' => 'image/png']],
-            [['acl' => 'owner_read'], ['ACL' => AmazonMetadataBuilder::BUCKET_OWNER_READ, 'contentType' => 'image/png']],
-            [['acl' => 'owner_full_control'], ['ACL' => AmazonMetadataBuilder::BUCKET_OWNER_FULL_CONTROL, 'contentType' => 'image/png']],
-            [['storage' => 'standard'], ['storage' => AmazonMetadataBuilder::STORAGE_STANDARD, 'contentType' => 'image/png']],
-            [['storage' => 'reduced'], ['storage' => AmazonMetadataBuilder::STORAGE_REDUCED, 'contentType' => 'image/png']],
-            [['cache_control' => 'max-age=86400'], ['CacheControl' => 'max-age=86400', 'contentType' => 'image/png']],
-            [['encryption' => 'aes256'], ['encryption' => 'AES256', 'contentType' => 'image/png']],
-            [['meta' => ['key' => 'value']], ['meta' => ['key' => 'value'], 'contentType' => 'image/png']],
-            [['acl' => 'public', 'storage' => 'standard', 'cache_control' => 'max-age=86400', 'encryption' => 'aes256', 'meta' => ['key' => 'value']], ['ACL' => AmazonMetadataBuilder::PUBLIC_READ, 'storage' => Storage::STANDARD, 'meta' => ['key' => 'value'], 'CacheControl' => 'max-age=86400', 'encryption' => 'AES256', 'contentType' => 'image/png']],
+        yield [['acl' => 'private'], ['ACL' => AmazonMetadataBuilder::PRIVATE_ACCESS, 'contentType' => 'image/png']];
+        yield [['acl' => 'public'], ['ACL' => AmazonMetadataBuilder::PUBLIC_READ, 'contentType' => 'image/png']];
+        yield [['acl' => 'open'], ['ACL' => AmazonMetadataBuilder::PUBLIC_READ_WRITE, 'contentType' => 'image/png']];
+        yield [['acl' => 'auth_read'], ['ACL' => AmazonMetadataBuilder::AUTHENTICATED_READ, 'contentType' => 'image/png']];
+        yield [['acl' => 'owner_read'], ['ACL' => AmazonMetadataBuilder::BUCKET_OWNER_READ, 'contentType' => 'image/png']];
+        yield [['acl' => 'owner_full_control'], ['ACL' => AmazonMetadataBuilder::BUCKET_OWNER_FULL_CONTROL, 'contentType' => 'image/png']];
+        yield [['storage' => 'standard'], ['storage' => AmazonMetadataBuilder::STORAGE_STANDARD, 'contentType' => 'image/png']];
+        yield [['storage' => 'reduced'], ['storage' => AmazonMetadataBuilder::STORAGE_REDUCED, 'contentType' => 'image/png']];
+        yield [['cache_control' => 'max-age=86400'], ['CacheControl' => 'max-age=86400', 'contentType' => 'image/png']];
+        yield [['encryption' => 'aes256'], ['encryption' => 'AES256', 'contentType' => 'image/png']];
+        yield [['meta' => ['key' => 'value']], ['meta' => ['key' => 'value'], 'contentType' => 'image/png']];
+        yield [
+            ['acl' => 'public', 'storage' => 'standard', 'cache_control' => 'max-age=86400', 'encryption' => 'aes256', 'meta' => ['key' => 'value']],
+            [
+                'ACL' => AmazonMetadataBuilder::PUBLIC_READ, 'storage' => class_exists(Storage::class) ? Storage::STANDARD : AmazonMetadataBuilder::STORAGE_STANDARD,
+                'meta' => ['key' => 'value'], 'CacheControl' => 'max-age=86400', 'encryption' => 'AES256', 'contentType' => 'image/png',
+            ],
         ];
     }
 }

--- a/tests/Metadata/ProxyMetadataBuilderTest.php
+++ b/tests/Metadata/ProxyMetadataBuilderTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\MediaBundle\Tests\Metadata;
 
 use Aws\S3\S3Client;
+use Aws\Sdk;
 use Gaufrette\Adapter\AwsS3;
 use Gaufrette\Filesystem;
 use PHPUnit\Framework\TestCase;
@@ -25,8 +26,9 @@ use Sonata\MediaBundle\Metadata\ProxyMetadataBuilder;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class ProxyMetadataBuilderTest extends TestCase
+final class ProxyMetadataBuilderTest extends TestCase
 {
     public function testProxyAmazon(): void
     {
@@ -40,23 +42,37 @@ class ProxyMetadataBuilderTest extends TestCase
             ->method('get')
             ->willReturn(['key' => 'noop']);
 
-        //adapter cannot be mocked
-        $amazonclient = S3Client::factory([
-            'credentials' => [
-                'key' => 'XXXXXXXXXXXX',
-                'secret' => 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-            ],
-            'region' => 'us-west-1',
-        ]);
+        if (class_exists(Sdk::class)) {
+            // AWS v3.x
+            $amazonclient = new S3Client([
+                'credentials' => [
+                    'key' => 'XXXXXXXXXXXX',
+                    'secret' => 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+                ],
+                'region' => 'us-west-1',
+                'version' => '2006-03-01',
+            ]);
+        } else {
+            // AWS v2.x. Remove this condition when the support for this version is dropped.
+            $amazonclient = S3Client::factory([
+                'credentials' => [
+                    'key' => 'XXXXXXXXXXXX',
+                    'secret' => 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+                ],
+                'region' => 'us-west-1',
+            ]);
+        }
+
+        // adapter cannot be mocked
         $adapter = new AwsS3($amazonclient, '');
 
-        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem = $this->createStub(Filesystem::class);
         $filesystem->method('getAdapter')->willReturn($adapter);
 
-        $provider = $this->createMock(MediaProviderInterface::class);
+        $provider = $this->createStub(MediaProviderInterface::class);
         $provider->method('getFilesystem')->willReturn($filesystem);
 
-        $media = $this->createMock(MediaInterface::class);
+        $media = $this->createStub(MediaInterface::class);
         $media
             ->method('getProviderName')
             ->willReturn('sonata.media.provider.image');
@@ -89,13 +105,13 @@ class ProxyMetadataBuilderTest extends TestCase
         //adapter cannot be mocked
         $adapter = new Local('');
 
-        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem = $this->createStub(Filesystem::class);
         $filesystem->method('getAdapter')->willReturn($adapter);
 
-        $provider = $this->createMock(MediaProviderInterface::class);
+        $provider = $this->createStub(MediaProviderInterface::class);
         $provider->method('getFilesystem')->willReturn($filesystem);
 
-        $media = $this->createMock(MediaInterface::class);
+        $media = $this->createStub(MediaInterface::class);
         $media
             ->method('getProviderName')
             ->willReturn('sonata.media.provider.image');
@@ -125,16 +141,16 @@ class ProxyMetadataBuilderTest extends TestCase
             ->method('get')
             ->willReturn(['key' => 'noop']);
 
-        //adapter cannot be mocked
+        // adapter cannot be mocked
         $adapter = new Local('');
 
-        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem = $this->createStub(Filesystem::class);
         $filesystem->method('getAdapter')->willReturn($adapter);
 
-        $provider = $this->createMock(MediaProviderInterface::class);
+        $provider = $this->createStub(MediaProviderInterface::class);
         $provider->method('getFilesystem')->willReturn($filesystem);
 
-        $media = $this->createMock(MediaInterface::class);
+        $media = $this->createStub(MediaInterface::class);
         $media
             ->method('getProviderName')
             ->willReturn('wrongprovider');
@@ -164,25 +180,39 @@ class ProxyMetadataBuilderTest extends TestCase
             ->method('get')
             ->willReturn(['key' => 'noop']);
 
-        //adapter cannot be mocked
-        $amazonclient = S3Client::factory([
-            'credentials' => [
-                'key' => 'XXXXXXXXXXXX',
-                'secret' => 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-            ],
-            'region' => 'us-west-1',
-        ]);
+        if (class_exists(Sdk::class)) {
+            // AWS v3.x
+            $amazonclient = new S3Client([
+                'credentials' => [
+                    'key' => 'XXXXXXXXXXXX',
+                    'secret' => 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+                ],
+                'region' => 'us-west-1',
+                'version' => '2006-03-01',
+            ]);
+        } else {
+            // AWS v2.x. Remove this condition when the support for this version is dropped.
+            $amazonclient = S3Client::factory([
+                'credentials' => [
+                    'key' => 'XXXXXXXXXXXX',
+                    'secret' => 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+                ],
+                'region' => 'us-west-1',
+            ]);
+        }
+
+        // adapter cannot be mocked
         $adapter1 = new AwsS3($amazonclient, '');
         $adapter2 = new Local('');
         $adapter = new Replicate($adapter1, $adapter2);
 
-        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem = $this->createStub(Filesystem::class);
         $filesystem->method('getAdapter')->willReturn($adapter);
 
-        $provider = $this->createMock(MediaProviderInterface::class);
+        $provider = $this->createStub(MediaProviderInterface::class);
         $provider->method('getFilesystem')->willReturn($filesystem);
 
-        $media = $this->createMock(MediaInterface::class);
+        $media = $this->createStub(MediaInterface::class);
         $media
             ->method('getProviderName')
             ->willReturn('sonata.media.provider.image');
@@ -212,18 +242,18 @@ class ProxyMetadataBuilderTest extends TestCase
             ->method('get')
             ->willReturn(['key' => 'noop']);
 
-        //adapter cannot be mocked
+        // adapter cannot be mocked
         $adapter1 = new Local('');
         $adapter2 = new Local('');
         $adapter = new Replicate($adapter1, $adapter2);
 
-        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem = $this->createStub(Filesystem::class);
         $filesystem->method('getAdapter')->willReturn($adapter);
 
-        $provider = $this->createMock(MediaProviderInterface::class);
+        $provider = $this->createStub(MediaProviderInterface::class);
         $provider->method('getFilesystem')->willReturn($filesystem);
 
-        $media = $this->createMock(MediaInterface::class);
+        $media = $this->createStub(MediaInterface::class);
         $media
             ->method('getProviderName')
             ->willReturn('sonata.media.provider.image');
@@ -241,7 +271,7 @@ class ProxyMetadataBuilderTest extends TestCase
         $this->assertSame(['key' => 'noop'], $proxymetadatabuilder->get($media, $filename));
     }
 
-    protected function getContainer(array $services): Container
+    private function getContainer(array $services): ContainerInterface
     {
         $container = new Container();
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Fix support for "aws/aws-sdk-php:^3.0".
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes respect BC.

Related to #1018.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed calls to deprecated method `AwsClient::factory()` when using aws/aws-sdk-php:^3.0;
- Fixed passing required arguments to "sonata.media.cdn.cloudfront" service when using aws/aws-sdk-php:^3.0;
- Fixed respecting "sonata_media.filesystem.s3.region", "sonata_media.filesystem.s3.version" and "sonata_media.filesystem.s3.endpoint" configuration nodes when using aws/aws-sdk-php:^2.0.

### Deprecated
- Deprecated "sonata_media.filesystem.s3.sdk_version" configuration node.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
## To do

- [x] Deprecate `sonata_media.filesystem.s3.sdk_version` configuration node, since there is no way to install "aws/aws-sdk-php" 2.x and 3.x at the same time (this probably was added to switch between version 1.x and 2.x, since 1.x was provided by a [different package](https://github.com/amazonwebservices/aws-sdk-for-php)).
- [x] Add new CloudFront configuration options [required in v3.x](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/getting-started_migration.html#region-and-version-options-are-now-required) (region, version, etc).
- [x] Update the documentation;
- [x] Fix the arguments passed to `CloudFrontClient::createInvalidation()` when using aws/aws-sdk-php:^3.0.

