### PR TITLE
Allow symfony/validator and symfony/finder ^5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "symfony/dependency-injection": "^4.4",
         "symfony/event-dispatcher": "^4.4",
         "symfony/filesystem": "^4.4 || ^5.1",
-        "symfony/finder": "^4.4",
+        "symfony/finder": "^4.4 || ^5.1",
         "symfony/form": "^4.4",
         "symfony/framework-bundle": "^4.4",
         "symfony/http-foundation": "^4.4",
@@ -55,7 +55,7 @@
         "symfony/translation": "^4.4",
         "symfony/twig-bridge": "^4.4",
         "symfony/twig-bundle": "^4.4",
-        "symfony/validator": "^4.4",
+        "symfony/validator": "^4.4 || ^5.1",
         "twig/string-extra": "^3.0",
         "twig/twig": "^2.12.1"
     },


### PR DESCRIPTION
## Subject

I wish to use symfony/validator ^5.1 in my project and Sonatas Media and Formatter bundle are preventing this. I have removed the development dependency on the formatter bundle in this change because otherwise it's impossible to update shared dependencies.

I also updated symfony/finder to ^5.1.

I am targeting this branch, because it is a backwards compatible change.

## Changelog

```markdown
### Added
- Support for symfony/validator ^5.1
```