### PR TITLE
Add missing service declaration

### DIFF
--- a/src/Resources/config/controllers.php
+++ b/src/Resources/config/controllers.php
@@ -40,13 +40,15 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->tag('container.service_subscriber')
             ->call('setContainer', [new ReferenceConfigurator(ContainerInterface::class)])
 
-        ->set(MediaAdminController::class)
-            ->public()
+        ->set('sonata.media.controller.media.admin', MediaAdminController::class)
             ->tag('container.service_subscriber')
             ->call('setContainer', [new ReferenceConfigurator(ContainerInterface::class)])
-
-        ->set(GalleryAdminController::class)
+            ->alias(MediaAdminController::class, 'sonata.media.controller.media.admin')
             ->public()
+
+        ->set('sonata.media.controller.gallery.admin', GalleryAdminController::class)
             ->tag('container.service_subscriber')
-            ->call('setContainer', [new ReferenceConfigurator(ContainerInterface::class)]);
+            ->call('setContainer', [new ReferenceConfigurator(ContainerInterface::class)])
+            ->alias(GalleryAdminController::class, 'sonata.media.controller.gallery.admin')
+            ->public();
 };

--- a/src/Resources/config/controllers.php
+++ b/src/Resources/config/controllers.php
@@ -41,14 +41,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->call('setContainer', [new ReferenceConfigurator(ContainerInterface::class)])
 
         ->set('sonata.media.controller.media.admin', MediaAdminController::class)
+            ->public()
             ->tag('container.service_subscriber')
             ->call('setContainer', [new ReferenceConfigurator(ContainerInterface::class)])
-            ->alias(MediaAdminController::class, 'sonata.media.controller.media.admin')
-            ->public()
 
         ->set('sonata.media.controller.gallery.admin', GalleryAdminController::class)
+            ->public()
             ->tag('container.service_subscriber')
-            ->call('setContainer', [new ReferenceConfigurator(ContainerInterface::class)])
-            ->alias(GalleryAdminController::class, 'sonata.media.controller.gallery.admin')
-            ->public();
+            ->call('setContainer', [new ReferenceConfigurator(ContainerInterface::class)]);
 };

--- a/src/Resources/config/controllers.php
+++ b/src/Resources/config/controllers.php
@@ -48,7 +48,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->set(GalleryAdminController::class)
             ->public()
             ->tag('container.service_subscriber')
-            ->call('setContainer', [new ReferenceConfigurator(ContainerInterface::class)])
-    ;
-
+            ->call('setContainer', [new ReferenceConfigurator(ContainerInterface::class)]);
 };

--- a/src/Resources/config/controllers.php
+++ b/src/Resources/config/controllers.php
@@ -12,7 +12,9 @@ declare(strict_types=1);
  */
 
 use Psr\Container\ContainerInterface;
+use Sonata\MediaBundle\Controller\GalleryAdminController;
 use Sonata\MediaBundle\Controller\GalleryController;
+use Sonata\MediaBundle\Controller\MediaAdminController;
 use Sonata\MediaBundle\Controller\MediaController;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator;
@@ -36,5 +38,17 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 new ReferenceConfigurator('sonata.media.pool'),
             ])
             ->tag('container.service_subscriber')
-            ->call('setContainer', [new ReferenceConfigurator(ContainerInterface::class)]);
+            ->call('setContainer', [new ReferenceConfigurator(ContainerInterface::class)])
+
+        ->set(MediaAdminController::class)
+            ->public()
+            ->tag('container.service_subscriber')
+            ->call('setContainer', [new ReferenceConfigurator(ContainerInterface::class)])
+
+        ->set(GalleryAdminController::class)
+            ->public()
+            ->tag('container.service_subscriber')
+            ->call('setContainer', [new ReferenceConfigurator(ContainerInterface::class)])
+    ;
+
 };

--- a/src/Resources/config/doctrine_mongodb_admin.php
+++ b/src/Resources/config/doctrine_mongodb_admin.php
@@ -15,8 +15,6 @@ use Sonata\AdminBundle\Controller\CRUDController;
 use Sonata\MediaBundle\Admin\GalleryAdmin;
 use Sonata\MediaBundle\Admin\GalleryItemAdmin;
 use Sonata\MediaBundle\Admin\ODM\MediaAdmin;
-use Sonata\MediaBundle\Controller\GalleryAdminController;
-use Sonata\MediaBundle\Controller\MediaAdminController;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator;
 
@@ -39,7 +37,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->args([
                 '',
                 '%sonata.media.admin.media.entity%',
-                MediaAdminController::class,
+                'sonata.media.controller.media.admin',
                 new ReferenceConfigurator('sonata.media.pool'),
                 (new ReferenceConfigurator('sonata.media.manager.category'))->nullOnInvalid(),
             ])
@@ -64,7 +62,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->args([
                 '',
                 '%sonata.media.admin.gallery.entity%',
-                GalleryAdminController::class,
+                'sonata.media.controller.gallery.admin',
                 new ReferenceConfigurator('sonata.media.pool'),
             ])
             ->call('setTranslationDomain', ['SonataMediaBundle'])

--- a/src/Resources/config/doctrine_orm_admin.php
+++ b/src/Resources/config/doctrine_orm_admin.php
@@ -15,8 +15,6 @@ use Sonata\AdminBundle\Controller\CRUDController;
 use Sonata\MediaBundle\Admin\GalleryAdmin;
 use Sonata\MediaBundle\Admin\GalleryItemAdmin;
 use Sonata\MediaBundle\Admin\ORM\MediaAdmin;
-use Sonata\MediaBundle\Controller\GalleryAdminController;
-use Sonata\MediaBundle\Controller\MediaAdminController;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator;
 
@@ -39,7 +37,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->args([
                 '',
                 '%sonata.media.admin.media.entity%',
-                MediaAdminController::class,
+                'sonata.media.controller.media.admin',
                 new ReferenceConfigurator('sonata.media.pool'),
                 (new ReferenceConfigurator('sonata.media.manager.category'))->nullOnInvalid(),
             ])
@@ -65,7 +63,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->args([
                 '',
                 '%sonata.media.admin.gallery.entity%',
-                GalleryAdminController::class,
+                'sonata.media.controller.gallery.admin',
                 new ReferenceConfigurator('sonata.media.pool'),
             ])
             ->call('setTranslationDomain', ['SonataMediaBundle'])


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This fix the missing MediaAdminController and GalleryAdminController service declarations.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because only applicable on master branch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

