### PR TITLE
Narrow some constructor types for `RolesDownloadStrategy` and `SessionDownloadStrategy`

### DIFF
--- a/src/Security/RolesDownloadStrategy.php
+++ b/src/Security/RolesDownloadStrategy.php
@@ -40,15 +40,10 @@ class RolesDownloadStrategy implements DownloadStrategyInterface
     protected $translator;
 
     /**
-     * @param AuthorizationCheckerInterface $security
-     * @param string[]                      $roles
+     * @param string[] $roles
      */
-    public function __construct(TranslatorInterface $translator, $security, array $roles = [])
+    public function __construct(TranslatorInterface $translator, AuthorizationCheckerInterface $security, array $roles = [])
     {
-        if (!$security instanceof AuthorizationCheckerInterface) {
-            throw new \InvalidArgumentException('Argument 2 should be an instance of Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
-        }
-
         $this->roles = $roles;
         $this->security = $security;
         $this->translator = $translator;

--- a/tests/Security/SessionDownloadStrategyTest.php
+++ b/tests/Security/SessionDownloadStrategyTest.php
@@ -19,6 +19,7 @@ use Sonata\MediaBundle\Security\SessionDownloadStrategy;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\Translation\Translator;
 use Symfony\Component\Translation\TranslatorInterface;
 
 /**
@@ -84,10 +85,8 @@ final class SessionDownloadStrategyTest extends TestCase
 
     public function testInvalidArgumentException(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(\TypeError::class);
 
-        $translator = $this->createMock(TranslatorInterface::class);
-
-        new SessionDownloadStrategy($translator, 'foo', 1);
+        new SessionDownloadStrategy(new Translator('es_AR'), 'foo', 1);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Narrow some constructor type for `RolesDownloadStrategy` and `SessionSessionDownloadStrategy`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Related to comments at #1923.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Stricter type checks for arguments at `RolesDownloadStrategy::__construct()`;
- Stricter type checks for arguments at `SessionDownloadStrategy::__construct()`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
