### PR TITLE
Datetimeinterface

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -51,6 +51,11 @@ are required when aws/aws-sdk-php 3.x is installed.
 
 The `Guzzle` and `Buzz` dependencies are deprecated and will be replaced with the abstract `http-client` interface, so you can choose your preferred client implementation. You should adapt to the new `BaseVideoProvider::__construct()` signature.
 
+## Model classes use `\DateTimeInterface`
+
+If you overrided some date-related methods (`setUpdatedAt`, `setCreatedAt`, `setCdnFlushAt`) in model classes (Gallery, Media, GalleryHasMedia),
+you need to change type hint of argument to `\DateTimeInterface`.
+
 UPGRADE FROM 3.25 to 3.26
 =========================
 

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -51,11 +51,6 @@ are required when aws/aws-sdk-php 3.x is installed.
 
 The `Guzzle` and `Buzz` dependencies are deprecated and will be replaced with the abstract `http-client` interface, so you can choose your preferred client implementation. You should adapt to the new `BaseVideoProvider::__construct()` signature.
 
-## Model classes use `\DateTimeInterface`
-
-If you overrided some date-related methods (`setUpdatedAt`, `setCreatedAt`, `setCdnFlushAt`) in model classes (Gallery, Media, GalleryHasMedia),
-you need to change type hint of argument to `\DateTimeInterface`.
-
 UPGRADE FROM 3.25 to 3.26
 =========================
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -49,6 +49,9 @@ If you have implemented a custom model, you must adapt the signature of the foll
  * `GalleryHasMediaInterface::getId`
  * `GalleryInterface::getId`
 
+If you overrided some date-related methods (`setUpdatedAt`, `setCreatedAt`, `setCdnFlushAt`) in model classes (Gallery, Media, GalleryHasMedia),
+you need to change type hint of argument to `\DateTimeInterface`.
+
 ## Renamed GalleryHasMedia to GalleryItem
 
 All Actions, Controllers, Interfaces and anything related to this is renamed accordingly.

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -49,8 +49,8 @@ If you have implemented a custom model, you must adapt the signature of the foll
  * `GalleryHasMediaInterface::getId`
  * `GalleryInterface::getId`
 
-If you overrided some date-related methods (`setUpdatedAt`, `setCreatedAt`, `setCdnFlushAt`) in model classes (Gallery, Media, GalleryHasMedia),
-you need to change type hint of argument to `\DateTimeInterface`.
+If you have overridden some date-related methods (`setUpdatedAt()`, `setCreatedAt()`, `setCdnFlushAt()`) in model classes (`Gallery`, `Media`, `GalleryHasMedia`),
+you need to change the arguments' type declarations to `\DateTimeInterface`.
 
 ## Renamed GalleryHasMedia to GalleryItem
 

--- a/src/Model/Gallery.php
+++ b/src/Model/Gallery.php
@@ -35,12 +35,12 @@ abstract class Gallery implements GalleryInterface
     protected $enabled;
 
     /**
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
     protected $updatedAt;
 
     /**
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
     protected $createdAt;
 
@@ -79,7 +79,7 @@ abstract class Gallery implements GalleryInterface
         return $this->enabled;
     }
 
-    public function setUpdatedAt(?\DateTime $updatedAt = null): void
+    public function setUpdatedAt(?\DateTimeInterface $updatedAt = null): void
     {
         $this->updatedAt = $updatedAt;
     }
@@ -89,7 +89,7 @@ abstract class Gallery implements GalleryInterface
         return $this->updatedAt;
     }
 
-    public function setCreatedAt(?\DateTime $createdAt = null): void
+    public function setCreatedAt(?\DateTimeInterface $createdAt = null): void
     {
         $this->createdAt = $createdAt;
     }

--- a/src/Model/GalleryInterface.php
+++ b/src/Model/GalleryInterface.php
@@ -70,24 +70,24 @@ interface GalleryInterface
     /**
      * Set updated_at.
      */
-    public function setUpdatedAt(?\DateTime $updatedAt = null);
+    public function setUpdatedAt(?\DateTimeInterface $updatedAt = null);
 
     /**
      * Get updated_at.
      *
-     * @return \DateTime|null $updatedAt
+     * @return \DateTimeInterface|null $updatedAt
      */
     public function getUpdatedAt();
 
     /**
      * Set created_at.
      */
-    public function setCreatedAt(?\DateTime $createdAt = null);
+    public function setCreatedAt(?\DateTimeInterface $createdAt = null);
 
     /**
      * Get created_at.
      *
-     * @return \DateTime|null $createdAt
+     * @return \DateTimeInterface|null $createdAt
      */
     public function getCreatedAt();
 

--- a/src/Model/GalleryItem.php
+++ b/src/Model/GalleryItem.php
@@ -31,12 +31,12 @@ abstract class GalleryItem implements GalleryItemInterface
     protected $position = 0;
 
     /**
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
     protected $updatedAt;
 
     /**
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
     protected $createdAt;
 
@@ -50,7 +50,7 @@ abstract class GalleryItem implements GalleryItemInterface
         return $this->getGallery().' | '.$this->getMedia();
     }
 
-    public function setCreatedAt(?\DateTime $createdAt = null): void
+    public function setCreatedAt(?\DateTimeInterface $createdAt = null): void
     {
         $this->createdAt = $createdAt;
     }
@@ -100,7 +100,7 @@ abstract class GalleryItem implements GalleryItemInterface
         return $this->position;
     }
 
-    public function setUpdatedAt(?\DateTime $updatedAt = null): void
+    public function setUpdatedAt(?\DateTimeInterface $updatedAt = null): void
     {
         $this->updatedAt = $updatedAt;
     }

--- a/src/Model/GalleryItemInterface.php
+++ b/src/Model/GalleryItemInterface.php
@@ -61,17 +61,17 @@ interface GalleryItemInterface
      */
     public function getPosition();
 
-    public function setUpdatedAt(?\DateTime $updatedAt = null);
+    public function setUpdatedAt(?\DateTimeInterface $updatedAt = null);
 
     /**
-     * @return \DateTime|null
+     * @return \DateTimeInterface|null
      */
     public function getUpdatedAt();
 
-    public function setCreatedAt(?\DateTime $createdAt = null);
+    public function setCreatedAt(?\DateTimeInterface $createdAt = null);
 
     /**
-     * @return \DateTime|null
+     * @return \DateTimeInterface|null
      */
     public function getCreatedAt();
 }

--- a/src/Model/Media.php
+++ b/src/Model/Media.php
@@ -94,7 +94,7 @@ abstract class Media implements MediaInterface
     protected $cdnFlushIdentifier;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $cdnFlushAt;
 
@@ -104,12 +104,12 @@ abstract class Media implements MediaInterface
     protected $cdnStatus;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $updatedAt;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $createdAt;
 
@@ -363,7 +363,7 @@ abstract class Media implements MediaInterface
         return $this->cdnFlushIdentifier;
     }
 
-    public function setCdnFlushAt(?\DateTime $cdnFlushAt = null): void
+    public function setCdnFlushAt(?\DateTimeInterface $cdnFlushAt = null): void
     {
         $this->cdnFlushAt = $cdnFlushAt;
     }
@@ -373,7 +373,7 @@ abstract class Media implements MediaInterface
         return $this->cdnFlushAt;
     }
 
-    public function setUpdatedAt(?\DateTime $updatedAt = null): void
+    public function setUpdatedAt(?\DateTimeInterface $updatedAt = null): void
     {
         $this->updatedAt = $updatedAt;
     }
@@ -383,7 +383,7 @@ abstract class Media implements MediaInterface
         return $this->updatedAt;
     }
 
-    public function setCreatedAt(?\DateTime $createdAt = null): void
+    public function setCreatedAt(?\DateTimeInterface $createdAt = null): void
     {
         $this->createdAt = $createdAt;
     }

--- a/src/Model/MediaInterface.php
+++ b/src/Model/MediaInterface.php
@@ -277,12 +277,12 @@ interface MediaInterface
      *
      * @param \DateTime $cdnFlushAt
      */
-    public function setCdnFlushAt(?\DateTime $cdnFlushAt = null);
+    public function setCdnFlushAt(?\DateTimeInterface $cdnFlushAt = null);
 
     /**
      * Get cdn_flush_at.
      *
-     * @return \DateTime $cdnFlushAt
+     * @return \DateTimeInterface $cdnFlushAt
      */
     public function getCdnFlushAt();
 
@@ -291,12 +291,12 @@ interface MediaInterface
      *
      * @param \DateTime $updatedAt
      */
-    public function setUpdatedAt(?\DateTime $updatedAt = null);
+    public function setUpdatedAt(?\DateTimeInterface $updatedAt = null);
 
     /**
      * Get updated_at.
      *
-     * @return \DateTime $updatedAt
+     * @return \DateTimeInterface $updatedAt
      */
     public function getUpdatedAt();
 
@@ -305,12 +305,12 @@ interface MediaInterface
      *
      * @param \DateTime $createdAt
      */
-    public function setCreatedAt(?\DateTime $createdAt = null);
+    public function setCreatedAt(?\DateTimeInterface $createdAt = null);
 
     /**
      * Get created_at.
      *
-     * @return \DateTime $createdAt
+     * @return \DateTimeInterface $createdAt
      */
     public function getCreatedAt();
 

--- a/tests/CDN/PantherPortalTest.php
+++ b/tests/CDN/PantherPortalTest.php
@@ -18,6 +18,9 @@ use Sonata\MediaBundle\CDN\PantherPortal;
 
 class PantherPortalTest extends TestCase
 {
+    /**
+     * @requires extension soap
+     */
     public function testPortal(): void
     {
         $client = $this->createMock(ClientSpy::class);
@@ -35,6 +38,9 @@ class PantherPortalTest extends TestCase
         $panther->flushPaths([$path]);
     }
 
+    /**
+     * @requires extension soap
+     */
     public function testException(): void
     {
         $this->expectException(\RuntimeException::class);
@@ -50,10 +56,12 @@ class PantherPortalTest extends TestCase
     }
 }
 
-class ClientSpy extends \SoapClient
-{
-    public function flush(): string
+if (class_exists(\SoapClient::class)) {
+    class ClientSpy extends \SoapClient
     {
-        return 'hello';
+        public function flush(): string
+        {
+            return 'hello';
+        }
     }
 }

--- a/tests/Entity/MediaTest.php
+++ b/tests/Entity/MediaTest.php
@@ -66,8 +66,8 @@ class MediaTest extends TestCase
         $this->assertSame('Thomas', $media->getAuthorName());
         $this->assertTrue($media->getCdnIsFlushable());
         $this->assertSame('identifier_123', $media->getCdnFlushIdentifier());
-        $this->assertInstanceOf('DateTime', $media->getCdnFlushAt());
-        $this->assertInstanceOf('DateTime', $media->getCreatedAt());
+        $this->assertInstanceOf(\DateTimeInterface::class, $media->getCdnFlushAt());
+        $this->assertInstanceOf(\DateTimeInterface::class, $media->getCreatedAt());
         $this->assertSame('sonata/media', $media->getContentType());
         $this->assertSame('MediaBundle', (string) $media);
 

--- a/tests/Form/Type/MediaTypeTest.php
+++ b/tests/Form/Type/MediaTypeTest.php
@@ -69,6 +69,9 @@ class MediaTypeTest extends AbstractTypeTest
         $this->factory->create($this->getFormType(), null);
     }
 
+    /**
+     * @requires extension gd
+     */
     public function testMissingFormContextOption(): void
     {
         $this->mediaPool->method('getProviderList')->willReturn([
@@ -127,6 +130,9 @@ class MediaTypeTest extends AbstractTypeTest
         ]);
     }
 
+    /**
+     * @requires extension gd
+     */
     public function testInvalidFormContextOption(): void
     {
         $this->mediaPool->method('getProviderList')->willReturn([

--- a/tests/Functional/Controller/TruncateControllerTest.php
+++ b/tests/Functional/Controller/TruncateControllerTest.php
@@ -21,6 +21,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 final class TruncateControllerTest extends TestCase
 {
+    /**
+     * @requires extension gd
+     */
     public function testTruncate(): void
     {
         $client = new KernelBrowser(new AppKernel());

--- a/tests/Provider/FileProviderTest.php
+++ b/tests/Provider/FileProviderTest.php
@@ -136,7 +136,7 @@ class FileProviderTest extends AbstractProviderTest
         $media->setBinaryContent($file);
         $this->provider->transform($media);
 
-        $this->assertInstanceOf(\DateTime::class, $media->getUpdatedAt());
+        $this->assertInstanceOf(\DateTimeInterface::class, $media->getUpdatedAt());
         $this->assertNotNull($media->getProviderReference());
 
         $this->provider->postUpdate($media);


### PR DESCRIPTION
## Subject

As detailed in related issue, this PR replace type hints and return type of DateTime with broader DateTimeInterface, allowing to use DateTimeImmutable.

I am targeting this branch, because change is BC.

Closes #1710

## Changelog

Replaced DateTime type hints and return types with DateTimeInterface 

```markdown
### Changed
- Replaced DateTime type hints and return types with DateTimeInterface 
```

Added some checks in testing, to skip tests when not appliable.
Notice that this can be fixed in some other ways (e.g. by forcing some requires in dev). Anyway, I couldn't run my tests without such changes.
