### PR TITLE
Avoid to generate the same caller reference twice for a CloudFront invalidation batch request

### DIFF
--- a/src/CDN/CloudFront.php
+++ b/src/CDN/CloudFront.php
@@ -189,7 +189,7 @@ class CloudFront implements CDNInterface
                     'Quantity' => \count($normalizedPaths),
                     'Items' => $normalizedPaths,
                 ],
-                'CallerReference' => $this->getCallerReference($normalizedPaths),
+                'CallerReference' => $this->getCallerReference(),
             ]);
 
             $status = $result->get('Status');
@@ -289,14 +289,14 @@ class CloudFront implements CDNInterface
     }
 
     /**
-     * Generates a valid caller reference from given paths regardless its order.
+     * Generates a caller reference.
      *
-     * @return string a md5 representation
+     * @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_InvalidationBatch.html.
+     *
+     * NEXT_MAJOR: Generate the reference based on the `MediaInterface::getUpdatedAt()` property for the given media.
      */
-    protected function getCallerReference(array $paths)
+    protected function getCallerReference()
     {
-        sort($paths);
-
-        return md5(implode(',', $paths));
+        return (string) time();
     }
 }

--- a/src/CDN/CloudFrontVersion3.php
+++ b/src/CDN/CloudFrontVersion3.php
@@ -115,7 +115,7 @@ final class CloudFrontVersion3 implements CDNInterface
                         'Quantity' => \count($normalizedPaths),
                         'Items' => $normalizedPaths,
                     ],
-                    'CallerReference' => $this->getCallerReference($normalizedPaths),
+                    'CallerReference' => $this->getCallerReference(),
                 ],
             ]);
             $status = $result->get('Invalidation')['Status'];
@@ -151,16 +151,14 @@ final class CloudFrontVersion3 implements CDNInterface
     }
 
     /**
-     * Generates a valid caller reference from given paths regardless its order.
+     * Generates a caller reference.
      *
-     * @phpstan-param list<string> $paths
+     * @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_InvalidationBatch.html.
      *
-     * @return string a md5 representation
+     * NEXT_MAJOR: Generate the reference based on the `MediaInterface::getUpdatedAt()` property for the given media.
      */
-    private function getCallerReference(array $paths): string
+    private function getCallerReference(): string
     {
-        sort($paths);
-
-        return md5(implode(',', $paths));
+        return (string) time();
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Avoid to generate the same caller reference twice for a CloudFront invalidation batch request, since the CDN don't allow the submitted paths to be flushed if this reference was previously used.
See https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_InvalidationBatch.html#cloudfront-Type-InvalidationBatch-CallerReference.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- CDN invalidation from CloudFront when submitting paths that were previously invalidated.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
