### PR TITLE
Fix event listeners

### DIFF
--- a/src/Listener/BaseMediaEventSubscriber.php
+++ b/src/Listener/BaseMediaEventSubscriber.php
@@ -33,76 +33,84 @@ abstract class BaseMediaEventSubscriber implements EventSubscriber
 
     public function postUpdate(LifecycleEventArgs $args): void
     {
-        if (!($provider = $this->getProvider($args))) {
+        $media = $this->getMedia($args);
+
+        if (null === $media) {
             return;
         }
 
-        $provider->postUpdate($this->getMedia($args));
+        $this->getProvider($media)->postUpdate($media);
     }
 
     public function postRemove(LifecycleEventArgs $args): void
     {
-        if (!($provider = $this->getProvider($args))) {
+        $media = $this->getMedia($args);
+
+        if (null === $media) {
             return;
         }
 
-        $provider->postRemove($this->getMedia($args));
+        $this->getProvider($media)->postRemove($media);
     }
 
     public function postPersist(LifecycleEventArgs $args): void
     {
-        if (!($provider = $this->getProvider($args))) {
+        $media = $this->getMedia($args);
+
+        if (null === $media) {
             return;
         }
 
-        $provider->postPersist($this->getMedia($args));
+        $this->getProvider($media)->postPersist($media);
     }
 
     public function preUpdate(LifecycleEventArgs $args): void
     {
-        if (!($provider = $this->getProvider($args))) {
+        $media = $this->getMedia($args);
+
+        if (null === $media) {
             return;
         }
 
-        $provider->transform($this->getMedia($args));
-        $provider->preUpdate($this->getMedia($args));
+        $provider = $this->getProvider($media);
+
+        $provider->transform($media);
+        $provider->preUpdate($media);
 
         $this->recomputeSingleEntityChangeSet($args);
     }
 
     public function preRemove(LifecycleEventArgs $args): void
     {
-        if (!($provider = $this->getProvider($args))) {
+        $media = $this->getMedia($args);
+
+        if (null === $media) {
             return;
         }
 
-        $provider->preRemove($this->getMedia($args));
+        $this->getProvider($media)->preRemove($media);
     }
 
     public function prePersist(LifecycleEventArgs $args): void
     {
-        if (!($provider = $this->getProvider($args))) {
+        $media = $this->getMedia($args);
+
+        if (null === $media) {
             return;
         }
 
-        $provider->transform($this->getMedia($args));
-        $provider->prePersist($this->getMedia($args));
+        $provider = $this->getProvider($media);
+
+        $provider->transform($media);
+        $provider->prePersist($media);
     }
 
-    abstract protected function recomputeSingleEntityChangeSet(LifecycleEventArgs $args);
+    abstract protected function recomputeSingleEntityChangeSet(LifecycleEventArgs $args): void;
 
-    /**
-     * @throws \RuntimeException
-     *
-     * @return MediaInterface
-     */
-    abstract protected function getMedia(LifecycleEventArgs $args);
+    abstract protected function getMedia(LifecycleEventArgs $args): ?MediaInterface;
 
-    /**
-     * @return MediaProviderInterface
-     */
-    protected function getProvider(LifecycleEventArgs $args)
+    protected function getProvider(MediaInterface $media): MediaProviderInterface
     {
-        return $this->pool->getProvider($this->getMedia($args)->getProviderName());
+        return $this->pool->getProvider($media->getProviderName());
     }
 }

--- a/src/Listener/ODM/MediaEventSubscriber.php
+++ b/src/Listener/ODM/MediaEventSubscriber.php
@@ -45,12 +45,12 @@ final class MediaEventSubscriber extends BaseMediaEventSubscriber
         );
     }
 
-    protected function getMedia(LifecycleEventArgs $args)
+    protected function getMedia(LifecycleEventArgs $args): ?MediaInterface
     {
         $media = $args->getObject();
 
         if (!$media instanceof MediaInterface) {
-            throw new \LogicException('There is no media on the persistence event.');
+            return null;
         }
 
         return $media;

--- a/src/Listener/ORM/MediaEventSubscriber.php
+++ b/src/Listener/ORM/MediaEventSubscriber.php
@@ -71,12 +71,12 @@ final class MediaEventSubscriber extends BaseMediaEventSubscriber
         );
     }
 
-    protected function getMedia(LifecycleEventArgs $args)
+    protected function getMedia(LifecycleEventArgs $args): ?MediaInterface
     {
         $media = $args->getObject();
 
         if (!$media instanceof MediaInterface) {
-            throw new \LogicException('There is no media on the persistence event.');
+            return null;
         }
 
         if (null !== $this->categoryManager && !$media->getCategory()) {
@@ -88,19 +88,19 @@ final class MediaEventSubscriber extends BaseMediaEventSubscriber
 
     /**
      * @throws \RuntimeException
-     *
-     * @return CategoryInterface
      */
-    protected function getRootCategory(MediaInterface $media)
+    protected function getRootCategory(MediaInterface $media): CategoryInterface
     {
-        if (!$this->rootCategories) {
-            $this->rootCategories = $this->categoryManager->getRootCategories(false);
+        if (null === $this->rootCategories) {
+            $this->rootCategories = $this->categoryManager->getAllRootCategories(false);
         }
 
-        if (!\array_key_exists($media->getContext(), $this->rootCategories)) {
-            throw new \RuntimeException(sprintf('There is no main category related to context: %s', $media->getContext()));
+        $context = $media->getContext();
+
+        if (!\array_key_exists($context, $this->rootCategories)) {
+            throw new \RuntimeException(sprintf('There is no main category related to context: %s', $context));
         }
 
-        return $this->rootCategories[$media->getContext()];
+        return $this->rootCategories[$context];
     }
 }

--- a/tests/Listener/ORM/MediaEventSubscriberTest.php
+++ b/tests/Listener/ORM/MediaEventSubscriberTest.php
@@ -41,13 +41,13 @@ class MediaEventSubscriberTest extends TestCase
             ->setConstructorArgs(['default'])
             ->getMock();
 
-        $pool->method('getProvider')->willReturnMap([['provider', $provider]]);
+        $pool->method('getProvider')->willReturn($provider);
 
         $category = $this->createMock(CategoryInterface::class);
         $catManager = $this->createMock(CategoryManagerInterface::class);
 
         $catManager->expects($this->exactly(2))
-            ->method('getRootCategories')
+            ->method('getAllRootCategories')
             ->willReturn(['context' => $category]);
 
         $subscriber = new MediaEventSubscriber($pool, $catManager);


### PR DESCRIPTION
When doing: https://github.com/sonata-project/SonataMediaBundle/pull/1975/files

I fucked up the event listeners. I didn't realize all entities go through this events, you just have to know if it is a media entity, otherwise do nothing.

Label it as pedantic since it wasn't released.