### PR TITLE
Add support for doctrine/persistence 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,7 @@
     "conflict": {
         "doctrine/dbal": "<2.6.0",
         "doctrine/mongodb-odm": "<2.0",
+        "doctrine/persistence": "<1.3",
         "friendsofsymfony/rest-bundle": "<2.6",
         "jms/serializer": "<0.13",
         "liip/imagine-bundle": "<1.9",

--- a/src/Listener/PHPCR/MediaEventSubscriber.php
+++ b/src/Listener/PHPCR/MediaEventSubscriber.php
@@ -36,7 +36,7 @@ class MediaEventSubscriber extends BaseMediaEventSubscriber
 
     protected function recomputeSingleEntityChangeSet(EventArgs $args)
     {
-        /* @var $args \Doctrine\Common\Persistence\Event\LifecycleEventArgs */
+        /* @var $args \Doctrine\Persistence\Event\LifecycleEventArgs */
         /** @var $dm \Doctrine\ODM\PHPCR\DocumentManager */
         $dm = $args->getObjectManager();
 

--- a/tests/Document/MediaManagerTest.php
+++ b/tests/Document/MediaManagerTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Tests\Document;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
 use Sonata\MediaBundle\Document\MediaManager;
 use Sonata\MediaBundle\Model\MediaInterface;

--- a/tests/Entity/GalleryManagerTest.php
+++ b/tests/Entity/GalleryManagerTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Test\Entity;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\Doctrine\Test\EntityManagerMockFactoryTrait;

--- a/tests/Entity/MediaManagerTest.php
+++ b/tests/Entity/MediaManagerTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Test\Entity;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\Doctrine\Test\EntityManagerMockFactoryTrait;

--- a/tests/PHPCR/MediaManagerTest.php
+++ b/tests/PHPCR/MediaManagerTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Tests\PHPCR;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\PHPCR\MediaManager;


### PR DESCRIPTION
## Subject

Since https://github.com/sonata-project/SonataNotificationBundle/releases/tag/3.11.0, we can use doctrine/persistence 2 in this bundle ; that's why tests are failing. I fixed this.
