### PR TITLE
Amazon mimetype bugfix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "jms/serializer-bundle": "^2.3.1 || ^3.0",
         "knplabs/gaufrette": "^0.8 || ^0.9",
         "kriswallsmith/buzz": "^0.15 || ^0.16",
+        "league/mime-type-detection": "^1.5",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
         "jms/serializer-bundle": "^2.3.1 || ^3.0",
         "knplabs/gaufrette": "^0.8 || ^0.9",
         "kriswallsmith/buzz": "^0.15 || ^0.16",
-        "league/mime-type-detection": "^1.5",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0",

--- a/src/Metadata/AmazonMetadataBuilder.php
+++ b/src/Metadata/AmazonMetadataBuilder.php
@@ -114,12 +114,15 @@ class AmazonMetadataBuilder implements MetadataBuilderInterface
     /**
      * Gets the correct content-type.
      *
-     * @param string $filename
+     * @param string $filename path to the file inside the s3 bucket
      *
      * @return array
      */
     protected function getContentType($filename)
     {
-        return ['contentType' => $this->mimeTypes->guessMimeType($filename)];
+        $extension = pathinfo($filename, PATHINFO_EXTENSION);
+        $contentType = Psr7\mimetype_from_extension($extension);
+
+        return ['contentType' => $contentType];
     }
 }

--- a/src/Metadata/AmazonMetadataBuilder.php
+++ b/src/Metadata/AmazonMetadataBuilder.php
@@ -13,8 +13,9 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Metadata;
 
-use League\MimeTypeDetection\ExtensionMimeTypeDetector;
 use Sonata\MediaBundle\Model\MediaInterface;
+use Symfony\Component\Mime\MimeTypes;
+use Symfony\Component\Mime\MimeTypesInterface;
 
 /**
  * @final since sonata-project/media-bundle 3.21.0
@@ -38,11 +39,6 @@ class AmazonMetadataBuilder implements MetadataBuilderInterface
     protected $settings;
 
     /**
-     * @var ExtensionMimeTypeDetector
-     */
-    protected $extensionMimeTypeDetector;
-
-    /**
      * @var string[]
      */
     protected $acl = [
@@ -54,10 +50,15 @@ class AmazonMetadataBuilder implements MetadataBuilderInterface
         'owner_full_control' => self::BUCKET_OWNER_FULL_CONTROL,
     ];
 
-    public function __construct(array $settings)
+    /**
+     * @var MimeTypes
+     */
+    private $mimeTypes;
+
+    public function __construct(array $settings, ?MimeTypesInterface $mimeTypes = null)
     {
         $this->settings = $settings;
-        $this->extensionMimeTypeDetector = new ExtensionMimeTypeDetector();
+        $this->mimeTypes = $mimeTypes ?? new MimeTypes();
     }
 
     public function get(MediaInterface $media, $filename)
@@ -119,6 +120,9 @@ class AmazonMetadataBuilder implements MetadataBuilderInterface
      */
     protected function getContentType($filename)
     {
-        return ['contentType' => $this->extensionMimeTypeDetector->detectMimeTypeFromPath($filename)];
+        $ext = pathinfo($filename, PATHINFO_EXTENSION);
+        $mimeTypes = $this->mimeTypes->getMimeTypes($ext);
+
+        return ['contentType' => current($mimeTypes)];
     }
 }

--- a/src/Metadata/AmazonMetadataBuilder.php
+++ b/src/Metadata/AmazonMetadataBuilder.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Metadata;
 
+use League\MimeTypeDetection\ExtensionMimeTypeDetector;
 use Sonata\MediaBundle\Model\MediaInterface;
 
 /**
@@ -37,6 +38,11 @@ class AmazonMetadataBuilder implements MetadataBuilderInterface
     protected $settings;
 
     /**
+     * @var ExtensionMimeTypeDetector
+     */
+    protected $extensionMimeTypeDetector;
+
+    /**
      * @var string[]
      */
     protected $acl = [
@@ -51,6 +57,7 @@ class AmazonMetadataBuilder implements MetadataBuilderInterface
     public function __construct(array $settings)
     {
         $this->settings = $settings;
+        $this->extensionMimeTypeDetector = new ExtensionMimeTypeDetector();
     }
 
     public function get(MediaInterface $media, $filename)
@@ -112,9 +119,6 @@ class AmazonMetadataBuilder implements MetadataBuilderInterface
      */
     protected function getContentType($filename)
     {
-        $extension = pathinfo($filename, PATHINFO_EXTENSION);
-        $contentType = Psr7\mimetype_from_extension($extension);
-
-        return ['contentType' => $contentType];
+        return ['contentType' => $this->extensionMimeTypeDetector->detectMimeTypeFromPath($filename)];
     }
 }

--- a/src/Metadata/AmazonMetadataBuilder.php
+++ b/src/Metadata/AmazonMetadataBuilder.php
@@ -14,8 +14,6 @@ declare(strict_types=1);
 namespace Sonata\MediaBundle\Metadata;
 
 use Sonata\MediaBundle\Model\MediaInterface;
-use Symfony\Component\Mime\MimeTypes;
-use Symfony\Component\Mime\MimeTypesInterface;
 
 /**
  * @final since sonata-project/media-bundle 3.21.0
@@ -50,15 +48,9 @@ class AmazonMetadataBuilder implements MetadataBuilderInterface
         'owner_full_control' => self::BUCKET_OWNER_FULL_CONTROL,
     ];
 
-    /**
-     * @var MimeTypes
-     */
-    private $mimeTypes;
-
-    public function __construct(array $settings, ?MimeTypesInterface $mimeTypes = null)
+    public function __construct(array $settings)
     {
         $this->settings = $settings;
-        $this->mimeTypes = $mimeTypes ?? new MimeTypes();
     }
 
     public function get(MediaInterface $media, $filename)


### PR DESCRIPTION
## Subject

this happened on 3.28 and should be reverted (the fix will be BC).

Fix Amazon guess MimeType on amazon s3 
actually the `$filename` at this point is `amazon s3 path` and not the `tmp path` for the file 
So, any mime guesser will fail because file not found on the machine

related to [#1664] Deprecate Guzzle and Buzz usage in BaseVideoProvider (@core23)

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- update AmazonMetadataBuilder::getContentType 

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
