### PR TITLE
Add missing italian translations

### DIFF
--- a/src/Resources/translations/SonataMediaBundle.it.xliff
+++ b/src/Resources/translations/SonataMediaBundle.it.xliff
@@ -11,8 +11,12 @@
                 <target>Media</target>
             </trans-unit>
             <trans-unit id="gallery">
-                <source>Gallery</source>
+                <source>gallery</source>
                 <target>Gallerie</target>
+            </trans-unit>
+            <trans-unit id="Gallery">
+                <source>Gallery</source>
+                <target>Galleria</target>
             </trans-unit>
             <trans-unit id="options">
                 <source>Options</source>


### PR DESCRIPTION
I am targeting this branch, because this is a bugfix.

## Changelog

```markdown
### Changed
- Translation keys for `gallery` and `Gallery`, inspired by the DE translation file, 
  for correct translations of menu key and the form group.
```
