### PR TITLE
Remove dev dependency on sonata-project/formatter-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,6 @@
         "sonata-project/block-bundle": "^3.17",
         "sonata-project/datagrid-bundle": "^2.5",
         "sonata-project/doctrine-orm-admin-bundle": "^3.14",
-        "sonata-project/formatter-bundle": "^3.4 || ^4.0",
         "sonata-project/notification-bundle": "^3.3",
         "sonata-project/seo-bundle": "^2.5",
         "symfony/browser-kit": "^4.4 || ^5.1",

--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -72,10 +72,6 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
             $loader->load('consumer.xml');
         }
 
-        if (isset($bundles['SonataFormatterBundle'])) {
-            $loader->load('formatter.xml');
-        }
-
         if (isset($bundles['SonataBlockBundle'])) {
             $loader->load('block.xml');
         }

--- a/src/Resources/config/formatter.xml
+++ b/src/Resources/config/formatter.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-    <services>
-        <service id="sonata.media.formatter.twig" class="Sonata\MediaBundle\Twig\Extension\FormatterMediaExtension" public="true">
-            <argument type="service" id="sonata.media.twig.extension"/>
-        </service>
-    </services>
-</container>

--- a/src/Resources/config/twig.xml
+++ b/src/Resources/config/twig.xml
@@ -9,5 +9,8 @@
         <service id="sonata.media.twig.global" class="Sonata\MediaBundle\Twig\GlobalVariables">
             <argument type="service" id="service_container"/>
         </service>
+        <service id="sonata.media.formatter.twig" class="Sonata\MediaBundle\Twig\Extension\FormatterMediaExtension" public="true">
+            <argument type="service" id="sonata.media.twig.extension"/>
+        </service>
     </services>
 </container>


### PR DESCRIPTION
## Subject

As mentioned in #1834 (and also #1807) the circular dependency between the formatter bundle and media bundle should be removed. This PR removes the dev dependency on the formatter bundle and merges the formatter.xml settings with twig.xml, as suggested in https://github.com/sonata-project/SonataMediaBundle/pull/1834#issuecomment-705825021.

I am targeting this branch, because it's backwards compatible.

## Changelog

```markdown
### Removed
- Dev dependency on sonata-project/formatter-bundle.
```