### PR TITLE
Fix guessing mime type in AmazonMetadataBuilder

### DIFF
--- a/src/Metadata/AmazonMetadataBuilder.php
+++ b/src/Metadata/AmazonMetadataBuilder.php
@@ -114,12 +114,16 @@ class AmazonMetadataBuilder implements MetadataBuilderInterface
     /**
      * Gets the correct content-type.
      *
-     * @param string $filename
+     * @param string $filename path to the file inside the S3 bucket
      *
      * @return array
+     * @phpstan-return array{contentType: string}
      */
     protected function getContentType($filename)
     {
-        return ['contentType' => $this->mimeTypes->guessMimeType($filename)];
+        $ext = pathinfo($filename, PATHINFO_EXTENSION);
+        $mimeTypes = $this->mimeTypes->getMimeTypes($ext);
+
+        return ['contentType' => current($mimeTypes)];
     }
 }

--- a/tests/Metadata/AmazonMetadataBuilderTest.php
+++ b/tests/Metadata/AmazonMetadataBuilderTest.php
@@ -26,8 +26,10 @@ final class AmazonMetadataBuilderTest extends TestCase
      */
     public function testAmazon(array $settings, array $expected): void
     {
-        $mimeTypes = $this->createMock(MimeTypesInterface::class);
-        $mimeTypes->method('guessMimeType')->willReturn($expected['contentType']);
+        $mimeTypes = $this->createStub(MimeTypesInterface::class);
+        $mimeTypes->method('getMimeTypes')->willReturnCallback(static function (string $ext): array {
+            return 'png' === $ext ? ['image/png'] : [];
+        });
 
         $media = $this->createStub(MediaInterface::class);
         $filename = '/test/folder/testfile.png';


### PR DESCRIPTION
## Subject

`AmazonMetadataBuilder->getContentType()` should not try to access the `$filename` parameter as a local file because it has been uploaded already to S3.

I am targeting this branch, because it's fixing a regression.

Closes #1854.

## Changelog

```markdown
### Fixed
- Guessing the content type of a file stored on Amazon S3.
```