### PR TITLE
Update link for CoopTilleulsCKEditorSonataMediaBundle install doc

### DIFF
--- a/docs/reference/extra.rst
+++ b/docs/reference/extra.rst
@@ -121,7 +121,7 @@ Medias in CKEditor with CoopTilleulsCKEditorSonataMediaBundle
 
 `CoopTilleulsCKEditorSonataMediaBundle <https://github.com/coopTilleuls/CoopTilleulsCKEditorSonataMediaBundle>`_ allows to browse and upload files managed by SonataMedia directly from the UI of the `CKEditor <http://ckeditor.com/>`_ WYSIWYG editor.
 
-To use this feature, follow `CoopTilleulsCKEditorSonataMediaBundle installation instructions <https://github.com/coopTilleuls/CoopTilleulsCKEditorSonataMediaBundle/blob/master/docs/install.md>`.
+To use this feature, follow `CoopTilleulsCKEditorSonataMediaBundle installation instructions <https://github.com/coopTilleuls/CoopTilleulsCKEditorSonataMediaBundle/blob/master/Resources/doc/install.md>`_.
 
 Now, just create a field with ckeditor as type and your done::
 


### PR DESCRIPTION
## Subject

Doc update : link for CoopTilleulsCKEditorSonataMediaBundle install doc was broken and unclickable.
I am targeting this branch, because these changes respect BC.
