### PR TITLE
Fix error on YouTube media creation

### DIFF
--- a/src/Validator/Constraints/ImageUploadDimensionValidator.php
+++ b/src/Validator/Constraints/ImageUploadDimensionValidator.php
@@ -48,7 +48,7 @@ final class ImageUploadDimensionValidator extends ConstraintValidator
             throw new UnexpectedTypeException($value, MediaInterface::class);
         }
 
-        if (null === $value->getBinaryContent()) {
+        if (!$value->getBinaryContent() instanceof \SplFileInfo) {
             return;
         }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch because this is a bug fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1804 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
- Error on YouTube media creation in `ImageUploadDimensionValidator`

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
