### PR TITLE
Fix arguments passed to `sprintf()` in `flushPaths()` methods at `CloudFront` and `CloudFrontVersion3`

### DIFF
--- a/src/CDN/CloudFront.php
+++ b/src/CDN/CloudFront.php
@@ -200,7 +200,7 @@ class CloudFront implements CDNInterface
 
             return $result->get('Id');
         } catch (CloudFrontException $ex) {
-            throw new \RuntimeException(sprintf('Unable to flush paths "%s".', implode('", "', $paths), 0, $ex));
+            throw new \RuntimeException(sprintf('Unable to flush paths "%s".', implode('", "', $paths)), 0, $ex);
         }
     }
 

--- a/src/CDN/CloudFrontVersion3.php
+++ b/src/CDN/CloudFrontVersion3.php
@@ -126,7 +126,7 @@ final class CloudFrontVersion3 implements CDNInterface
 
             return $result->get('Invalidation')['Id'];
         } catch (CloudFrontException $ex) {
-            throw new \RuntimeException(sprintf('Unable to flush paths "%s".', implode('", "', $paths), 0, $ex));
+            throw new \RuntimeException(sprintf('Unable to flush paths "%s".', implode('", "', $paths)), 0, $ex);
         }
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Fix arguments passed to `sprintf()` in `flushPaths()` methods at `CloudFront` and `CloudFrontVersion3`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Arguments passed to `sprintf()` in `flushPaths()` methods at `CloudFront` and `CloudFrontVersion3`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
