### PR TITLE
Set sonata.media.pool service as public

### DIFF
--- a/src/Resources/config/providers.php
+++ b/src/Resources/config/providers.php
@@ -27,6 +27,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->services()
 
         ->set('sonata.media.pool', Pool::class)
+            ->public()
             ->args([''])
 
         ->alias(Pool::class, 'sonata.media.pool')


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Needed because of the InlineValidator in form-extension repo (See https://github.com/sonata-project/form-extensions/blob/master/src/Validator/InlineValidator.php#L53).

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because only applicable on master.


