### PR TITLE
Small refactoring of translations files

### DIFF
--- a/src/Admin/GalleryAdmin.php
+++ b/src/Admin/GalleryAdmin.php
@@ -85,7 +85,9 @@ class GalleryAdmin extends AbstractAdmin
     {
         // define group zoning
         $formMapper
+            // NEXT_MAJOR: Change Gallery key to `form_group.gallery` and update translations files.
             ->with('Gallery', ['class' => 'col-md-9'])->end()
+            // NEXT_MAJOR: Change Options key to `form_group.options` and update translations files.
             ->with('Options', ['class' => 'col-md-3'])->end()
         ;
 

--- a/src/Resources/translations/SonataMediaBundle.de.xliff
+++ b/src/Resources/translations/SonataMediaBundle.de.xliff
@@ -10,9 +10,21 @@
                 <source>media</source>
                 <target>Medien</target>
             </trans-unit>
+            <trans-unit id="media_">
+                <source>Media</source>
+                <target>Medien</target>
+            </trans-unit>
             <trans-unit id="gallery">
                 <source>gallery</source>
                 <target>Galerie</target>
+            </trans-unit>
+            <trans-unit id="gallery_">
+                <source>Gallery</source>
+                <target>Galerie</target>
+            </trans-unit>
+            <trans-unit id="options">
+                <source>Options</source>
+                <target>Einstellungen</target>
             </trans-unit>
             <trans-unit id="sonata_media">
                 <source>sonata_media</source>
@@ -562,18 +574,6 @@
             <trans-unit id="form.label_class">
                 <source>form.label_class</source>
                 <target>CSS Klasse</target>
-            </trans-unit>
-            <trans-unit id="media_">
-                <source>Media</source>
-                <target>Medien</target>
-            </trans-unit>
-            <trans-unit id="gallery_">
-                <source>Gallery</source>
-                <target>Galerie</target>
-            </trans-unit>
-            <trans-unit id="options">
-                <source>Options</source>
-                <target>Einstellungen</target>
             </trans-unit>
             <trans-unit id="form.label_translation_domain">
                 <source>form.label_translation_domain</source>

--- a/src/Resources/translations/SonataMediaBundle.it.xliff
+++ b/src/Resources/translations/SonataMediaBundle.it.xliff
@@ -11,8 +11,12 @@
                 <target>Media</target>
             </trans-unit>
             <trans-unit id="gallery">
-                <source>Gallery</source>
+                <source>gallery</source>
                 <target>Gallerie</target>
+            </trans-unit>
+            <trans-unit id="gallery_">
+                <source>Gallery</source>
+                <target>Galleria</target>
             </trans-unit>
             <trans-unit id="options">
                 <source>Options</source>


### PR DESCRIPTION
## Subject

I am targeting this branch, because this is a small improvement.

## Changelog

```markdown
### Added

- Comments in `GalleryAdmin.php` for the next-major translations refactoring

### Changed

- `SonataMediaBundle.de.xliff` re-arranged translation keys

### Fixed

- `SonataMediaBundle.it.xliff` fixed "gallery" and "Gallery" translations (case)
```
