### PR TITLE
Fix CDN flush behavior

### DIFF
--- a/docs/reference/command_line.rst
+++ b/docs/reference/command_line.rst
@@ -102,3 +102,17 @@ Creates default root categories for the ``SonataClassificationBundle`` if they d
 .. code-block:: bash
 
    bin/console sonata:media:fix-media-context
+
+Update CDN status
+^^^^^^^^^^^^^^^^^
+
+Updates and keeps synchronized the media with the CDN flush status for a given provider
+(IE: ``sonata.media.provider.image``) in the given context (IE: ``default``).
+
+.. note::
+
+   There is also an interactive shell for arguments.
+
+.. code-block:: bash
+
+   bin/console sonata:media:update-cdn-status sonata.media.provider.image default

--- a/src/Provider/BaseProvider.php
+++ b/src/Provider/BaseProvider.php
@@ -92,20 +92,43 @@ abstract class BaseProvider implements MediaProviderInterface
 
     public function flushCdn(MediaInterface $media)
     {
-        if ($media->getId() && $this->requireThumbnails() && !$media->getCdnIsFlushable()) {
-            $flushPaths = [];
-            foreach ($this->getFormats() as $format => $settings) {
-                if (MediaProviderInterface::FORMAT_ADMIN === $format ||
-                    substr($format, 0, \strlen((string) $media->getContext())) === $media->getContext()) {
-                    $flushPaths[] = $this->getFilesystem()->get($this->generatePrivateUrl($media, $format), true)->getKey();
-                }
+        if (!$media->getId() || !$media->getCdnIsFlushable()) {
+            // If the medium is new or if it isn't marked as flushable, skip the CDN flush process.
+            return;
+        }
+
+        // Check if the medium already has a pending CDN flush.
+        if ($media->getCdnFlushIdentifier()) {
+            $cdnStatus = $this->getCdn()->getFlushStatus($media->getCdnFlushIdentifier());
+            // Update the flush status.
+            $media->setCdnStatus($cdnStatus);
+
+            if (!\in_array($cdnStatus, [CDNInterface::STATUS_OK, CDNInterface::STATUS_ERROR], true)) {
+                // If the previous flush process is still pending, do nothing.
+                return;
             }
-            if (!empty($flushPaths)) {
-                $cdnFlushIdentifier = $this->getCdn()->flushPaths($flushPaths);
-                $media->setCdnFlushIdentifier($cdnFlushIdentifier);
-                $media->setCdnIsFlushable(true);
-                $media->setCdnStatus(CDNInterface::STATUS_TO_FLUSH);
+
+            // If the previous flush process is finished, we clean its identifier.
+            $media->setCdnFlushIdentifier(null);
+
+            if (CDNInterface::STATUS_OK === $cdnStatus) {
+                $media->setCdnFlushAt(new \DateTime());
             }
+        }
+
+        $flushPaths = [];
+
+        foreach ($this->getFormats() as $format => $settings) {
+            if (MediaProviderInterface::FORMAT_ADMIN === $format ||
+                substr($format, 0, \strlen((string) $media->getContext())) === $media->getContext()) {
+                $flushPaths[] = $this->getFilesystem()->get($this->generatePrivateUrl($media, $format), true)->getKey();
+            }
+        }
+
+        if (!empty($flushPaths)) {
+            $cdnFlushIdentifier = $this->getCdn()->flushPaths($flushPaths);
+            $media->setCdnFlushIdentifier($cdnFlushIdentifier);
+            $media->setCdnStatus(CDNInterface::STATUS_TO_FLUSH);
         }
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Fix CDN flush behavior.
<!-- Describe your Pull Request content here -->

The CDN flush behavior is an asynchronous operation. It consists in telling the CDN a path must be invalidated, in order to pick the path content again from its origin. This operation can take some time, so the invalidation result must be obtained using long polling, a scheduled task (like `UpdateCdnStatusCommand`) or something similar, in order to know if it has finished successfully or not. When this operation is done, the result is passed to `MediaInterface::setCdnStatus()`.
The users are able to mark a medium as flushable (indicating it must be track any update and kept fresh in the CDN) by calling `MediaInterface::setCdnIsFlushable()`.

Previous to this change, the behavior at `BaseProvider::flushCdn()` and `UpdateCdnStatusCommand` were making wrong assumptions about of the purpose of `MediaInterface::getCdnIsFlushable()`. They were calling `MediaInterface::setCdnIsFlushable()` arbitrarily, but they should not do that since it was overriding what the users have chosen about the CDN content for each medium.

Additionally to this fix, these changes also allow `BaseProvider::flushCdn()` to update the flush status of a medium with a pending flush, if its result is successful. It also prevents to attempt a new flush request if a previous one is in a pending (different than `CDNInterface::STATUS_OK` or `CDNInterface::STATUS_ERROR`) status.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added CDN flush status check at `BaseProvider::flushCdn()` in order to resolve previous flushing processes.

### Fixed
- Fixed marking the medium as not CDN synced (`Media::$cdnIsFlushable`) in `BaseProvider::flushCdn()` and `UpdateCdnStatusCommand`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
## To do

- [x] Update the tests;
- [x] Update the documentation in order to tell how to use the command `sonata:media:update-cdn-status`.