### PR TITLE
Make `sonata.media.admin.media.manager` an alias of `sonata.admin.manager.orm` / `sonata.admin.manager.doctrine_mongodb` 

### DIFF
--- a/src/Resources/config/doctrine_mongodb_admin.xml
+++ b/src/Resources/config/doctrine_mongodb_admin.xml
@@ -40,9 +40,7 @@
                 </argument>
             </call>
         </service>
-        <service id="sonata.media.admin.media.manager" class="Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager" public="true">
-            <argument type="service" id="doctrine_mongodb"/>
-        </service>
+        <service id="sonata.media.admin.media.manager" alias="sonata.admin.manager.doctrine_mongodb" public="true"/>
         <service id="sonata.media.admin.gallery" class="%sonata.media.admin.gallery.class%" public="true">
             <tag name="sonata.admin" manager_type="doctrine_mongodb" group="%sonata.media.admin.groupname%" label_catalogue="%sonata.media.admin.gallery.translation_domain%" label="gallery" label_translator_strategy="sonata.admin.label.strategy.underscore" icon="%sonata.media.admin.groupicon%"/>
             <argument/>

--- a/src/Resources/config/doctrine_orm_admin.xml
+++ b/src/Resources/config/doctrine_orm_admin.xml
@@ -41,9 +41,7 @@
                 </argument>
             </call>
         </service>
-        <service id="sonata.media.admin.media.manager" class="Sonata\DoctrineORMAdminBundle\Model\ModelManager" public="true">
-            <argument type="service" id="doctrine"/>
-        </service>
+        <service id="sonata.media.admin.media.manager" alias="sonata.admin.manager.orm" public="true"/>
         <service id="sonata.media.admin.gallery" class="%sonata.media.admin.gallery.class%" public="true">
             <tag name="sonata.admin" manager_type="orm" group="%sonata.media.admin.groupname%" label="gallery" label_catalogue="%sonata.media.admin.gallery.translation_domain%" label_translator_strategy="sonata.admin.label.strategy.underscore" icon="%sonata.media.admin.groupicon%"/>
             <argument/>


### PR DESCRIPTION
## Subject

Since sonata-project/doctrine-orm-admin-bundle 3.22 the constructor of `Sonata\DoctrineORMAdminBundle\Model\ModelManager` throws a deprecation warning when the second argument is not provided. The file `doctrine_orm_admin.xml` of the media bundle registers this class as the service `sonata.media.admin.media.manager` without this argument. I think this service can be made an alias of `sonata.admin.manager.orm`. This makes sure the parameters are correct regardless of the orm bundle version.

Maybe I've overlooked something that would make this solution invalid, but it seems this solution also makes sure there is just one instance of the `ModelManager`, which seems a plus.

I am targeting this branch, because it is a backwards compatible change.

## Changelog

```markdown
### Changed
- When using Doctrine ORM or MongoDB the service `sonata.media.admin.media.manager` is now an alias of `sonata.admin.manager.orm` or `sonata.admin.manager.doctrine_mongodb` instead of a separate service implemented by the same class.

### Fixed
- Deprecation notice in `Sonata\DoctrineORMAdminBundle\Model\ModelManager` and `Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager`.
```