### PR TITLE
Add typehints to tests

### DIFF
--- a/tests/Admin/GalleryAdminTest.php
+++ b/tests/Admin/GalleryAdminTest.php
@@ -20,11 +20,14 @@ use Sonata\MediaBundle\Provider\Pool;
 
 class GalleryAdminTest extends TestCase
 {
-    protected $mediaAdmin;
+    /**
+     * @var GalleryAdmin
+     */
+    protected $galleryAdmin;
 
     protected function setUp(): void
     {
-        $this->mediaAdmin = new GalleryAdmin(
+        $this->galleryAdmin = new GalleryAdmin(
             'media',
             BaseGallery::class,
             'SonataMediaBundle:GalleryAdmin',
@@ -34,6 +37,6 @@ class GalleryAdminTest extends TestCase
 
     public function testItIsInstantiable(): void
     {
-        $this->assertNotNull($this->mediaAdmin);
+        $this->assertNotNull($this->galleryAdmin);
     }
 }

--- a/tests/Admin/GalleryItemAdminTest.php
+++ b/tests/Admin/GalleryItemAdminTest.php
@@ -19,11 +19,14 @@ use Sonata\MediaBundle\Entity\BaseGallery;
 
 class GalleryItemAdminTest extends TestCase
 {
-    private $mediaAdmin;
+    /**
+     * @var GalleryItemAdmin
+     */
+    private $galleryItemAdmin;
 
     protected function setUp(): void
     {
-        $this->mediaAdmin = new GalleryItemAdmin(
+        $this->galleryItemAdmin = new GalleryItemAdmin(
             'gallery',
             BaseGallery::class,
             'SonataMediaBundle:GalleryAdmin'
@@ -32,6 +35,6 @@ class GalleryItemAdminTest extends TestCase
 
     public function testItIsInstantiable(): void
     {
-        $this->assertNotNull($this->mediaAdmin);
+        $this->assertNotNull($this->galleryItemAdmin);
     }
 }

--- a/tests/Admin/ORM/MediaAdminTest.php
+++ b/tests/Admin/ORM/MediaAdminTest.php
@@ -21,6 +21,9 @@ use Sonata\MediaBundle\Provider\Pool;
 
 class MediaAdminTest extends TestCase
 {
+    /**
+     * @var MediaAdmin
+     */
     private $mediaAdmin;
 
     protected function setUp(): void

--- a/tests/App/Provider/TestProvider.php
+++ b/tests/App/Provider/TestProvider.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpFoundation\Response;
 class TestProvider extends BaseProvider
 {
     /**
-     * @var string
+     * @var string|null
      */
     public $prevReferenceImage;
 

--- a/tests/Block/FeatureMediaBlockServiceTest.php
+++ b/tests/Block/FeatureMediaBlockServiceTest.php
@@ -21,6 +21,9 @@ use Sonata\MediaBundle\Provider\Pool;
 
 class FeatureMediaBlockServiceTest extends BlockServiceTestCase
 {
+    /**
+     * @var FeatureMediaBlockService
+     */
     private $blockService;
 
     protected function setUp(): void

--- a/tests/Block/GalleryListBlockServiceTest.php
+++ b/tests/Block/GalleryListBlockServiceTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Tests\Block;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use Sonata\BlockBundle\Block\BlockContext;
 use Sonata\BlockBundle\Model\Block;
 use Sonata\BlockBundle\Test\BlockServiceTestCase;
@@ -23,8 +24,14 @@ use Sonata\MediaBundle\Provider\Pool;
 
 class GalleryListBlockServiceTest extends BlockServiceTestCase
 {
+    /**
+     * @var MockObject&GalleryManagerInterface
+     */
     protected $galleryManager;
 
+    /**
+     * @var MockObject&Pool
+     */
     protected $pool;
 
     protected function setUp(): void

--- a/tests/Command/CleanMediaCommandTest.php
+++ b/tests/Command/CleanMediaCommandTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Tests\Command;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use Sonata\MediaBundle\Command\CleanMediaCommand;
 use Sonata\MediaBundle\Filesystem\Local;
 use Sonata\MediaBundle\Model\MediaInterface;
@@ -45,21 +46,29 @@ class CleanMediaCommandTest extends FilesystemTestCase
      */
     protected $tester;
 
+    /**
+     * @var MockObject&Pool
+     */
     private $pool;
 
+    /**
+     * @var MockObject&MediaManagerInterface
+     */
     private $mediaManager;
 
+    /**
+     * @var MockObject&Local
+     */
     private $fileSystemLocal;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->pool = $pool = $this->createMock(Pool::class);
+        $this->pool = $this->createMock(Pool::class);
+        $this->mediaManager = $this->createMock(MediaManagerInterface::class);
+        $this->fileSystemLocal = $this->createMock(Local::class);
 
-        $this->mediaManager = $mediaManager = $this->createMock(MediaManagerInterface::class);
-
-        $this->fileSystemLocal = $fileSystemLocal = $this->createMock(Local::class);
         $this->fileSystemLocal->expects($this->once())->method('getDirectory')->willReturn($this->workspace);
 
         $this->command = new CleanMediaCommand($this->fileSystemLocal, $this->pool, $this->mediaManager);

--- a/tests/Command/FixMediaContextCommandTest.php
+++ b/tests/Command/FixMediaContextCommandTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Tests\Command;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
@@ -46,10 +47,19 @@ class FixMediaContextCommandTest extends TestCase
      */
     protected $tester;
 
+    /**
+     * @var MockObject&Pool
+     */
     private $pool;
 
+    /**
+     * @var MockObject&ContextManagerInterface
+     */
     private $contextManager;
 
+    /**
+     * @var MockObject&CategoryManagerInterface
+     */
     private $categoryManager;
 
     protected function setUp(): void

--- a/tests/Command/RemoveThumbsCommandTest.php
+++ b/tests/Command/RemoveThumbsCommandTest.php
@@ -23,7 +23,6 @@ use Sonata\MediaBundle\Tests\Entity\Media;
 use Sonata\MediaBundle\Tests\Fixtures\FilesystemTestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
-use Symfony\Component\DependencyInjection\Container;
 
 /**
  * @author Anton Dyshkant <vyshkant@gmail.com>
@@ -32,11 +31,6 @@ use Symfony\Component\DependencyInjection\Container;
  */
 final class RemoveThumbsCommandTest extends FilesystemTestCase
 {
-    /**
-     * @var Container
-     */
-    private $container;
-
     /**
      * @var Application
      */
@@ -53,12 +47,12 @@ final class RemoveThumbsCommandTest extends FilesystemTestCase
     private $tester;
 
     /**
-     * @var Pool|MockObject
+     * @var MockObject&Pool
      */
     private $pool;
 
     /**
-     * @var MediaManagerInterface|MockObject
+     * @var MockObject&MediaManagerInterface
      */
     private $mediaManager;
 
@@ -66,8 +60,8 @@ final class RemoveThumbsCommandTest extends FilesystemTestCase
     {
         parent::setUp();
 
-        $this->mediaManager = $this->createStub(MediaManagerInterface::class);
-        $this->pool = $this->createStub(Pool::class);
+        $this->mediaManager = $this->createMock(MediaManagerInterface::class);
+        $this->pool = $this->createMock(Pool::class);
 
         $this->command = new RemoveThumbsCommand($this->pool, $this->mediaManager);
 

--- a/tests/Controller/Api/GalleryTest.php
+++ b/tests/Controller/Api/GalleryTest.php
@@ -15,6 +15,9 @@ namespace Sonata\MediaBundle\Tests\Controller\Api;
 
 class GalleryTest
 {
+    /**
+     * @var int
+     */
     private $id;
 
     public function __construct()
@@ -22,7 +25,7 @@ class GalleryTest
         $this->id = random_int(0, getrandmax());
     }
 
-    public function getId()
+    public function getId(): int
     {
         return $this->id;
     }

--- a/tests/Controller/GalleryAdminControllerTest.php
+++ b/tests/Controller/GalleryAdminControllerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Tests\Controller;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool as AdminPool;
@@ -40,20 +41,32 @@ class GalleryAdminControllerTest extends TestCase
      */
     private $container;
 
+    /**
+     * @var MockObject&AdminInterface
+     */
     private $admin;
 
+    /**
+     * @var Request
+     */
     private $request;
 
+    /**
+     * @var GalleryAdminController
+     */
     private $controller;
 
+    /**
+     * @var MockObject&Environment
+     */
     private $twig;
 
     protected function setUp(): void
     {
         $this->container = new Container();
-        $this->admin = $this->createStub(AdminInterface::class);
+        $this->admin = $this->createMock(AdminInterface::class);
         $this->request = new Request();
-        $this->twig = $this->createStub(Environment::class);
+        $this->twig = $this->createMock(Environment::class);
         $this->container->set('twig', $this->twig);
         $this->container->set('admin_code', $this->admin);
 

--- a/tests/Document/Media.php
+++ b/tests/Document/Media.php
@@ -17,6 +17,9 @@ use Sonata\MediaBundle\Document\BaseMedia;
 
 class Media extends BaseMedia
 {
+    /**
+     * @var int|string|object|null
+     */
     protected $id;
 
     public function setId($id): void

--- a/tests/Document/MediaManagerTest.php
+++ b/tests/Document/MediaManagerTest.php
@@ -25,7 +25,9 @@ use Sonata\MediaBundle\Model\MediaInterface;
  */
 class MediaManagerTest extends TestCase
 {
-    /** @var MediaManager */
+    /**
+     * @var MediaManager
+     */
     private $manager;
 
     protected function setUp(): void

--- a/tests/Entity/Media.php
+++ b/tests/Entity/Media.php
@@ -17,6 +17,9 @@ use Sonata\MediaBundle\Entity\BaseMedia;
 
 class Media extends BaseMedia
 {
+    /**
+     * @var int|string|object|null
+     */
     protected $id;
 
     public function setId($id): void

--- a/tests/Fixtures/FilesystemTestCase.php
+++ b/tests/Fixtures/FilesystemTestCase.php
@@ -30,6 +30,9 @@ class FilesystemTestCase extends TestCase
      */
     protected $workspace;
 
+    /**
+     * @var int
+     */
     private $umask;
 
     /**

--- a/tests/Form/Type/AbstractTypeTest.php
+++ b/tests/Form/Type/AbstractTypeTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Tests\Form\Type;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Component\Form\FormBuilder;
@@ -35,7 +36,7 @@ abstract class AbstractTypeTest extends TypeTestCase
     protected $formType;
 
     /**
-     * @var Pool
+     * @var MockObject&Pool
      */
     protected $mediaPool;
 

--- a/tests/Model/MediaTest.php
+++ b/tests/Model/MediaTest.php
@@ -74,6 +74,9 @@ class MediaTest extends TestCase
         return $property;
     }
 
+    /**
+     * @param mixed $id
+     */
     protected function getMedia($id): Media
     {
         $media = $this->getMockForAbstractClass(Media::class);

--- a/tests/Model/NoDriverManagerTest.php
+++ b/tests/Model/NoDriverManagerTest.php
@@ -30,7 +30,7 @@ class NoDriverManagerTest extends TestCase
         \call_user_func_array([new NoDriverManager(), $method], $arguments);
     }
 
-    public function testIsInstanceOfGalleryManagerInterface()
+    public function testIsInstanceOfGalleryManagerInterface(): void
     {
         $this->assertInstanceOf(GalleryManagerInterface::class, new NoDriverManager());
     }

--- a/tests/Provider/AbstractProviderTest.php
+++ b/tests/Provider/AbstractProviderTest.php
@@ -36,7 +36,7 @@ use Symfony\Component\Form\FormTypeInterface;
 abstract class AbstractProviderTest extends TestCase
 {
     /**
-     * @var FormBuilderInterface|MockObject
+     * @var MockObject&FormBuilderInterface
      */
     protected $formBuilder;
 
@@ -46,7 +46,7 @@ abstract class AbstractProviderTest extends TestCase
     protected $form;
 
     /**
-     * @var FormTypeInterface|MockObject
+     * @var MockObject&FormTypeInterface
      */
     protected $formType;
 

--- a/tests/Provider/FakeHttpWrapper.php
+++ b/tests/Provider/FakeHttpWrapper.php
@@ -15,6 +15,9 @@ namespace Sonata\MediaBundle\Tests\Provider;
 
 class FakeHttpWrapper
 {
+    /**
+     * @var string[]
+     */
     public static $ref = [
         // youtube content
         'http://www.youtube.com/oembed?url=http://www.youtube.com/watch?v=BDYAbAtaDzA&format=json' => 'valide_youtube.txt',
@@ -29,9 +32,9 @@ class FakeHttpWrapper
         'http://b.vimeocdn.com/ts/136/375/136375440_1280.jpg' => 'logo.jpg',
     ];
 
-    /* Properties */
-    public $context;
-
+    /**
+     * @var resource|null
+     */
     public $fp;
 
     /* Methods */


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->

Adding typehints to tests to make it easy to bump phpstan on another PRs.