### PR TITLE
Add option to set additional S3 configuration settings

### DIFF
--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -111,7 +111,9 @@ Full configuration options:
                 encryption:     aes256 # can be aes256 or not set
                 cache_control:  max-age=86400 # or any other
                 meta:
-                    key1:       value1 #any amount of metas(sent as x-amz-meta-key1 = value1)
+                    key1:       value1 # any amount of metas(sent as x-amz-meta-key1 = value1)
+                config:
+                    key1:       value1 # any amount of additional configuration settings to pass to the AWS SDK
 
             mogilefs:
                 hosts:      []

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -310,6 +310,12 @@ class Configuration implements ConfigurationInterface
                                     ->prototype('scalar')
                                     ->end()
                                 ->end()
+                                ->arrayNode('config')
+                                    ->info('Additional configuration settings to pass to the AWS S3 SDK')
+                                    ->useAttributeAsKey('name')
+                                    ->prototype('scalar')
+                                    ->end()
+                                ->end()
                             ->end()
                         ->end()
 

--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -475,6 +475,10 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
                     ->setFactory([S3Client::class, 'factory']);
             }
 
+            if (!empty($config['filesystem']['s3']['config'])) {
+                $arguments = array_merge($arguments, $config['filesystem']['s3']['config']);
+            }
+
             $container->getDefinition('sonata.media.adapter.service.s3')
                 ->replaceArgument(0, $arguments);
         } else {

--- a/tests/DependencyInjection/SonataMediaExtensionTest.php
+++ b/tests/DependencyInjection/SonataMediaExtensionTest.php
@@ -228,6 +228,7 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
                     'secret' => 'secret',
                     'key' => 'access',
                 ],
+                'extra' => true,
             ],
             [
                 'filesystem' => [
@@ -237,6 +238,9 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
                         'version' => 'version',
                         'secretKey' => 'secret',
                         'accessKey' => 'access',
+                        'config' => [
+                            'extra' => true,
+                        ],
                     ],
                 ],
             ],
@@ -337,6 +341,7 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
                 'version' => 'version',
                 'secret' => 'secret',
                 'key' => 'access',
+                'extra' => true,
             ],
             [
                 'filesystem' => [
@@ -346,6 +351,9 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
                         'version' => 'version',
                         'secretKey' => 'secret',
                         'accessKey' => 'access',
+                        'config' => [
+                            'extra' => true,
+                        ],
                     ],
                 ],
             ],


### PR DESCRIPTION
## Subject

I am using S3 compatible file storage (MinIO) in my environment. This requires that the URLs to it have the path style: `http://endpoint/bucket/filepath`. This is supported by the S3 SDK if the `use_path_style_endpoint` parameter is set.

Currently, setting additional options to the S3Client is not supported. This PR adds a new configuration node that lets the user set additional configuration values to be passed to the S3 client.

I am targeting this branch, because it's backwards compatible.

## Changelog

```markdown
### Added
- Added option to set additional S3 configuration settings
```
