### PR TITLE
Replace is_callable call with ReflectionClass

### DIFF
--- a/src/DependencyInjection/Compiler/ThumbnailCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ThumbnailCompilerPass.php
@@ -32,7 +32,9 @@ class ThumbnailCompilerPass implements CompilerPassInterface
             'sonata.media.thumbnail.format'
         );
 
-        if (!\is_callable([$container->getParameterBag()->resolveValue($definition->getClass()), 'addResizer'])) {
+        $reflectionClass = new \ReflectionClass($container->getParameterBag()->resolveValue($definition->getClass()));
+
+        if (!$reflectionClass->hasMethod('addResizer') || !$reflectionClass->getMethod('addResizer')->isPublic()) {
             return;
         }
 


### PR DESCRIPTION
In PHP8, is_callable fails when checking for a non-static method with a classname. 

See https://github.com/php/php-src/blob/f5be0e5110ff816d2ce168c154cb3575d08e3cad/UPGRADING#L30

I haven't check other packages how have they solved this, maybe there is another way.

I guess the proper way to solve it (for next major version) is to create an interface with that method and check if the class implements that interface.