### PR TITLE
Fix getting values returned by `CloudFrontClient` methods when using "aws/aws-sdk-php:^3.0"

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,26 @@ UPGRADE 3.x
 UPGRADE FROM 3.x to 3.x
 =======================
 
+### Sonata\MediaBundle\CDN\CloudFront
+
+The previous signature of `CloudFront::__construct()` is deprecated.
+
+Before:
+
+```php
+public function __construct(string $path, string $key, string $secret, string $distributionId, ?string $region = null, ?string $version = null)
+```
+
+After:
+
+```php
+public function __construct(Aws\CloudFront\CloudFrontClient $client, string $distributionId, string $path)
+```
+
+Returning `false` or any value not present in the `CDNInterface::STATUS_*` constants from `CloudFront::getFlushStatus()` is deprecated.
+
+The methods `CloudFront::setClient()` and `CloudFront::getStatusList()` are deprecated.
+
 ### MogileFS filesystem adapter is deprecated
 
 The services `sonata.media.adapter.filesystem.mogilefs`, `sonata.media.filesystem.mogilefs`

--- a/src/CDN/CDNInterface.php
+++ b/src/CDN/CDNInterface.php
@@ -36,7 +36,7 @@ interface CDNInterface
      *
      * @param string $string
      *
-     * @return void|string
+     * @return string
      */
     public function flush($string);
 
@@ -45,14 +45,14 @@ interface CDNInterface
      *
      * @param string $string
      *
-     * @return void|string
+     * @return string
      */
     public function flushByString($string);
 
     /**
      * Flush a set of resources matching the paths in provided array.
      *
-     * @return void|string
+     * @return string
      */
     public function flushPaths(array $paths);
 
@@ -61,7 +61,7 @@ interface CDNInterface
      *
      * @param string $identifier
      *
-     * @return string
+     * @return int
      */
     public function getFlushStatus($identifier);
 }

--- a/src/CDN/CloudFrontVersion3.php
+++ b/src/CDN/CloudFrontVersion3.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\CDN;
+
+use Aws\CloudFront\CloudFrontClient;
+use Aws\CloudFront\Exception\CloudFrontException;
+
+/**
+ * From http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html.
+ *
+ * Invalidating Objects (Web Distributions Only)
+ * If you need to remove an object from CloudFront edge-server caches before it
+ * expires, you can do one of the following:
+ * Invalidate the object. The next time a viewer requests the object, CloudFront
+ * returns to the origin to fetch the latest version of the object.
+ * Use object versioning to serve a different version of the object that has a
+ * different name. For more information, see Updating Existing Objects Using
+ * Versioned Object Names.
+ * Important:
+ * You can invalidate most types of objects that are served by a web
+ * distribution, but you cannot invalidate media files in the Microsoft Smooth
+ * Streaming format when you have enabled Smooth Streaming for the corresponding
+ * cache behavior. In addition, you cannot invalidate objects that are served by
+ * an RTMP distribution. You can invalidate a specified number of objects each
+ * month for free. Above that limit, you pay a fee for each object that you
+ * invalidate. For example, to invalidate a directory and all of the files in
+ * the directory, you must invalidate the directory and each file individually.
+ * If you need to invalidate a lot of files, it might be easier and less
+ * expensive to create a new distribution and change your object paths to refer
+ * to the new distribution. For more information about the charges for
+ * invalidation, see Paying for Object Invalidation.
+ *
+ * @uses CloudFrontClient for establishing a connection with CloudFront service
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.htmlInvalidating Objects (Web Distributions Only)
+ *
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+final class CloudFrontVersion3 implements CDNInterface
+{
+    private const AVAILABLE_STATUSES = [
+        self::STATUS_OK => 'Completed',
+        self::STATUS_WAITING => 'InProgress',
+    ];
+
+    /**
+     * @var CloudFrontClient
+     */
+    private $client;
+
+    /**
+     * @var string
+     */
+    private $distributionId;
+
+    /**
+     * @var string
+     */
+    private $path;
+
+    public function __construct(CloudFrontClient $client, string $distributionId, string $path)
+    {
+        $this->client = $client;
+        $this->distributionId = $distributionId;
+        $this->path = rtrim($path, '/');
+    }
+
+    public function getPath($relativePath, $isFlushable = false): string
+    {
+        return sprintf('%s/%s', $this->path, ltrim($relativePath, '/'));
+    }
+
+    public function flushByString($string): string
+    {
+        return $this->flushPaths([$string]);
+    }
+
+    public function flush($string): string
+    {
+        return $this->flushPaths([$string]);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see https://docs.aws.amazon.com/aws-sdk-php/latest/class-Aws.CloudFront.CloudFrontClient.html#_createInvalidation
+     */
+    public function flushPaths(array $paths): string
+    {
+        if (empty($paths)) {
+            throw new \RuntimeException('Unable to flush : expected at least one path');
+        }
+        // Normalizes paths due possible typos since all the CloudFront's
+        // objects starts with a leading slash
+        $normalizedPaths = array_map(static function (string $path): string {
+            return '/'.ltrim($path, '/');
+        }, $paths);
+
+        try {
+            $result = $this->client->createInvalidation([
+                'DistributionId' => $this->distributionId,
+                'InvalidationBatch' => [
+                    'Paths' => [
+                        'Quantity' => \count($normalizedPaths),
+                        'Items' => $normalizedPaths,
+                    ],
+                    'CallerReference' => $this->getCallerReference($normalizedPaths),
+                ],
+            ]);
+            $status = $result->get('Invalidation')['Status'];
+
+            if (false === array_search($status, self::AVAILABLE_STATUSES, true)) {
+                throw new \RuntimeException(sprintf('Unable to determine the flush status from the given response: "%s".', $status));
+            }
+
+            return $result->get('Invalidation')['Id'];
+        } catch (CloudFrontException $ex) {
+            throw new \RuntimeException(sprintf('Unable to flush paths "%s".', implode('", "', $paths), 0, $ex));
+        }
+    }
+
+    public function getFlushStatus($identifier): int
+    {
+        try {
+            $result = $this->client->getInvalidation([
+                'DistributionId' => $this->distributionId,
+                'Id' => $identifier,
+            ]);
+
+            $status = array_search($result->get('Invalidation')['Status'], self::AVAILABLE_STATUSES, true);
+
+            if (false !== $status) {
+                return $status;
+            }
+
+            throw new \RuntimeException(sprintf('Unable to determine the flush status from the given response: "%s".', $status));
+        } catch (CloudFrontException $ex) {
+            throw new \RuntimeException(sprintf('Unable to retrieve flush status for identifier %s.', $identifier), 0, $ex);
+        }
+    }
+
+    /**
+     * Generates a valid caller reference from given paths regardless its order.
+     *
+     * @phpstan-param list<string> $paths
+     *
+     * @return string a md5 representation
+     */
+    private function getCallerReference(array $paths): string
+    {
+        sort($paths);
+
+        return md5(implode(',', $paths));
+    }
+}

--- a/src/CDN/Server.php
+++ b/src/CDN/Server.php
@@ -28,12 +28,12 @@ class Server implements CDNInterface
      */
     public function __construct($path)
     {
-        $this->path = $path;
+        $this->path = rtrim($path, '/');
     }
 
     public function getPath($relativePath, $isFlushable)
     {
-        return sprintf('%s/%s', rtrim($this->path, '/'), ltrim($relativePath, '/'));
+        return sprintf('%s/%s', $this->path, ltrim($relativePath, '/'));
     }
 
     public function flushByString($string)

--- a/src/Resources/config/media.xml
+++ b/src/Resources/config/media.xml
@@ -18,10 +18,11 @@
             <argument/>
             <argument/>
         </service>
-        <service id="sonata.media.cdn.cloudfront" class="Sonata\MediaBundle\CDN\CloudFront">
-            <argument/>
-            <argument/>
-            <argument/>
+        <service id="sonata.media.cdn.cloudfront.client" class="Aws\CloudFront\CloudFrontClient">
+            <argument type="collection"/>
+        </service>
+        <!-- The class for "sonata.media.cdn.cloudfront" service is set dynamically at `SonataMediaExtension` -->
+        <service id="sonata.media.cdn.cloudfront">
             <argument/>
             <argument/>
             <argument/>

--- a/tests/CDN/CloudFrontClientSpy.php
+++ b/tests/CDN/CloudFrontClientSpy.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\CDN;
+
+use Aws\CloudFront\CloudFrontClient;
+
+/**
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+class CloudFrontClientSpy extends CloudFrontClient
+{
+    public function createInvalidation()
+    {
+        return parent::createInvalidation();
+    }
+
+    public function getInvalidation()
+    {
+        return parent::getInvalidation();
+    }
+}

--- a/tests/CDN/CloudFrontTest.php
+++ b/tests/CDN/CloudFrontTest.php
@@ -13,149 +13,88 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Tests\CDN;
 
-use Aws\CloudFront\CloudFrontClient;
+use Aws\CloudFront\Exception\CloudFrontException;
 use Aws\Sdk;
 use PHPUnit\Framework\TestCase;
 use Sonata\MediaBundle\CDN\CloudFront;
 
 /**
+ * @todo Remove this class when support for aws/aws-sdk-php < 3.0 is dropped.
+ *
  * @author Javier Spagnoletti <phansys@gmail.com>
  */
 final class CloudFrontTest extends TestCase
 {
-    /**
-     * @group legacy
-     */
-    public function testLegacyCloudFront(): void
-    {
-        $client = $this->createMock(CloudFrontClientSpy::class);
-
-        $client->expects($this->exactly(3))->method('createInvalidation')->willReturn(new CloudFrontResultSpy());
-
-        $cloudFront = $this->getMockBuilder(CloudFront::class)
-            ->setConstructorArgs(['/foo', 'secret', 'key', 'xxxxxxxxxxxxxx', 'us-west-1', '2020-05-31'])
-            ->onlyMethods([])
-            ->getMock();
-        $cloudFront->setClient($client);
-
-        $this->assertSame('/foo/bar.jpg', $cloudFront->getPath('bar.jpg', true));
-
-        $path = '/mypath/file.jpg';
-
-        $cloudFront->flushByString($path);
-        $cloudFront->flush($path);
-        $cloudFront->flushPaths([$path]);
-    }
-
-    /**
-     * @group legacy
-     */
-    public function testLegacyException(): void
-    {
-        $client = $this->createMock(CloudFrontClientSpy::class);
-        $client->expects($this->once())->method('createInvalidation')->willReturn(new CloudFrontResultSpy(true));
-        $cloudFront = $this->getMockBuilder(CloudFront::class)
-            ->setConstructorArgs(['/foo', 'secret', 'key', 'xxxxxxxxxxxxxx', 'us-west-1', '2020-05-31'])
-            ->onlyMethods([])
-            ->getMock();
-        $cloudFront->setClient($client);
-
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Unable to flush : ');
-
-        $cloudFront->flushPaths(['boom']);
-    }
-
-    /**
-     * @todo: Remove this method when support for aws/aws-sdk-php < 3.0 is dropped.
-     *
-     * @dataProvider cloudFrontWithMissingArgumentsProvider
-     *
-     * @group legacy
-     */
-    public function testCloudFrontWithMissingArguments(string $expectedExceptionMessage, string $path, string $secret, string $key, string $distributionId, ?string $region = null, ?string $version = null): void
-    {
-        if (!class_exists(Sdk::class)) {
-            $this->markTestSkipped('This test requires aws/aws-sdk-php 3.x.');
-        }
-
-        $client = $this->createMock(CloudFrontClientSpy::class);
-
-        $client->expects($this->never())->method('createInvalidation')->willReturn(new CloudFrontResultSpy());
-
-        $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage($expectedExceptionMessage);
-
-        new CloudFront($path, $secret, $key, $distributionId, $region, $version);
-    }
-
-    public function cloudFrontWithMissingArgumentsProvider(): iterable
-    {
-        yield 'missing_argument_5' => [
-            'Argument 5 for "Sonata\MediaBundle\CDN\CloudFront::__construct()" is required and can not be null when aws/aws-sdk-php >= 3.0 is installed.',
-            '/foo', 'secret', 'key', 'xxxxxxxxxxxxxx',
-        ];
-
-        yield 'missing_argument_6' => [
-            'Argument 6 for "Sonata\MediaBundle\CDN\CloudFront::__construct()" is required and can not be null when aws/aws-sdk-php >= 3.0 is installed.',
-            '/foo', 'secret', 'key', 'xxxxxxxxxxxxxx', 'eu-west-3',
-        ];
-    }
-
-    /**
-     * @todo: Remove this method when support for aws/aws-sdk-php < 3.0 is dropped.
-     *
-     * @group legacy
-     */
-    public function testCloudFrontWithSdkV2(): void
+    protected function setUp(): void
     {
         if (class_exists(Sdk::class)) {
             $this->markTestSkipped('This test requires aws/aws-sdk-php 2.x.');
         }
 
+        parent::setUp();
+    }
+
+    public function testCloudFront(): void
+    {
         $client = $this->createMock(CloudFrontClientSpy::class);
-
-        $client->expects($this->exactly(3))->method('createInvalidation')->willReturn(new CloudFrontResultSpy());
-
-        $cloudFront = $this->getMockBuilder(CloudFront::class)
-            ->setConstructorArgs(['/foo', 'secret', 'key', 'xxxxxxxxxxxxxx'])
-            ->onlyMethods([])
-            ->getMock();
-        $cloudFront->setClient($client);
+        $cloudFront = new CloudFront($client, 'xxxxxxxxxxxxxx', '/foo');
 
         $this->assertSame('/foo/bar.jpg', $cloudFront->getPath('bar.jpg', true));
 
         $path = '/mypath/file.jpg';
 
-        $cloudFront->flushByString($path);
-        $cloudFront->flush($path);
-        $cloudFront->flushPaths([$path]);
+        $client->expects($this->exactly(3))
+            ->method('createInvalidation')
+            ->willReturn(new CloudFrontResult([
+                'Id' => 'invalidation_id',
+                'Status' => 'InProgress',
+            ]));
+
+        $this->assertSame('invalidation_id', $cloudFront->flushByString($path));
+        $this->assertSame('invalidation_id', $cloudFront->flush($path));
+        $this->assertSame('invalidation_id', $cloudFront->flushPaths([$path]));
+
+        $client->expects($this->once())
+            ->method('getInvalidation')
+            ->willReturn(new CloudFrontResult([
+                'Id' => 'invalidation_id',
+                'Status' => 'InProgress',
+            ]));
+
+        $this->assertSame(CloudFront::STATUS_WAITING, $cloudFront->getFlushStatus('invalidation_id'));
+    }
+
+    public function testCreateInvalidationException(): void
+    {
+        $client = $this->createMock(CloudFrontClientSpy::class);
+        $cloudFront = new CloudFront($client, 'xxxxxxxxxxxxxx', '/foo');
+
+        $client->expects($this->once())
+            ->method('createInvalidation')
+            ->willThrowException(new CloudFrontException('An exception occurred.'));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unable to flush paths "/bar", "/baz".');
+
+        $cloudFront->flushPaths(['/bar', '/baz']);
     }
 }
 
-class CloudFrontClientSpy extends CloudFrontClient
+class CloudFrontResult
 {
-    public function createInvalidation(): CloudFrontResultSpy
-    {
-        return new CloudFrontResultSpy();
-    }
-}
+    private $data = [];
 
-final class CloudFrontResultSpy
-{
-    private $fail;
-
-    public function __construct(bool $fail = false)
+    public function __construct(array $data)
     {
-        $this->fail = $fail;
+        $this->data = $data;
     }
 
-    public function get($data): string
+    public function get(string $key)
     {
-        if ('Status' !== $data || $this->fail) {
-            return '';
+        if (!\array_key_exists($key, $this->data)) {
+            throw new \OutOfBoundsException('Invalid argument.');
         }
 
-        return 'InProgress';
+        return $this->data[$key];
     }
 }

--- a/tests/CDN/CloudFrontVersion3Test.php
+++ b/tests/CDN/CloudFrontVersion3Test.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\CDN;
+
+use Aws\CloudFront\Exception\CloudFrontException;
+use Aws\Command;
+use Aws\Result;
+use Aws\Sdk;
+use PHPUnit\Framework\TestCase;
+use Sonata\MediaBundle\CDN\CloudFrontVersion3;
+
+/**
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+final class CloudFrontVersion3Test extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!class_exists(Sdk::class)) {
+            $this->markTestSkipped('This test requires aws/aws-sdk-php 3.x.');
+        }
+
+        parent::setUp();
+    }
+
+    /**
+     * @dataProvider provideCloudFrontTestCases
+     */
+    public function testCloudFront(
+        string $expectedPath,
+        string $path,
+        string $relativePath,
+        string $invalidationId,
+        int $expectedStatus,
+        string $invalidationStatus
+    ): void {
+        $client = $this->createMock(CloudFrontClientSpy::class);
+
+        $cloudFront = new CloudFrontVersion3($client, 'xxxxxxxxxxxxxx', $path);
+
+        $this->assertSame($expectedPath, $cloudFront->getPath($relativePath, true));
+
+        $flushPath = '/mypath/file.jpg';
+
+        $client->expects($this->exactly(3))
+            ->method('createInvalidation')
+            ->willReturn(new Result([
+                'Invalidation' => [
+                    'Id' => $invalidationId,
+                    'Status' => $invalidationStatus,
+                ],
+            ]));
+
+        $this->assertSame($invalidationId, $cloudFront->flushByString($flushPath));
+        $this->assertSame($invalidationId, $cloudFront->flush($flushPath));
+        $this->assertSame($invalidationId, $cloudFront->flushPaths([$flushPath]));
+
+        $client->expects($this->once())
+            ->method('getInvalidation')
+            ->willReturn(new Result([
+                'Invalidation' => [
+                    'Id' => $invalidationId,
+                    'Status' => $invalidationStatus,
+                ],
+            ]));
+
+        $this->assertSame($expectedStatus, $cloudFront->getFlushStatus($invalidationId));
+    }
+
+    public function provideCloudFrontTestCases(): iterable
+    {
+        yield ['/foo/bar.jpg', '/foo', '/bar.jpg', 'ivalidation_id_42', CloudFrontVersion3::STATUS_WAITING, 'InProgress'];
+
+        yield ['/foo/bar.jpg', '/foo', 'bar.jpg', 'ivalidation_a', CloudFrontVersion3::STATUS_OK, 'Completed'];
+    }
+
+    public function testCreateInvalidationException(): void
+    {
+        $client = $this->createMock(CloudFrontClientSpy::class);
+
+        $client->expects($this->once())
+            ->method('createInvalidation')
+            ->willThrowException(new CloudFrontException('An exception occurred.', new Command('command_name')));
+
+        $cloudFront = new CloudFrontVersion3($client, 'xxxxxxxxxxxxxx', '/foo');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unable to flush paths "/bar", "/baz".');
+
+        $cloudFront->flushPaths(['/bar', '/baz']);
+    }
+
+    public function testUnknownStatusException(): void
+    {
+        $client = $this->createMock(CloudFrontClientSpy::class);
+        $cloudFront = new CloudFrontVersion3($client, 'xxxxxxxxxxxxxx', '/foo');
+
+        $client->expects($this->once())
+            ->method('createInvalidation')
+            ->willReturn(new Result([
+                'Invalidation' => [
+                    'Id' => 'invalidation_id',
+                    'Status' => 'SomeUnknownStatus',
+                ],
+            ]));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unable to determine the flush status from the given response: "SomeUnknownStatus".');
+
+        $cloudFront->flushPaths(['/boom']);
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Fix getting values returned by `CloudFrontClient` methods when using "aws/aws-sdk-php:^3.0".
<!-- Describe your Pull Request content here -->

The method `CloudFrontClient::getInvalidation()` from SDK [v2](https://docs.aws.amazon.com/aws-sdk-php/v2/api/class-Aws.CloudFront.CloudFrontClient.html#_getInvalidation) returns the following array structure:
```php
[
    'Id' => '<string>',
    'Status' => '<string>',
    'CreateTime' => <DateTime>,
    'InvalidationBatch' => [
        'Paths' => [
            'Items' => ['<string>', ...],
            'Quantity' => <integer>,
        ],
        'CallerReference' => '<string>',
    ],
    'RequestId' => '<>',
]
```
while the SDK [v3](https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-cloudfront-2018-06-18.html#getinvalidation) returns the following:
```php
[
    'Invalidation' => [
        'CreateTime' => <DateTime>,
        'Id' => '<string>',
        'InvalidationBatch' => [
            'CallerReference' => '<string>',
            'Paths' => [
                'Items' => ['<string>', ...],
                'Quantity' => <integer>,
            ],
        ],
        'Status' => '<string>',
    ],
]
```
the same occurs with the method `CloudFrontClient::createInvalidation()`, but we are currently trying to deal with the structure returned by the SDK v3 without being aware of this difference.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Follow up of #1814.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed getting values returned by `CloudFrontClient::createInvalidation()` and `CloudFrontClient::getInvalidation()` methods when using "aws/aws-sdk-php:^3.0".

### Deprecated
- Deprecated method signature for `CloudFront::__construct()`;
- Deprecated methods `CloudFront::setClient()` and `CloudFront::getStatusList()`;
- Deprecated returning `false` or any value not present in the `CDNInterface::STATUS_*` constants from `CloudFront::getFlushStatus()`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
