### PR TITLE
No deprecation message for classes that implement old and new TranslatorInterface

### DIFF
--- a/src/Security/ForbiddenDownloadStrategy.php
+++ b/src/Security/ForbiddenDownloadStrategy.php
@@ -30,22 +30,29 @@ class ForbiddenDownloadStrategy implements DownloadStrategyInterface
 
     public function __construct(object $translator)
     {
-        if ($translator instanceof LegacyTranslatorInterface) {
-            @trigger_error(sprintf(
-                'Passing other type than "%s" as argument 1 to "%s()" is deprecated since sonata-project/media-bundle 3.31'
-                .' and will throw a "%s" error in 4.0.',
-                TranslatorInterface::class,
-                __METHOD__,
-                \TypeError::class
-            ), \E_USER_DEPRECATED);
-        } elseif (!$translator instanceof TranslatorInterface) {
-            throw new \TypeError(sprintf(
-                'Argument 1 passed to "%s()" MUST be an instance of "%s" or "%s", "%s" given.',
-                __METHOD__,
-                LegacyTranslatorInterface::class,
-                TranslatorInterface::class,
-                \get_class($translator)
-            ));
+        if (!$translator instanceof TranslatorInterface) {
+            if (!$translator instanceof LegacyTranslatorInterface) {
+                throw new \TypeError(
+                    sprintf(
+                        'Argument 1 passed to "%s()" MUST be an instance of "%s" or "%s", "%s" given.',
+                        __METHOD__,
+                        LegacyTranslatorInterface::class,
+                        TranslatorInterface::class,
+                        \get_class($translator)
+                    )
+                );
+            }
+
+            @trigger_error(
+                sprintf(
+                    'Passing other type than "%s" as argument 1 to "%s()" is deprecated since sonata-project/media-bundle 3.31'
+                    .' and will throw a "%s" error in 4.0.',
+                    TranslatorInterface::class,
+                    __METHOD__,
+                    \TypeError::class
+                ),
+                \E_USER_DEPRECATED
+            );
         }
 
         $this->translator = $translator;

--- a/src/Security/PublicDownloadStrategy.php
+++ b/src/Security/PublicDownloadStrategy.php
@@ -30,22 +30,29 @@ class PublicDownloadStrategy implements DownloadStrategyInterface
 
     public function __construct(object $translator)
     {
-        if ($translator instanceof LegacyTranslatorInterface) {
-            @trigger_error(sprintf(
-                'Passing other type than "%s" as argument 1 to "%s()" is deprecated since sonata-project/media-bundle 3.31'
-                .' and will throw a "%s" error in 4.0.',
-                TranslatorInterface::class,
-                __METHOD__,
-                \TypeError::class
-            ), \E_USER_DEPRECATED);
-        } elseif (!$translator instanceof TranslatorInterface) {
-            throw new \TypeError(sprintf(
-                'Argument 1 passed to "%s()" MUST be an instance of "%s" or "%s", "%s" given.',
-                __METHOD__,
-                LegacyTranslatorInterface::class,
-                TranslatorInterface::class,
-                \get_class($translator)
-            ));
+        if (!$translator instanceof TranslatorInterface) {
+            if (!$translator instanceof LegacyTranslatorInterface) {
+                throw new \TypeError(
+                    sprintf(
+                        'Argument 1 passed to "%s()" MUST be an instance of "%s" or "%s", "%s" given.',
+                        __METHOD__,
+                        LegacyTranslatorInterface::class,
+                        TranslatorInterface::class,
+                        \get_class($translator)
+                    )
+                );
+            }
+
+            @trigger_error(
+                sprintf(
+                    'Passing other type than "%s" as argument 1 to "%s()" is deprecated since sonata-project/media-bundle 3.31'
+                    .' and will throw a "%s" error in 4.0.',
+                    TranslatorInterface::class,
+                    __METHOD__,
+                    \TypeError::class
+                ),
+                \E_USER_DEPRECATED
+            );
         }
 
         $this->translator = $translator;

--- a/src/Security/RolesDownloadStrategy.php
+++ b/src/Security/RolesDownloadStrategy.php
@@ -45,22 +45,29 @@ class RolesDownloadStrategy implements DownloadStrategyInterface
      */
     public function __construct(object $translator, AuthorizationCheckerInterface $security, array $roles = [])
     {
-        if ($translator instanceof LegacyTranslatorInterface) {
-            @trigger_error(sprintf(
-                'Passing other type than "%s" as argument 1 to "%s()" is deprecated since sonata-project/media-bundle 3.31'
-                .' and will throw a "%s" error in 4.0.',
-                TranslatorInterface::class,
-                __METHOD__,
-                \TypeError::class
-            ), \E_USER_DEPRECATED);
-        } elseif (!$translator instanceof TranslatorInterface) {
-            throw new \TypeError(sprintf(
-                'Argument 1 passed to "%s()" MUST be an instance of "%s" or "%s", "%s" given.',
-                __METHOD__,
-                LegacyTranslatorInterface::class,
-                TranslatorInterface::class,
-                \get_class($translator)
-            ));
+        if (!$translator instanceof TranslatorInterface) {
+            if (!$translator instanceof LegacyTranslatorInterface) {
+                throw new \TypeError(
+                    sprintf(
+                        'Argument 1 passed to "%s()" MUST be an instance of "%s" or "%s", "%s" given.',
+                        __METHOD__,
+                        LegacyTranslatorInterface::class,
+                        TranslatorInterface::class,
+                        \get_class($translator)
+                    )
+                );
+            }
+
+            @trigger_error(
+                sprintf(
+                    'Passing other type than "%s" as argument 1 to "%s()" is deprecated since sonata-project/media-bundle 3.31'
+                    .' and will throw a "%s" error in 4.0.',
+                    TranslatorInterface::class,
+                    __METHOD__,
+                    \TypeError::class
+                ),
+                \E_USER_DEPRECATED
+            );
         }
 
         $this->roles = $roles;

--- a/src/Security/SessionDownloadStrategy.php
+++ b/src/Security/SessionDownloadStrategy.php
@@ -61,22 +61,29 @@ class SessionDownloadStrategy implements DownloadStrategyInterface
      */
     public function __construct(object $translator, object $sessionOrContainer, $times)
     {
-        if ($translator instanceof LegacyTranslatorInterface) {
-            @trigger_error(sprintf(
-                'Passing other type than "%s" as argument 1 to "%s()" is deprecated since sonata-project/media-bundle 3.31'
-                .' and will throw a "%s" error in 4.0.',
-                TranslatorInterface::class,
-                __METHOD__,
-                \TypeError::class
-            ), \E_USER_DEPRECATED);
-        } elseif (!$translator instanceof TranslatorInterface) {
-            throw new \TypeError(sprintf(
-                'Argument 1 passed to "%s()" MUST be an instance of "%s" or "%s", "%s" given.',
-                __METHOD__,
-                LegacyTranslatorInterface::class,
-                TranslatorInterface::class,
-                \get_class($translator)
-            ));
+        if (!$translator instanceof TranslatorInterface) {
+            if (!$translator instanceof LegacyTranslatorInterface) {
+                throw new \TypeError(
+                    sprintf(
+                        'Argument 1 passed to "%s()" MUST be an instance of "%s" or "%s", "%s" given.',
+                        __METHOD__,
+                        LegacyTranslatorInterface::class,
+                        TranslatorInterface::class,
+                        \get_class($translator)
+                    )
+                );
+            }
+
+            @trigger_error(
+                sprintf(
+                    'Passing other type than "%s" as argument 1 to "%s()" is deprecated since sonata-project/media-bundle 3.31'
+                    .' and will throw a "%s" error in 4.0.',
+                    TranslatorInterface::class,
+                    __METHOD__,
+                    \TypeError::class
+                ),
+                \E_USER_DEPRECATED
+            );
         }
 
         // NEXT_MAJOR: Remove these checks and declare `SessionInterface` for argument 2.


### PR DESCRIPTION
## Subject

Since release 3.31 I receive the following deprecation message:

> Passing other type than "Symfony\Contracts\Translation\TranslatorInterface" as argument 1 to "Sonata\MediaBundle\Security\RolesDownloadStrategy::__construct()" is deprecated since sonata-project/media-bundle 3.31 and will throw a "TypeError" error in 4.0.

This got introduced in PR #1923.

In my application, argument 1 is an instance of `Symfony\Component\Translation\DataCollectorTranslator`. This class implements both `TranslatorInterface`s, and I think this should not trigger the error.

I am targeting this branch, because it is backwards compatible.

## Changelog

```markdown
### Fixed
- Remove superfluous deprecation message when translator class is registered that implements both the legacy and new `TranslatorInterface`.
```