### PR TITLE
Add CropResizer

### DIFF
--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -152,7 +152,7 @@ Full configuration options:
 
             image:
                 service:    sonata.media.provider.image
-                resizer:    sonata.media.resizer.simple # sonata.media.resizer.square
+                resizer:    sonata.media.resizer.simple # sonata.media.resizer.square, sonata.media.resizer.crop
                 filesystem: sonata.media.filesystem.local
                 cdn:        sonata.media.cdn.server
                 generator:  sonata.media.generator.default

--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -111,7 +111,7 @@ SonataMediaBundle Configuration
     a transversal ``admin`` format to be used by the ``mediaadmin`` class.
 
 Also, you can determine the resizer to use; the default value is
-``sonata.media.resizer.simple`` but you can change it to ``sonata.media.resizer.square``
+``sonata.media.resizer.simple`` but you can change it to ``sonata.media.resizer.square`` or ``sonata.media.resizer.crop``
 
 .. code-block:: yaml
 
@@ -127,6 +127,9 @@ Also, you can determine the resizer to use; the default value is
     The square resizer works like the simple resizer when the image format has
     only the width. But if you specify the height the resizer crop the image in
     the lower size.
+
+    The crop resizer crops the image to the exact width and height. This is done by
+    resizing the image first and cropping the unwanted parts at the end.
 
 Doctrine ORM Configuration
 --------------------------

--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -548,6 +548,16 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
 
     private function configureResizers(ContainerBuilder $container, array $config): void
     {
+        if ($container->hasParameter('sonata.media.resizer.crop.class')) {
+            $class = $container->getParameter('sonata.media.resizer.crop.class');
+            $definition = new Definition($class, [
+                new Reference('sonata.media.adapter.image.default'),
+                new Reference('sonata.media.metadata.proxy'),
+            ]);
+            $definition->addTag('sonata.media.resizer');
+            $container->setDefinition('sonata.media.resizer.crop', $definition);
+        }
+
         if ($container->hasParameter('sonata.media.resizer.simple.class')) {
             $class = $container->getParameter('sonata.media.resizer.simple.class');
             $definition = new Definition($class, [

--- a/src/Resizer/CropResizer.php
+++ b/src/Resizer/CropResizer.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Resizer;
+
+use Gaufrette\File;
+use Imagine\Image\Box;
+use Imagine\Image\ImageInterface;
+use Imagine\Image\ImagineInterface;
+use Imagine\Image\Point;
+use Sonata\MediaBundle\Metadata\MetadataBuilderInterface;
+use Sonata\MediaBundle\Model\MediaInterface;
+
+/**
+ * @author Christian Gripp <mail@core23.de>
+ */
+final class CropResizer implements ResizerInterface
+{
+    /**
+     * @var ImagineInterface
+     */
+    private $adapter;
+
+    /**
+     * @var MetadataBuilderInterface
+     */
+    private $metadata;
+
+    public function __construct(ImagineInterface $adapter, MetadataBuilderInterface $metadata)
+    {
+        $this->adapter = $adapter;
+        $this->metadata = $metadata;
+    }
+
+    public function resize(MediaInterface $media, File $in, File $out, $format, array $settings): void
+    {
+        if (!isset($settings['width'])) {
+            throw new \InvalidArgumentException(sprintf(
+                'The "width" parameter is missing in context "%s" for provider "%s".',
+                $media->getContext(),
+                $media->getProviderName()
+            ));
+        }
+
+        if (!isset($settings['height'])) {
+            throw new \InvalidArgumentException(sprintf(
+                'The "height" parameter is missing in context "%s" for provider "%s".',
+                $media->getContext(),
+                $media->getProviderName()
+            ));
+        }
+
+        $image = $this->adapter->load($in->getContent());
+
+        $sourceSize = $media->getBox();
+        $targetSize = $this->createTargetBox($settings);
+
+        if ($this->shouldModify($sourceSize, $targetSize)) {
+            $image = $this->cropImage($image, $sourceSize, $targetSize);
+        }
+
+        // Always change format and quality
+        $content = $image->get($format, [
+            'quality' => $settings['quality'],
+        ]);
+
+        $out->setContent($content, $this->metadata->get($media, $out->getName()));
+    }
+
+    public function getBox(MediaInterface $media, array $settings): Box
+    {
+        $sourceSize = $media->getBox();
+        $targetSize = $this->createTargetBox($settings);
+
+        return new Box(
+            min($sourceSize->getWidth(), $targetSize->getWidth()),
+            min($sourceSize->getHeight(), $targetSize->getHeight())
+        );
+    }
+
+    /**
+     * @param array<string, int> $settings
+     *
+     * @phpstan-param array{width: int, height: int} $settings
+     */
+    private function createTargetBox(array $settings): Box
+    {
+        return new Box($settings['width'], $settings['height']);
+    }
+
+    private function shouldModify(Box $sourceSize, Box $targetSize): bool
+    {
+        return !($sourceSize->getWidth() <= $targetSize->getWidth() && $sourceSize->getHeight() <= $targetSize->getHeight());
+    }
+
+    private function shouldResize(Box $sourceSize, Box $targetSize): bool
+    {
+        if ($sourceSize->getWidth() <= $targetSize->getWidth()) {
+            return false;
+        }
+
+        return $sourceSize->getHeight() > $targetSize->getHeight();
+    }
+
+    private function shouldCrop(Box $sourceSize, Box $targetSize): bool
+    {
+        return $sourceSize->getWidth() > $targetSize->getWidth() || $sourceSize->getHeight() > $targetSize->getHeight();
+    }
+
+    private function cropImage(ImageInterface $image, Box $sourceSize, Box $targetSize): ImageInterface
+    {
+        if ($this->shouldResize($sourceSize, $targetSize)) {
+            $scaleSize = $this->createBox($sourceSize, $targetSize, false);
+
+            $image = $image->thumbnail($scaleSize, 'outbound');
+
+            $sourceSize = $scaleSize;
+        }
+
+        if ($this->shouldCrop($sourceSize, $targetSize)) {
+            $cropSize = new Box(
+                min($sourceSize->getWidth(), $targetSize->getWidth()),
+                min($sourceSize->getHeight(), $targetSize->getHeight())
+            );
+
+            $point = new Point(
+                (int) (($sourceSize->getWidth() - $cropSize->getWidth()) / 2),
+                (int) (($sourceSize->getHeight() - $cropSize->getHeight()) / 2)
+            );
+
+            $image = $image->crop($point, $cropSize);
+        }
+
+        return $image;
+    }
+
+    private function createBox(Box $sourceSize, Box $targetSize, bool $smallest = true): Box
+    {
+        $widthRatio = (float) ($targetSize->getWidth() / $sourceSize->getWidth());
+        $heightRatio = (float) ($targetSize->getHeight() / $sourceSize->getHeight());
+
+        if (0.0 !== $widthRatio - $heightRatio) {
+            return $sourceSize->scale(
+                $smallest ? min($widthRatio, $heightRatio) : max($widthRatio, $heightRatio)
+            );
+        }
+
+        if ($targetSize->getHeight() >= $sourceSize->getHeight()) {
+            return $sourceSize;
+        }
+
+        if ($targetSize->getWidth() >= $sourceSize->getWidth()) {
+            return $sourceSize;
+        }
+
+        return $targetSize;
+    }
+}

--- a/src/Resizer/ResizerInterface.php
+++ b/src/Resizer/ResizerInterface.php
@@ -20,11 +20,14 @@ use Sonata\MediaBundle\Model\MediaInterface;
 interface ResizerInterface
 {
     /**
-     * @param string $format
+     * @param string               $format
+     * @param array<string, mixed> $settings
      */
     public function resize(MediaInterface $media, File $in, File $out, $format, array $settings);
 
     /**
+     * @param array<string, mixed> $settings
+     *
      * @return Box
      */
     public function getBox(MediaInterface $media, array $settings);

--- a/src/Resources/config/media.xml
+++ b/src/Resources/config/media.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
+        <parameter key="sonata.media.resizer.crop.class">Sonata\MediaBundle\Resizer\CropResizer</parameter>
         <parameter key="sonata.media.resizer.simple.class">Sonata\MediaBundle\Resizer\SimpleResizer</parameter>
         <parameter key="sonata.media.resizer.square.class">Sonata\MediaBundle\Resizer\SquareResizer</parameter>
         <parameter key="sonata.media.adapter.image.gd.class">Imagine\Gd\Imagine</parameter>

--- a/tests/Resizer/CropResizerTest.php
+++ b/tests/Resizer/CropResizerTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Tests\Resizer;
+
+use Gaufrette\File;
+use Imagine\Image\Box;
+use Imagine\Image\ImageInterface;
+use Imagine\Image\ImagineInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sonata\MediaBundle\Metadata\MetadataBuilderInterface;
+use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Resizer\CropResizer;
+
+/**
+ * @author Christian Gripp <mail@core23.de>
+ */
+final class CropResizerTest extends TestCase
+{
+    private const FORMAT = 'format';
+
+    private const QUALITY = 75;
+
+    /**
+     * @var ImagineInterface&MockObject
+     */
+    private $adapter;
+
+    /**
+     * @var MockObject&MetadataBuilderInterface
+     */
+    private $metadata;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->adapter = $this->createMock(ImagineInterface::class);
+        $this->metadata = $this->createStub(MetadataBuilderInterface::class);
+    }
+
+    /**
+     * @dataProvider getResizeProvider
+     */
+    public function testResize(
+        int $srcWidth,
+        int $srcHeight,
+        int $targetWidth,
+        int $targetHeight,
+        int $scaleWidth,
+        int $scaleHeight,
+        int $cropWidth,
+        int $cropHeight
+    ): void {
+        $media = $this->createMock(MediaInterface::class);
+        $media->method('getContext')->willReturn('sample');
+        $media->method('getProviderName')->willReturn('acme.sample.provider');
+        $media->method('getBox')->willReturn(new Box($srcWidth, $srcHeight));
+
+        $input = $this->createStub(File::class);
+        $output = $this->createStub(File::class);
+
+        $image = $this->createMock(ImageInterface::class);
+        $image->expects(0 === $scaleHeight && 0 === $scaleWidth ? static::never() : static::once())
+            ->method('thumbnail')
+            ->with(static::callback(static function (Box $box) use ($scaleWidth, $scaleHeight): bool {
+                return $box->getWidth() === $scaleWidth && $box->getHeight() === $scaleHeight;
+            }), static::equalTo('outbound'))
+            ->willReturnReference($image)
+        ;
+
+        $image->expects(0 === $cropWidth && 0 === $cropHeight ? static::never() : static::once())
+            ->method('crop')
+            ->with(static::anything(), static::callback(static function (Box $box) use ($cropWidth, $cropHeight): bool {
+                return $box->getWidth() === $cropWidth && $box->getHeight() === $cropHeight;
+            }))
+            ->willReturnReference($image)
+        ;
+
+        $image->method('get')
+            ->with(self::FORMAT, [
+                'quality' => self::QUALITY,
+            ])
+            ->willReturn('CONTENT')
+        ;
+
+        $this->adapter->method('load')->willReturn($image);
+
+        $resizer = new CropResizer($this->adapter, $this->metadata);
+        $resizer->resize($media, $input, $output, self::FORMAT, [
+            'width' => $targetWidth,
+            'height' => $targetHeight,
+            'quality' => self::QUALITY,
+        ]);
+    }
+
+    /**
+     * @return int[][]
+     */
+    public function getResizeProvider(): iterable
+    {
+        yield 'landscape: resize, no crop' => [800, 200, 400, 100, 400, 100, 0, 0];
+        yield 'landscape: resize, crop' => [800, 200, 600, 100, 600, 150, 600, 100];
+        yield 'landscape: no resize, crop' => [800, 200, 800, 100, 0, 0, 800, 100];
+
+        yield 'landscape to portrait: no resize, crop' => [800, 200, 200, 800, 0, 0, 200, 200];
+        yield 'landscape to portrait: resize, crop' => [8000, 4000, 400, 800, 1600, 800, 400, 800];
+
+        yield 'portrait: resize, no crop' => [200, 800, 100, 400, 100, 400, 0, 0];
+        yield 'portrait: resize, crop' => [200, 800, 100, 600, 150, 600, 100, 600];
+        yield 'portrait: no resize, crop' => [200, 800, 100, 800, 0, 0, 100, 800];
+
+        yield 'portrait to landscape: crop' => [200, 800, 800, 200, 0, 0, 200, 200];
+        yield 'portrait to landscape: resize, crop' => [4000, 8000, 800, 400, 800, 1600, 800, 400];
+
+        yield 'square: resize, no crop' => [200, 200, 100, 100, 100, 100, 0, 0];
+        yield 'square: no resize, no crop' => [200, 200, 200, 200, 0, 0, 0, 0];
+    }
+
+    /**
+     * @dataProvider getResizeNoChangeProvider
+     */
+    public function testResizeNoChange(
+        int $srcWidth,
+        int $srcHeight,
+        int $targetWidth,
+        int $targetHeight
+    ): void {
+        $media = $this->createMock(MediaInterface::class);
+        $media->method('getContext')->willReturn('sample');
+        $media->method('getProviderName')->willReturn('acme.sample.provider');
+        $media->method('getBox')->willReturn(new Box($srcWidth, $srcHeight));
+
+        $input = $this->createStub(File::class);
+        $output = $this->createStub(File::class);
+
+        $image = $this->createMock(ImageInterface::class);
+        $image->expects(static::never())->method('thumbnail');
+        $image->expects(static::never())->method('crop');
+
+        $image->method('get')
+            ->with(self::FORMAT, [
+                'quality' => self::QUALITY,
+            ])
+            ->willReturn('CONTENT')
+        ;
+
+        $this->adapter->method('load')->willReturn($image);
+
+        $resizer = new CropResizer($this->adapter, $this->metadata);
+        $resizer->resize($media, $input, $output, self::FORMAT, [
+            'width' => $targetWidth,
+            'height' => $targetHeight,
+            'quality' => self::QUALITY,
+        ]);
+    }
+
+    /**
+     * @return int[][]
+     */
+    public function getResizeNoChangeProvider(): iterable
+    {
+        yield 'landscape: match' => [800, 200, 800, 200];
+        yield 'landscape: small width' => [800, 100, 800, 200];
+        yield 'landscape: small height' => [700, 200, 800, 200];
+
+        yield 'portrait: match' => [200, 800, 200, 800];
+        yield 'portrait: small width' => [100, 800, 200, 800];
+        yield 'portrait: small height' => [200, 700, 200, 800];
+
+        yield 'square: match' => [200, 200, 200, 200];
+        yield 'square: small' => [100, 100, 200, 200];
+    }
+
+    /**
+     * @dataProvider getBoxProvider
+     */
+    public function testGetBox(int $srcWidth, int $srcHeight, int $targetWidth, int $targetHeight, int $expectWidth, int $expectHeight): void
+    {
+        $media = $this->createMock(MediaInterface::class);
+        $media->method('getWidth')
+            ->willReturn($srcWidth)
+        ;
+        $media->method('getHeight')
+            ->willReturn($srcHeight)
+        ;
+        $media->expects(static::once())->method('getBox')
+            ->willReturn(new Box($srcWidth, $srcHeight))
+        ;
+
+        $resizer = new CropResizer($this->adapter, $this->metadata);
+        $box = $resizer->getBox($media, ['width' => $targetWidth, 'height' => $targetHeight]);
+
+        static::assertSame($expectWidth, $box->getWidth(), 'width mismatch');
+        static::assertSame($expectHeight, $box->getHeight(), 'height mismatch');
+    }
+
+    /**
+     * @return int[][]
+     */
+    public function getBoxProvider(): iterable
+    {
+        yield 'source = target' => [800, 800, 800, 800, 800, 800];
+
+        yield 'square: same ratio' => [1000, 1000, 60, 60, 60, 60];
+        yield 'square: wrong ratio (width)' => [1000, 1000, 200, 100, 200, 100];
+        yield 'square: wrong ratio (height)' => [1000, 1000, 100, 200, 100, 200];
+        yield 'square: source too small' => [1000, 1000, 2000, 2000, 1000, 1000];
+        yield 'square: source too wide' => [1000, 1000, 2000, 100, 1000, 100];
+        yield 'square: source too high' => [1000, 1000, 100, 2000, 100, 1000];
+
+        yield 'landscape: same ratio' => [1000, 100, 600, 60, 600, 60];
+        yield 'landscape: wrong ratio (width)' => [1000, 100, 600, 30, 600, 30];
+        yield 'landscape: wrong ratio (height)' => [1000, 100, 400, 10, 400, 10];
+        yield 'landscape: source too small' => [1000, 100, 10000, 1000, 1000, 100];
+        yield 'landscape: source too wide' => [1000, 100, 2000, 100, 1000, 100];
+        yield 'landscape: source too high' => [1000, 100, 100, 2000, 100, 100];
+
+        yield 'portrait: same ratio' => [100, 1000, 60, 600, 60, 600];
+        yield 'portrait: wrong ratio (width)' => [100, 1000, 30, 600, 30, 600];
+        yield 'portrait: wrong ratio (height)' => [100, 1000, 10, 400, 10, 400];
+        yield 'portrait: source too small' => [100, 1000, 1000, 10000, 100, 1000];
+        yield 'portrait: source too wide' => [100, 1000, 2000, 100, 100, 100];
+        yield 'portrait: source too high' => [100, 1000, 100, 2000, 100, 1000];
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Adds a new resizer that is similar to the existing `SquareResizer`, but the result can have any image ratio.

The new resizer can crop the Image to a given ratio. When given an Image with 1200 x 700 and you want an image with the format 100 x 70, the resizer will first scale the image down to 120 x 70 and then crops the remaining parts down to 100 x 70.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this feature is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `CropResizer`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
