### PR TITLE
Deprecate calling `getContext()` without existing context

### DIFF
--- a/src/Provider/Pool.php
+++ b/src/Provider/Pool.php
@@ -168,6 +168,14 @@ class Pool
     public function getContext($name)
     {
         if (!$this->hasContext($name)) {
+            // NEXT_MAJOR: Remove the deprecation and uncomment the exception.
+            @trigger_error(sprintf(
+                'Calling %s() with a context that does not exist is deprecated since sonata-project/media-bundle 3.x'
+                .'and will not be supported in version 4.0.',
+                __METHOD__,
+            ), \E_USER_DEPRECATED);
+            // throw new \LogicException(sprintf('Pool does not have context %s, did you configure all your contexts?', $name));
+
             return null;
         }
 

--- a/src/Provider/Pool.php
+++ b/src/Provider/Pool.php
@@ -171,7 +171,7 @@ class Pool
             // NEXT_MAJOR: Remove the deprecation and uncomment the exception.
             @trigger_error(sprintf(
                 'Calling %s() with a context that does not exist is deprecated since sonata-project/media-bundle 3.x'
-                .'and will not be supported in version 4.0.',
+                .' and will not be supported in version 4.0.',
                 __METHOD__,
             ), \E_USER_DEPRECATED);
             // throw new \LogicException(sprintf('Pool does not have context %s, did you configure all your contexts?', $name));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #2014 .

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecate `getContext()` from Pool without first having that context.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
