### PR TITLE
Replace PageableManagerInterface in favor for PageableInterface

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,21 @@ UPGRADE 3.x
 UPGRADE FROM 3.x to 3.x
 =======================
 
+### Remove deprecated calls
+
+- `Sonata\Doctrine\Model\PageableManagerInterface` is no longer used in profit of `Sonata\DatagridBundle\Pager\PageableInterface`
+
+### Dependencies
+
+- drop support for `sonata-project/datagrid-bundle` < ^3.0.
+
+    If you are extending these method you MUST add argument and return type declarations:
+
+    - `Sonata\MediaBundle\Entity\GalleryManager::getPager()`
+    - `Sonata\MediaBundle\Entity\MediaManager::getPager()`
+    - `Sonata\MediaBundle\Model\MediaManager::getPager()`
+    - `Sonata\MediaBundle\Model\MediaManager::getPager()`
+
 ### Sonata\MediaBundle\CDN\CloudFront
 
 The previous signature of `CloudFront::__construct()` is deprecated.

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -10,7 +10,7 @@ UPGRADE FROM 3.x to 3.x
 
 ### Dependencies
 
-- drop support for `sonata-project/datagrid-bundle` < 3.0.
+- Drop support for `sonata-project/datagrid-bundle` < 3.0.
 
     If you are extending these methods, you MUST add argument and return type declarations:
 

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -6,17 +6,17 @@ UPGRADE FROM 3.x to 3.x
 
 ### Remove deprecated calls
 
-- `Sonata\Doctrine\Model\PageableManagerInterface` is no longer used in profit of `Sonata\DatagridBundle\Pager\PageableInterface`
+- `Sonata\Doctrine\Model\PageableManagerInterface` is no longer used in profit of `Sonata\DatagridBundle\Pager\PageableInterface`.
 
 ### Dependencies
 
-- drop support for `sonata-project/datagrid-bundle` < ^3.0.
+- drop support for `sonata-project/datagrid-bundle` < 3.0.
 
-    If you are extending these method you MUST add argument and return type declarations:
+    If you are extending these methods, you MUST add argument and return type declarations:
 
     - `Sonata\MediaBundle\Entity\GalleryManager::getPager()`
     - `Sonata\MediaBundle\Entity\MediaManager::getPager()`
-    - `Sonata\MediaBundle\Model\MediaManager::getPager()`
+    - `Sonata\MediaBundle\Model\GalleryManager::getPager()`
     - `Sonata\MediaBundle\Model\MediaManager::getPager()`
 
 ### Sonata\MediaBundle\CDN\CloudFront

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,9 +4,9 @@ UPGRADE 3.x
 UPGRADE FROM 3.x to 3.x
 =======================
 
-### Remove deprecated calls
+### Sonata\DatagridBundle\Pager\PageableInterface
 
-- `Sonata\Doctrine\Model\PageableManagerInterface` is no longer used in profit of `Sonata\DatagridBundle\Pager\PageableInterface`.
+- Usages of `Sonata\Doctrine\Model\PageableManagerInterface` were replaced in favor of `Sonata\DatagridBundle\Pager\PageableInterface`.
 
 ### Dependencies
 

--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
         "nelmio/api-doc-bundle": "^2.13.4",
         "sonata-project/admin-bundle": "^3.41",
         "sonata-project/block-bundle": "^3.17",
-        "sonata-project/datagrid-bundle": "^3.0",
+        "sonata-project/datagrid-bundle": "^3.0.1",
         "sonata-project/doctrine-orm-admin-bundle": "^3.14",
         "sonata-project/notification-bundle": "^3.3",
         "sonata-project/seo-bundle": "^2.5",

--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
         "nelmio/api-doc-bundle": "^2.13.4",
         "sonata-project/admin-bundle": "^3.41",
         "sonata-project/block-bundle": "^3.17",
-        "sonata-project/datagrid-bundle": "^2.5 || ^3.0",
+        "sonata-project/datagrid-bundle": "^3.0",
         "sonata-project/doctrine-orm-admin-bundle": "^3.14",
         "sonata-project/notification-bundle": "^3.3",
         "sonata-project/seo-bundle": "^2.5",

--- a/src/Controller/Api/GalleryController.php
+++ b/src/Controller/Api/GalleryController.php
@@ -110,7 +110,7 @@ class GalleryController
             $sort = [$sort => 'asc'];
         }
 
-        return $this->getGalleryManager()->getPager($criteria, $page, $limit, $sort);
+        return $this->getGalleryManager()->getPager($criteria, (int) $page, (int) $limit, $sort);
     }
 
     /**

--- a/src/Controller/Api/MediaController.php
+++ b/src/Controller/Api/MediaController.php
@@ -132,7 +132,7 @@ class MediaController
             $sort = [$sort => 'asc'];
         }
 
-        return $this->mediaManager->getPager($criteria, $page, $limit, $sort);
+        return $this->mediaManager->getPager($criteria, (int) $page, (int) $limit, $sort);
     }
 
     /**

--- a/src/Document/GalleryManager.php
+++ b/src/Document/GalleryManager.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Document;
 
+use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\Doctrine\Document\BaseDocumentManager;
 use Sonata\MediaBundle\Model\GalleryInterface;
 use Sonata\MediaBundle\Model\GalleryManagerInterface;
@@ -34,7 +35,7 @@ class GalleryManager extends BaseDocumentManager implements GalleryManagerInterf
         parent::save($gallery);
     }
 
-    public function getPager(array $criteria, $page, $limit = 10, array $sort = [])
+    public function getPager(array $criteria, int $page, int $limit = 10, array $sort = []): PagerInterface
     {
         throw new \RuntimeException('Not Implemented yet');
     }

--- a/src/Document/MediaManager.php
+++ b/src/Document/MediaManager.php
@@ -13,12 +13,14 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Document;
 
+use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\Doctrine\Document\BaseDocumentManager;
+use Sonata\MediaBundle\Model\MediaManagerInterface;
 
 /**
  * @final since sonata-project/media-bundle 3.21.0
  */
-class MediaManager extends BaseDocumentManager
+class MediaManager extends BaseDocumentManager implements MediaManagerInterface
 {
     public function save($entity, $andFlush = true)
     {
@@ -40,7 +42,7 @@ class MediaManager extends BaseDocumentManager
         }
     }
 
-    public function getPager(array $criteria, $page, $limit = 10, array $sort = [])
+    public function getPager(array $criteria, int $page, int $limit = 10, array $sort = []): PagerInterface
     {
         throw new \RuntimeException('Not Implemented yet');
     }

--- a/src/Entity/GalleryManager.php
+++ b/src/Entity/GalleryManager.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\MediaBundle\Entity;
 
 use Sonata\DatagridBundle\Pager\Doctrine\Pager;
+use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;
 use Sonata\Doctrine\Entity\BaseEntityManager;
 use Sonata\MediaBundle\Model\GalleryInterface;
@@ -36,7 +37,7 @@ class GalleryManager extends BaseEntityManager implements GalleryManagerInterfac
         parent::save($gallery);
     }
 
-    public function getPager(array $criteria, $page, $limit = 10, array $sort = [])
+    public function getPager(array $criteria, int $page, int $limit = 10, array $sort = []): PagerInterface
     {
         $query = $this->getRepository()
             ->createQueryBuilder('g')

--- a/src/Entity/MediaManager.php
+++ b/src/Entity/MediaManager.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\MediaBundle\Entity;
 
 use Sonata\DatagridBundle\Pager\Doctrine\Pager;
+use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;
 use Sonata\Doctrine\Entity\BaseEntityManager;
 use Sonata\MediaBundle\Model\MediaManagerInterface;
@@ -47,7 +48,7 @@ class MediaManager extends BaseEntityManager implements MediaManagerInterface
         }
     }
 
-    public function getPager(array $criteria, $page, $limit = 10, array $sort = [])
+    public function getPager(array $criteria, int $page, int $limit = 10, array $sort = []): PagerInterface
     {
         $query = $this->getRepository()
             ->createQueryBuilder('m')

--- a/src/Model/GalleryManagerInterface.php
+++ b/src/Model/GalleryManagerInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Model;
 
+use Sonata\DatagridBundle\Pager\PageableInterface;
 use Sonata\Doctrine\Model\ManagerInterface;
-use Sonata\Doctrine\Model\PageableManagerInterface;
 
-interface GalleryManagerInterface extends ManagerInterface, PageableManagerInterface
+interface GalleryManagerInterface extends ManagerInterface, PageableInterface
 {
 }

--- a/src/Model/MediaManagerInterface.php
+++ b/src/Model/MediaManagerInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Model;
 
+use Sonata\DatagridBundle\Pager\PageableInterface;
 use Sonata\Doctrine\Model\ManagerInterface;
-use Sonata\Doctrine\Model\PageableManagerInterface;
 
-interface MediaManagerInterface extends ManagerInterface, PageableManagerInterface
+interface MediaManagerInterface extends ManagerInterface, PageableInterface
 {
 }

--- a/src/Model/NoDriverManager.php
+++ b/src/Model/NoDriverManager.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Model;
 
+use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\MediaBundle\Exception\NoDriverException;
 
 /**
@@ -87,7 +88,7 @@ final class NoDriverManager implements GalleryManagerInterface, MediaManagerInte
         throw new NoDriverException();
     }
 
-    public function getPager(array $criteria, $page, $limit = 10, array $sort = [])
+    public function getPager(array $criteria, int $page, int $limit = 10, array $sort = []): PagerInterface
     {
         throw new NoDriverException();
     }

--- a/tests/Controller/Api/GalleryControllerTest.php
+++ b/tests/Controller/Api/GalleryControllerTest.php
@@ -17,6 +17,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use FOS\RestBundle\Request\ParamFetcherInterface;
 use FOS\RestBundle\View\View;
 use PHPUnit\Framework\TestCase;
+use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\MediaBundle\Controller\Api\GalleryController;
 use Sonata\MediaBundle\Model\GalleryHasMediaInterface;
 use Sonata\MediaBundle\Model\GalleryInterface;
@@ -36,11 +37,12 @@ class GalleryControllerTest extends TestCase
 {
     public function testGetGalleriesAction(): void
     {
+        $pager = $this->createStub(PagerInterface::class);
         $gManager = $this->createMock(GalleryManagerInterface::class);
         $mediaManager = $this->createMock(MediaManagerInterface::class);
         $formFactory = $this->createMock(FormFactoryInterface::class);
 
-        $gManager->expects($this->once())->method('getPager')->willReturn([]);
+        $gManager->expects($this->once())->method('getPager')->willReturn($pager);
 
         $gController = new GalleryController($gManager, $mediaManager, $formFactory, 'test');
 
@@ -48,7 +50,7 @@ class GalleryControllerTest extends TestCase
         $paramFetcher->expects($this->exactly(3))->method('get');
         $paramFetcher->expects($this->once())->method('all')->willReturn([]);
 
-        $this->assertSame([], $gController->getGalleriesAction($paramFetcher));
+        $this->assertSame($pager, $gController->getGalleriesAction($paramFetcher));
     }
 
     public function testGetGalleryAction(): void

--- a/tests/Controller/Api/MediaControllerTest.php
+++ b/tests/Controller/Api/MediaControllerTest.php
@@ -16,6 +16,7 @@ namespace Sonata\MediaBundle\Tests\Controller\Api;
 use FOS\RestBundle\Request\ParamFetcherInterface;
 use FOS\RestBundle\View\View;
 use PHPUnit\Framework\TestCase;
+use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\MediaBundle\Controller\Api\MediaController;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Model\MediaManagerInterface;
@@ -34,10 +35,10 @@ class MediaControllerTest extends TestCase
 {
     public function testGetMediaAction(): void
     {
+        $pager = $this->createStub(PagerInterface::class);
         $mManager = $this->createMock(MediaManagerInterface::class);
-        $media = $this->createMock(MediaInterface::class);
 
-        $mManager->expects($this->once())->method('getPager')->willReturn([$media]);
+        $mManager->expects($this->once())->method('getPager')->willReturn($pager);
 
         $mController = $this->createMediaController($mManager);
 
@@ -45,7 +46,7 @@ class MediaControllerTest extends TestCase
         $paramFetcher->expects($this->exactly(3))->method('get');
         $paramFetcher->expects($this->once())->method('all')->willReturn([]);
 
-        $this->assertSame([$media], $mController->getMediaAction($paramFetcher));
+        $this->assertSame($pager, $mController->getMediaAction($paramFetcher));
     }
 
     public function testGetMediumAction(): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change should be done here. They provide little BC-break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1871.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Change using `Sonata\Doctrine\Model\PageableManagerInterface` in favor of `Sonata\DatagridBundle\Pager\PageableInterface`
### Removed
- Removed support for `sonata-project/datagrid-bundle` < 3.0
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
