### PR TITLE
Deprecate services related to `MogileFS` filesystem adapter

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,11 @@ UPGRADE 3.x
 UPGRADE FROM 3.x to 3.x
 =======================
 
+### MogileFS filesystem adapter is deprecated
+
+The services `sonata.media.adapter.filesystem.mogilefs`, `sonata.media.filesystem.mogilefs`
+and the configuration node "sonata_media.filesystem.mogilefs" are deprecated.
+
 ### Configuration node "sonata_media.filesystem.s3.sdk_version"
 
 The configuration node "sonata_media.filesystem.s3.sdk_version" is deprecated. The

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -315,6 +315,10 @@ class Configuration implements ConfigurationInterface
                         ->end()
 
                         ->arrayNode('mogilefs')
+                            ->setDeprecated(...$this->getBackwardCompatibleArgumentsForSetDeprecated(
+                                'The node "%node%" is deprecated and will be removed in version 4.0.',
+                                '3.x'
+                            ))
                             ->children()
                                 ->scalarNode('domain')->isRequired()->end()
                                 ->arrayNode('hosts')

--- a/src/Resources/config/gaufrette.xml
+++ b/src/Resources/config/gaufrette.xml
@@ -23,6 +23,7 @@
             <argument type="service" id="logger"/>
         </service>
         <service id="sonata.media.adapter.filesystem.mogilefs" class="Gaufrette\Adapter\MogileFS">
+            <deprecated>The "%service_id%" service is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0.</deprecated>
             <argument/>
             <argument/>
         </service>
@@ -41,6 +42,7 @@
             <argument/>
         </service>
         <service id="sonata.media.filesystem.mogilefs" class="Gaufrette\Filesystem">
+            <deprecated>The "%service_id%" service is deprecated since sonata-project/media-bundle 3.x and will be removed in version 4.0.</deprecated>
             <argument type="service" id="sonata.media.adapter.filesystem.mogilefs"/>
         </service>
         <service id="sonata.media.filesystem.ftp" class="Gaufrette\Filesystem">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Deprecate services related to `MogileFS` filesystem adapter, since it's [removed](https://github.com/KnpLabs/Gaufrette/blob/master/CHANGELOG.md#removed) in `knplabs/gaufrette:0.10.0`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- `sonata.media.adapter.filesystem.mogilefs` and `sonata.media.filesystem.mogilefs` services;
- `sonata_media.filesystem.mogilefs` configuration node.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
