### PR TITLE
Backport PHPStan configuration from `master`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,6 +99,8 @@
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^0.12.84",
         "phpstan/phpstan-phpunit": "^0.12.16",
+        "phpstan/phpstan-strict-rules": "^0.12.10",
+        "phpstan/phpstan-symfony": "^0.12.21",
         "psalm/plugin-phpunit": "^0.15",
         "sensio/framework-extra-bundle": "^6.1",
         "sonata-project/admin-bundle": "^3.98.2",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,5 +1,10 @@
 parameters:
     ignoreErrors:
+        -
+            message: "#^Variable method call on object\\.$#"
+            count: 1
+            path: src/Command/AddMassMediaCommand.php
+
         - # NEXT_MAJOR: Remove this issue.
             message: "#^Call to static method getInstance\\(\\) on an unknown class Sonata\\\\EasyExtendsBundle\\\\Mapper\\\\DoctrineCollector\\.$#"
             count: 1

--- a/phpstan-console-application.php
+++ b/phpstan-console-application.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Sonata\MediaBundle\Tests\App\AppKernel;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+
+require __DIR__.'/vendor/autoload.php';
+
+$kernel = new AppKernel();
+
+return new Application($kernel);

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,6 +5,8 @@ parameters:
     level: 0
     bootstrapFiles:
         - vendor/bin/.phpunit/phpunit/vendor/autoload.php
+    symfony:
+        console_application_loader: ./phpstan-console-application.php
     scanFiles:
         # NEXT_MAJOR: Remove the scanFiles part
         - .phpstan/stubs/MetadataInterface.file
@@ -12,3 +14,7 @@ parameters:
         - src
         - tests
     treatPhpDocTypesAsCertain: false
+    checkGenericClassInNonGenericObjectType: true
+    checkMissingIterableValueType: true
+    checkMissingVarTagTypehint: true
+    checkMissingTypehints: true

--- a/src/Admin/BaseMediaAdmin.php
+++ b/src/Admin/BaseMediaAdmin.php
@@ -68,7 +68,7 @@ abstract class BaseMediaAdmin extends AbstractAdmin
         }
 
         $filter = $this->getRequest()->get('filter');
-        if ($filter && \array_key_exists('context', $this->getRequest()->get('filter'))) {
+        if (null !== $filter && \array_key_exists('context', $this->getRequest()->get('filter'))) {
             $context = $filter['context']['value'];
         } else {
             $context = $this->getRequest()->get('context', $this->pool->getDefaultContext());
@@ -92,7 +92,7 @@ abstract class BaseMediaAdmin extends AbstractAdmin
 
         $categoryId = $this->getRequest()->get('category');
 
-        if (null !== $this->categoryManager && !$categoryId) {
+        if (null !== $this->categoryManager && null === $categoryId) {
             $categoryId = $this->categoryManager->getRootCategory($context)->getId();
         }
 
@@ -118,7 +118,7 @@ abstract class BaseMediaAdmin extends AbstractAdmin
 
             $media->setContext($context = $this->getRequest()->get('context'));
 
-            if (null !== $this->categoryManager && $categoryId = $this->getPersistentParameter('category')) {
+            if (null !== $this->categoryManager && null !== $categoryId = $this->getPersistentParameter('category')) {
                 $category = $this->categoryManager->find($categoryId);
 
                 if ($category && $category->getContext()->getId() === $context) {

--- a/src/Admin/GalleryAdmin.php
+++ b/src/Admin/GalleryAdmin.php
@@ -92,7 +92,7 @@ class GalleryAdmin extends AbstractAdmin
 
         $context = $this->getPersistentParameter('context');
 
-        if (!$context) {
+        if (null === $context) {
             $context = $this->pool->getDefaultContext();
         }
 
@@ -102,7 +102,7 @@ class GalleryAdmin extends AbstractAdmin
         }
 
         $contexts = [];
-        foreach ((array) $this->pool->getContexts() as $contextItem => $format) {
+        foreach ($this->pool->getContexts() as $contextItem => $format) {
             $contexts[$contextItem] = $contextItem;
         }
 

--- a/src/Admin/PHPCR/GalleryAdmin.php
+++ b/src/Admin/PHPCR/GalleryAdmin.php
@@ -50,7 +50,7 @@ class GalleryAdmin extends BaseGalleryAdmin
 
     public function id($model)
     {
-        return $this->getUrlsafeIdentifier($model);
+        return $this->getUrlSafeIdentifier($model);
     }
 
     protected function configureDatagridFilters(DatagridMapper $filter)

--- a/src/Admin/PHPCR/MediaAdmin.php
+++ b/src/Admin/PHPCR/MediaAdmin.php
@@ -50,7 +50,7 @@ class MediaAdmin extends Admin
 
     public function id($model)
     {
-        return $this->getUrlsafeIdentifier($model);
+        return $this->getUrlSafeIdentifier($model);
     }
 
     protected function configureDatagridFilters(DatagridMapper $filter)

--- a/src/Block/Breadcrumb/GalleryViewBreadcrumbBlockService.php
+++ b/src/Block/Breadcrumb/GalleryViewBreadcrumbBlockService.php
@@ -43,7 +43,7 @@ class GalleryViewBreadcrumbBlockService extends BaseGalleryBreadcrumbBlockServic
     {
         $menu = $this->getRootMenu($blockContext);
 
-        if ($gallery = $blockContext->getBlock()->getSetting('gallery')) {
+        if (null !== $gallery = $blockContext->getBlock()->getSetting('gallery')) {
             $menu->addChild($gallery->getName(), [
                 'route' => 'sonata_media_gallery_view',
                 'routeParameters' => [

--- a/src/Block/Breadcrumb/MediaViewBreadcrumbBlockService.php
+++ b/src/Block/Breadcrumb/MediaViewBreadcrumbBlockService.php
@@ -43,7 +43,7 @@ class MediaViewBreadcrumbBlockService extends BaseGalleryBreadcrumbBlockService
     {
         $menu = $this->getRootMenu($blockContext);
 
-        if ($media = $blockContext->getBlock()->getSetting('media')) {
+        if (null !== $media = $blockContext->getBlock()->getSetting('media')) {
             $menu->addChild($media->getName(), [
                 'route' => 'sonata_media_view',
                 'routeParameters' => [

--- a/src/Block/GalleryBlockService.php
+++ b/src/Block/GalleryBlockService.php
@@ -205,7 +205,7 @@ class GalleryBlockService extends AbstractBlockService
             'gallery' => $gallery,
             'block' => $blockContext->getBlock(),
             'settings' => $blockContext->getSettings(),
-            'elements' => $gallery ? $this->buildElements($gallery) : [],
+            'elements' => null !== $gallery ? $this->buildElements($gallery) : [],
         ], $response);
     }
 
@@ -213,7 +213,7 @@ class GalleryBlockService extends AbstractBlockService
     {
         $gallery = $block->getSetting('galleryId');
 
-        if ($gallery) {
+        if (null !== $gallery) {
             $gallery = $this->galleryManager->findOneBy(['id' => $gallery]);
         }
 

--- a/src/CDN/CloudFront.php
+++ b/src/CDN/CloudFront.php
@@ -173,7 +173,7 @@ class CloudFront implements CDNInterface
      */
     public function flushPaths(array $paths)
     {
-        if (empty($paths)) {
+        if ([] === $paths) {
             throw new \RuntimeException('Unable to flush: expected at least one path.');
         }
         // Normalizes paths due possible typos since all the CloudFront's

--- a/src/CDN/CloudFrontVersion3.php
+++ b/src/CDN/CloudFrontVersion3.php
@@ -98,7 +98,7 @@ final class CloudFrontVersion3 implements CDNInterface
      */
     public function flushPaths(array $paths): string
     {
-        if (empty($paths)) {
+        if ([] === $paths) {
             throw new \RuntimeException('Unable to flush : expected at least one path');
         }
         // Normalizes paths due possible typos since all the CloudFront's

--- a/src/Command/AddMassMediaCommand.php
+++ b/src/Command/AddMassMediaCommand.php
@@ -94,7 +94,7 @@ class AddMassMediaCommand extends BaseCommand
             return \STDIN;
         }
 
-        if (!$input->getOption('file')) {
+        if (null === $input->getOption('file')) {
             throw new \RuntimeException('Please provide a CSV file argument or CSV input stream');
         }
 

--- a/src/Command/CleanMediaCommand.php
+++ b/src/Command/CleanMediaCommand.php
@@ -69,7 +69,7 @@ class CleanMediaCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $dryRun = (bool) $input->getOption('dry-run');
+        $dryRun = $input->getOption('dry-run');
         $verbose = $output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE;
 
         $finder = Finder::create();

--- a/src/Controller/Api/GalleryController.php
+++ b/src/Controller/Api/GalleryController.php
@@ -139,7 +139,7 @@ class GalleryController
             }
         }
 
-        if (!$sort) {
+        if (null === $sort) {
             $sort = [];
         } elseif (!\is_array($sort)) {
             $sort = [$sort => 'asc'];

--- a/src/Controller/Api/Legacy/GalleryController.php
+++ b/src/Controller/Api/Legacy/GalleryController.php
@@ -106,7 +106,7 @@ class GalleryController
             }
         }
 
-        if (!$sort) {
+        if (null === $sort) {
             $sort = [];
         } elseif (!\is_array($sort)) {
             $sort = [$sort => 'asc'];

--- a/src/Controller/Api/Legacy/MediaController.php
+++ b/src/Controller/Api/Legacy/MediaController.php
@@ -128,7 +128,7 @@ class MediaController
             }
         }
 
-        if (!$sort) {
+        if (null === $sort) {
             $sort = [];
         } elseif (!\is_array($sort)) {
             $sort = [$sort => 'asc'];

--- a/src/Controller/Api/MediaController.php
+++ b/src/Controller/Api/MediaController.php
@@ -162,7 +162,7 @@ class MediaController
             return null !== $value;
         });
 
-        if (!$sort) {
+        if (null === $sort) {
             $sort = [];
         } elseif (!\is_array($sort)) {
             $sort = [$sort => 'asc'];

--- a/src/Controller/GalleryAdminController.php
+++ b/src/Controller/GalleryAdminController.php
@@ -49,7 +49,7 @@ class GalleryAdminController extends Controller
     {
         $this->admin->checkAccess('list');
 
-        if ($listMode = $request->get('_list_mode')) {
+        if (null !== $listMode = $request->get('_list_mode')) {
             $this->admin->setListMode($listMode);
         }
 

--- a/src/Controller/MediaAdminController.php
+++ b/src/Controller/MediaAdminController.php
@@ -28,7 +28,7 @@ class MediaAdminController extends Controller
     {
         $this->admin->checkAccess('create');
 
-        if (!$request->get('provider') && $request->isMethod('get')) {
+        if (null === $request->get('provider') && $request->isMethod('get')) {
             $pool = $this->get('sonata.media.pool');
 
             return $this->render('@SonataMedia/MediaAdmin/select_provider.html.twig', [
@@ -54,16 +54,14 @@ class MediaAdminController extends Controller
     {
         $this->admin->checkAccess('list');
 
-        if ($listMode = $request->get('_list_mode', 'mosaic')) {
-            $this->admin->setListMode($listMode);
-        }
+        $this->admin->setListMode($request->get('_list_mode', 'mosaic'));
 
         $datagrid = $this->admin->getDatagrid();
 
-        $filters = $request->get('filter');
+        $filters = $request->get('filter', []);
 
         // set the default context
-        if (!$filters || !\array_key_exists('context', $filters)) {
+        if ([] === $filters || !\array_key_exists('context', $filters)) {
             $context = $this->admin->getPersistentParameter('context', $this->get('sonata.media.pool')->getDefaultContext());
         } else {
             $context = $filters['context']['value'];
@@ -76,16 +74,16 @@ class MediaAdminController extends Controller
             $rootCategory = $this->get('sonata.media.manager.category')->getRootCategory($context);
         }
 
-        if (null !== $rootCategory && !$filters) {
+        if (null !== $rootCategory && [] === $filters) {
             $datagrid->setValue('category', null, $rootCategory->getId());
         }
-        if ($this->has('sonata.media.manager.category') && $request->get('category')) {
+        if ($this->has('sonata.media.manager.category') && null !== $request->get('category')) {
             $category = $this->get('sonata.media.manager.category')->findOneBy([
                 'id' => (int) $request->get('category'),
                 'context' => $context,
             ]);
 
-            if (!empty($category)) {
+            if (null !== $category) {
                 $datagrid->setValue('category', null, $category->getId());
             } else {
                 $datagrid->setValue('category', null, $rootCategory->getId());

--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -333,6 +333,8 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
         }
 
         if ($container->hasDefinition('sonata.media.cdn.cloudfront') && isset($config['cdn']['cloudfront'])) {
+            $cloudFrontConfig = [];
+
             if (isset($config['cdn']['cloudfront']['region'])) {
                 $cloudFrontConfig['region'] = $config['cdn']['cloudfront']['region'];
             }

--- a/src/Extra/ApiMediaFile.php
+++ b/src/Extra/ApiMediaFile.php
@@ -21,12 +21,12 @@ use Symfony\Component\HttpFoundation\File\File;
 class ApiMediaFile extends File
 {
     /**
-     * @var string
+     * @var string|null
      */
     protected $extension;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $mimetype;
 
@@ -50,7 +50,7 @@ class ApiMediaFile extends File
 
     public function getExtension()
     {
-        return $this->extension ?: parent::getExtension();
+        return $this->extension ?? parent::getExtension();
     }
 
     /**
@@ -61,9 +61,9 @@ class ApiMediaFile extends File
         $this->extension = $extension;
     }
 
-    public function getMimetype()
+    public function getMimeType()
     {
-        return $this->mimetype ?: parent::getMimeType();
+        return $this->mimetype ?? parent::getMimeType();
     }
 
     /**
@@ -76,6 +76,6 @@ class ApiMediaFile extends File
 
     public function guessExtension()
     {
-        return $this->extension ?: parent::guessExtension();
+        return $this->extension ?? parent::guessExtension();
     }
 }

--- a/src/Form/DataTransformer/ProviderDataTransformer.php
+++ b/src/Form/DataTransformer/ProviderDataTransformer.php
@@ -74,11 +74,12 @@ class ProviderDataTransformer implements DataTransformerInterface, LoggerAwareIn
         $binaryContent = $value->getBinaryContent();
 
         // no binary
-        if (empty($binaryContent)) {
+        if (null === $binaryContent) {
             // and no media id
             if (null === $value->getId() && $this->options['empty_on_new']) {
                 return;
-            } elseif ($value->getId()) {
+            }
+            if (null !== $value->getId()) {
                 return $value;
             }
 

--- a/src/Form/Type/MediaType.php
+++ b/src/Form/Type/MediaType.php
@@ -68,8 +68,8 @@ class MediaType extends AbstractType implements LoggerAwareInterface
 
         $builder->addModelTransformer($dataTransformer);
 
-        $builder->addEventListener(FormEvents::SUBMIT, static function (FormEvent $event) {
-            if ($event->getForm()->has('unlink') && $event->getForm()->get('unlink')->getData()) {
+        $builder->addEventListener(FormEvents::SUBMIT, static function (FormEvent $event): void {
+            if ($event->getForm()->has('unlink') && null !== $event->getForm()->get('unlink')->getData()) {
                 $event->setData(null);
             }
         });

--- a/src/Metadata/AmazonMetadataBuilder.php
+++ b/src/Metadata/AmazonMetadataBuilder.php
@@ -78,7 +78,7 @@ class AmazonMetadataBuilder implements MetadataBuilderInterface
     {
         //merge acl
         $output = [];
-        if (isset($this->settings['acl']) && !empty($this->settings['acl'])) {
+        if (isset($this->settings['acl'])) {
             $output['ACL'] = $this->acl[$this->settings['acl']];
         }
 
@@ -92,17 +92,17 @@ class AmazonMetadataBuilder implements MetadataBuilderInterface
         }
 
         //merge meta
-        if (isset($this->settings['meta']) && !empty($this->settings['meta'])) {
+        if (isset($this->settings['meta'])) {
             $output['meta'] = $this->settings['meta'];
         }
 
         //merge cache control header
-        if (isset($this->settings['cache_control']) && !empty($this->settings['cache_control'])) {
+        if (isset($this->settings['cache_control'])) {
             $output['CacheControl'] = $this->settings['cache_control'];
         }
 
         //merge encryption
-        if (isset($this->settings['encryption']) && !empty($this->settings['encryption'])) {
+        if (isset($this->settings['encryption'])) {
             if ('aes256' === $this->settings['encryption']) {
                 $output['encryption'] = 'AES256';
             }

--- a/src/Model/Gallery.php
+++ b/src/Model/Gallery.php
@@ -59,7 +59,7 @@ abstract class Gallery implements GalleryInterface, GalleryMediaCollectionInterf
 
     public function __toString()
     {
-        return $this->getName() ?: '-';
+        return $this->getName() ?? '-';
     }
 
     public function setName($name)

--- a/src/Model/Media.php
+++ b/src/Model/Media.php
@@ -151,7 +151,7 @@ abstract class Media implements MediaInterface
 
     public function __toString()
     {
-        return $this->getName() ?: 'n/a';
+        return $this->getName() ?? 'n/a';
     }
 
     // NEXT_MAJOR: Remove this method
@@ -495,7 +495,7 @@ abstract class Media implements MediaInterface
      */
     public function isStatusErroneous($context)
     {
-        if ($this->getBinaryContent() && self::STATUS_ERROR === $this->getProviderStatus()) {
+        if (null !== $this->getBinaryContent() && self::STATUS_ERROR === $this->getProviderStatus()) {
             // NEXT_MAJOR: Restore type hint
             if (!$context instanceof ExecutionContextInterface) {
                 throw new \InvalidArgumentException('Argument 1 should be an instance of Symfony\Component\Validator\ExecutionContextInterface');

--- a/src/Model/MediaInterface.php
+++ b/src/Model/MediaInterface.php
@@ -240,7 +240,7 @@ interface MediaInterface
     /**
      * Get context.
      *
-     * @return string $context
+     * @return string|null $context
      */
     public function getContext();
 

--- a/src/Provider/BaseProvider.php
+++ b/src/Provider/BaseProvider.php
@@ -92,7 +92,7 @@ abstract class BaseProvider implements MediaProviderInterface
 
     public function flushCdn(MediaInterface $media)
     {
-        if (!$media->getId() || !$media->getCdnIsFlushable()) {
+        if (null === $media->getId() || !$media->getCdnIsFlushable()) {
             // If the medium is new or if it isn't marked as flushable, skip the CDN flush process.
             return;
         }
@@ -125,7 +125,7 @@ abstract class BaseProvider implements MediaProviderInterface
             }
         }
 
-        if (!empty($flushPaths)) {
+        if ([] !== $flushPaths) {
             $cdnFlushIdentifier = $this->getCdn()->flushPaths($flushPaths);
             $media->setCdnFlushIdentifier($cdnFlushIdentifier);
             $media->setCdnStatus(CDNInterface::STATUS_TO_FLUSH);

--- a/src/Provider/BaseVideoProvider.php
+++ b/src/Provider/BaseVideoProvider.php
@@ -176,7 +176,7 @@ abstract class BaseVideoProvider extends BaseProvider
 
     public function postPersist(MediaInterface $media)
     {
-        if (!$media->getBinaryContent()) {
+        if (null === $media->getBinaryContent()) {
             return;
         }
 
@@ -216,7 +216,7 @@ abstract class BaseVideoProvider extends BaseProvider
 
         $metadata = json_decode($response, true);
 
-        if (!$metadata) {
+        if (null === $metadata) {
             throw new \RuntimeException('Unable to decode the video information for :'.$url);
         }
 

--- a/src/Provider/DailyMotionProvider.php
+++ b/src/Provider/DailyMotionProvider.php
@@ -132,7 +132,7 @@ class DailyMotionProvider extends BaseVideoProvider
 
     protected function fixBinaryContent(MediaInterface $media)
     {
-        if (!$media->getBinaryContent()) {
+        if (null === $media->getBinaryContent()) {
             return;
         }
 
@@ -145,7 +145,7 @@ class DailyMotionProvider extends BaseVideoProvider
     {
         $this->fixBinaryContent($media);
 
-        if (!$media->getBinaryContent()) {
+        if (null === $media->getBinaryContent()) {
             return;
         }
 

--- a/src/Provider/FileProvider.php
+++ b/src/Provider/FileProvider.php
@@ -236,7 +236,7 @@ class FileProvider extends BaseProvider implements FileProviderInterface
                 $file = $this->getFilesystem()->get($this->generatePrivateUrl($media, $format));
             }
 
-            return new StreamedResponse(static function () use ($file) {
+            return new StreamedResponse(static function () use ($file): void {
                 echo $file->getContent();
             }, 200, $headers);
         }
@@ -268,7 +268,7 @@ class FileProvider extends BaseProvider implements FileProviderInterface
             throw new \RuntimeException(sprintf('Invalid binary content type: %s', \get_class($media->getBinaryContent())));
         }
 
-        if ($media->getBinaryContent() instanceof UploadedFile && 0 === ($media->getBinaryContent()->getSize() ?: 0)) {
+        if ($media->getBinaryContent() instanceof UploadedFile && 0 === ($media->getBinaryContent()->getSize() ?? 0)) {
             $errorElement
                 ->with('binaryContent')
                     ->addViolation(
@@ -321,10 +321,10 @@ class FileProvider extends BaseProvider implements FileProviderInterface
     protected function fixFilename(MediaInterface $media)
     {
         if ($media->getBinaryContent() instanceof UploadedFile) {
-            $media->setName($media->getName() ?: $media->getBinaryContent()->getClientOriginalName());
+            $media->setName($media->getName() ?? $media->getBinaryContent()->getClientOriginalName());
             $media->setMetadataValue('filename', $media->getBinaryContent()->getClientOriginalName());
         } elseif ($media->getBinaryContent() instanceof File) {
-            $media->setName($media->getName() ?: $media->getBinaryContent()->getBasename());
+            $media->setName($media->getName() ?? $media->getBinaryContent()->getBasename());
             $media->setMetadataValue('filename', $media->getBinaryContent()->getBasename());
         }
 
@@ -379,7 +379,7 @@ class FileProvider extends BaseProvider implements FileProviderInterface
 
         $binaryContent = $media->getBinaryContent();
         if ($binaryContent instanceof File) {
-            $path = $binaryContent->getRealPath() ?: $binaryContent->getPathname();
+            $path = false !== $binaryContent->getRealPath() ? $binaryContent->getRealPath() : $binaryContent->getPathname();
             $file->setContent(file_get_contents($path), $metadata);
 
             return;

--- a/src/Provider/ImageProvider.php
+++ b/src/Provider/ImageProvider.php
@@ -76,7 +76,7 @@ class ImageProvider extends FileProvider
         $mediaWidth = $box->getWidth();
 
         $params = [
-            'alt' => $media->getDescription() ?: $media->getName(),
+            'alt' => $media->getDescription() ?? $media->getName(),
             'title' => $media->getName(),
             'src' => $this->generatePublicUrl($media, $format),
             'width' => $mediaWidth,

--- a/src/Provider/Pool.php
+++ b/src/Provider/Pool.php
@@ -71,7 +71,7 @@ class Pool
         if (!$name) {
             throw new \InvalidArgumentException('Provider name cannot be empty, did you forget to call setProviderName() in your Media object?');
         }
-        if (empty($this->providers)) {
+        if ([] === $this->providers) {
             throw new \RuntimeException(sprintf('Unable to retrieve provider named "%s" since there are no providers configured yet.', $name));
         }
         if (!isset($this->providers[$name])) {
@@ -237,8 +237,8 @@ class Pool
             return $providers;
         }
 
-        foreach ($this->getProviderNamesByContext($name) as $name) {
-            $providers[] = $this->getProvider($name);
+        foreach ($this->getProviderNamesByContext($name) as $providerName) {
+            $providers[] = $this->getProvider($providerName);
         }
 
         return $providers;

--- a/src/Provider/VimeoProvider.php
+++ b/src/Provider/VimeoProvider.php
@@ -131,7 +131,7 @@ class VimeoProvider extends BaseVideoProvider
 
     protected function fixBinaryContent(MediaInterface $media)
     {
-        if (!$media->getBinaryContent()) {
+        if (null === $media->getBinaryContent()) {
             return;
         }
 
@@ -144,7 +144,7 @@ class VimeoProvider extends BaseVideoProvider
     {
         $this->fixBinaryContent($media);
 
-        if (!$media->getBinaryContent()) {
+        if (null === $media->getBinaryContent()) {
             return;
         }
 

--- a/src/Provider/YouTubeProvider.php
+++ b/src/Provider/YouTubeProvider.php
@@ -251,7 +251,7 @@ class YouTubeProvider extends BaseVideoProvider
 
     protected function fixBinaryContent(MediaInterface $media)
     {
-        if (!$media->getBinaryContent()) {
+        if (null === $media->getBinaryContent()) {
             return;
         }
 
@@ -274,7 +274,7 @@ class YouTubeProvider extends BaseVideoProvider
     {
         $this->fixBinaryContent($media);
 
-        if (!$media->getBinaryContent()) {
+        if (null === $media->getBinaryContent()) {
             return;
         }
 

--- a/src/Thumbnail/ConsumerThumbnail.php
+++ b/src/Thumbnail/ConsumerThumbnail.php
@@ -83,7 +83,7 @@ class ConsumerThumbnail implements ThumbnailInterface
         $backend = $this->backend;
         $id = $this->id;
 
-        $publish = static function () use ($backend, $media, $id) {
+        $publish = static function () use ($backend, $media, $id): void {
             $backend->createAndPublish('sonata.media.create_thumbnail', [
                 'thumbnailId' => $id,
                 'mediaId' => $media->getId(),

--- a/tests/Admin/BaseMediaAdminTest.php
+++ b/tests/Admin/BaseMediaAdminTest.php
@@ -76,10 +76,10 @@ class BaseMediaAdminTest extends TestCase
 
         $newMedia = $this->mediaAdmin->getNewInstance();
 
-        $this->assertSame($media, $newMedia);
-        $this->assertSame('context', $media->getContext());
-        $this->assertSame($category, $media->getCategory());
-        $this->assertSame('providerName', $media->getProviderName());
+        self::assertSame($media, $newMedia);
+        self::assertSame('context', $media->getContext());
+        self::assertSame($category, $media->getCategory());
+        self::assertSame('providerName', $media->getProviderName());
     }
 
     public function testGetPersistentParametersWithMultipleProvidersInContext(): void
@@ -102,7 +102,7 @@ class BaseMediaAdminTest extends TestCase
 
         $persistentParameters = $this->mediaAdmin->getPersistentParameters();
 
-        $this->assertSame([
+        self::assertSame([
             'provider' => 'providerName',
             'context' => 'context',
             'category' => 1,

--- a/tests/Admin/GalleryAdminTest.php
+++ b/tests/Admin/GalleryAdminTest.php
@@ -34,6 +34,6 @@ class GalleryAdminTest extends TestCase
 
     public function testItIsInstantiable(): void
     {
-        $this->assertNotNull($this->mediaAdmin);
+        self::assertNotNull($this->mediaAdmin);
     }
 }

--- a/tests/Admin/GalleryHasMediaAdminTest.php
+++ b/tests/Admin/GalleryHasMediaAdminTest.php
@@ -32,6 +32,6 @@ class GalleryHasMediaAdminTest extends TestCase
 
     public function testItIsInstantiable(): void
     {
-        $this->assertNotNull($this->mediaAdmin);
+        self::assertNotNull($this->mediaAdmin);
     }
 }

--- a/tests/Admin/ORM/MediaAdminTest.php
+++ b/tests/Admin/ORM/MediaAdminTest.php
@@ -36,6 +36,6 @@ class MediaAdminTest extends TestCase
 
     public function testItIsInstantiable(): void
     {
-        $this->assertNotNull($this->mediaAdmin);
+        self::assertNotNull($this->mediaAdmin);
     }
 }

--- a/tests/Block/Breadcrumb/BreadcrumbTest.php
+++ b/tests/Block/Breadcrumb/BreadcrumbTest.php
@@ -33,6 +33,6 @@ class BreadcrumbTest extends BlockServiceTestCase
             $this->createStub(FactoryInterface::class)
         );
 
-        $this->assertTrue($blockService->handleContext('context'));
+        self::assertTrue($blockService->handleContext('context'));
     }
 }

--- a/tests/Block/GalleryBlockServiceTest.php
+++ b/tests/Block/GalleryBlockServiceTest.php
@@ -53,7 +53,7 @@ class GalleryBlockServiceTest extends BlockServiceTestCase
         $gallery->method('getGalleryHasMedias')->willReturn([]);
 
         $this->twig
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('render')
             ->with('template', [
                 'gallery' => $gallery,

--- a/tests/Block/GalleryListBlockServiceTest.php
+++ b/tests/Block/GalleryListBlockServiceTest.php
@@ -38,7 +38,7 @@ class GalleryListBlockServiceTest extends BlockServiceTestCase
     public function testExecute(): void
     {
         $pager = $this->createMock(PagerInterface::class);
-        $this->galleryManager->expects($this->once())->method('getPager')->willReturn($pager);
+        $this->galleryManager->expects(self::once())->method('getPager')->willReturn($pager);
 
         $block = new Block();
 
@@ -56,7 +56,7 @@ class GalleryListBlockServiceTest extends BlockServiceTestCase
         $blockService = new GalleryListBlockService($this->twig, null, $this->galleryManager, $this->pool);
 
         $this->twig
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('render')
             ->with('@SonataMedia/Block/block_gallery_list.html.twig', [
                 'context' => $blockContext,

--- a/tests/Block/MediaBlockServiceTest.php
+++ b/tests/Block/MediaBlockServiceTest.php
@@ -59,13 +59,13 @@ class MediaBlockServiceTest extends BlockServiceTestCase
             ['format', 'format'],
             ['mediaId', $media],
         ]);
-        $blockContext->expects($this->once())->method('setSetting')->with('format', 'format1');
+        $blockContext->expects(self::once())->method('setSetting')->with('format', 'format1');
         $blockContext->method('getSettings')->willReturn([]);
         $blockContext->method('getTemplate')->willReturn('template');
         $block->method('getSetting')->with('mediaId')->willReturn($media);
 
         $this->twig
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('render')
             ->with('template', [
                 'media' => $media,

--- a/tests/CDN/CloudFrontTest.php
+++ b/tests/CDN/CloudFrontTest.php
@@ -29,7 +29,7 @@ final class CloudFrontTest extends TestCase
     protected function setUp(): void
     {
         if (class_exists(Sdk::class)) {
-            $this->markTestSkipped('This test requires aws/aws-sdk-php 2.x.');
+            self::markTestSkipped('This test requires aws/aws-sdk-php 2.x.');
         }
 
         parent::setUp();
@@ -40,29 +40,29 @@ final class CloudFrontTest extends TestCase
         $client = $this->createMock(CloudFrontClientSpy::class);
         $cloudFront = new CloudFront($client, 'xxxxxxxxxxxxxx', '/foo');
 
-        $this->assertSame('/foo/bar.jpg', $cloudFront->getPath('bar.jpg', true));
+        self::assertSame('/foo/bar.jpg', $cloudFront->getPath('bar.jpg', true));
 
         $path = '/mypath/file.jpg';
 
-        $client->expects($this->exactly(3))
+        $client->expects(self::exactly(3))
             ->method('createInvalidation')
             ->willReturn(new CloudFrontResult([
                 'Id' => 'invalidation_id',
                 'Status' => 'InProgress',
             ]));
 
-        $this->assertSame('invalidation_id', $cloudFront->flushByString($path));
-        $this->assertSame('invalidation_id', $cloudFront->flush($path));
-        $this->assertSame('invalidation_id', $cloudFront->flushPaths([$path]));
+        self::assertSame('invalidation_id', $cloudFront->flushByString($path));
+        self::assertSame('invalidation_id', $cloudFront->flush($path));
+        self::assertSame('invalidation_id', $cloudFront->flushPaths([$path]));
 
-        $client->expects($this->once())
+        $client->expects(self::once())
             ->method('getInvalidation')
             ->willReturn(new CloudFrontResult([
                 'Id' => 'invalidation_id',
                 'Status' => 'InProgress',
             ]));
 
-        $this->assertSame(CloudFront::STATUS_WAITING, $cloudFront->getFlushStatus('invalidation_id'));
+        self::assertSame(CloudFront::STATUS_WAITING, $cloudFront->getFlushStatus('invalidation_id'));
     }
 
     public function testCreateInvalidationException(): void
@@ -70,7 +70,7 @@ final class CloudFrontTest extends TestCase
         $client = $this->createMock(CloudFrontClientSpy::class);
         $cloudFront = new CloudFront($client, 'xxxxxxxxxxxxxx', '/foo');
 
-        $client->expects($this->once())
+        $client->expects(self::once())
             ->method('createInvalidation')
             ->willThrowException(new CloudFrontException('An exception occurred.', $this->createStub(CommandInterface::class)));
 

--- a/tests/CDN/CloudFrontVersionTest.php
+++ b/tests/CDN/CloudFrontVersionTest.php
@@ -28,7 +28,7 @@ final class CloudFrontVersionTest extends TestCase
     protected function setUp(): void
     {
         if (!class_exists(Sdk::class)) {
-            $this->markTestSkipped('This test requires aws/aws-sdk-php 3.x.');
+            self::markTestSkipped('This test requires aws/aws-sdk-php 3.x.');
         }
 
         parent::setUp();
@@ -49,11 +49,11 @@ final class CloudFrontVersionTest extends TestCase
 
         $cloudFront = new CloudFrontVersion3($client, 'xxxxxxxxxxxxxx', $path);
 
-        $this->assertSame($expectedPath, $cloudFront->getPath($relativePath, true));
+        self::assertSame($expectedPath, $cloudFront->getPath($relativePath, true));
 
         $flushPath = '/mypath/file.jpg';
 
-        $client->expects($this->exactly(3))
+        $client->expects(self::exactly(3))
             ->method('createInvalidation')
             ->willReturn(new Result([
                 'Invalidation' => [
@@ -62,11 +62,11 @@ final class CloudFrontVersionTest extends TestCase
                 ],
             ]));
 
-        $this->assertSame($invalidationId, $cloudFront->flushByString($flushPath));
-        $this->assertSame($invalidationId, $cloudFront->flush($flushPath));
-        $this->assertSame($invalidationId, $cloudFront->flushPaths([$flushPath]));
+        self::assertSame($invalidationId, $cloudFront->flushByString($flushPath));
+        self::assertSame($invalidationId, $cloudFront->flush($flushPath));
+        self::assertSame($invalidationId, $cloudFront->flushPaths([$flushPath]));
 
-        $client->expects($this->once())
+        $client->expects(self::once())
             ->method('getInvalidation')
             ->willReturn(new Result([
                 'Invalidation' => [
@@ -75,7 +75,7 @@ final class CloudFrontVersionTest extends TestCase
                 ],
             ]));
 
-        $this->assertSame($expectedStatus, $cloudFront->getFlushStatus($invalidationId));
+        self::assertSame($expectedStatus, $cloudFront->getFlushStatus($invalidationId));
     }
 
     public function provideCloudFrontTestCases(): iterable
@@ -89,7 +89,7 @@ final class CloudFrontVersionTest extends TestCase
     {
         $client = $this->createMock(CloudFrontClientSpy::class);
 
-        $client->expects($this->once())
+        $client->expects(self::once())
             ->method('createInvalidation')
             ->willThrowException(new CloudFrontException('An exception occurred.', new Command('command_name')));
 
@@ -106,7 +106,7 @@ final class CloudFrontVersionTest extends TestCase
         $client = $this->createMock(CloudFrontClientSpy::class);
         $cloudFront = new CloudFrontVersion3($client, 'xxxxxxxxxxxxxx', '/foo');
 
-        $client->expects($this->once())
+        $client->expects(self::once())
             ->method('createInvalidation')
             ->willReturn(new Result([
                 'Invalidation' => [

--- a/tests/CDN/PantherPortalTest.php
+++ b/tests/CDN/PantherPortalTest.php
@@ -21,12 +21,12 @@ class PantherPortalTest extends TestCase
     public function testPortal(): void
     {
         $client = $this->createMock(ClientSpy::class);
-        $client->expects($this->exactly(3))->method('flush')->willReturn('Flush successfully submitted.');
+        $client->expects(self::exactly(3))->method('flush')->willReturn('Flush successfully submitted.');
 
         $panther = new PantherPortal('/foo', 'login', 'pass', 42);
         $panther->setClient($client);
 
-        $this->assertSame('/foo/bar.jpg', $panther->getPath('bar.jpg', true));
+        self::assertSame('/foo/bar.jpg', $panther->getPath('bar.jpg', true));
 
         $path = '/mypath/file.jpg';
 
@@ -41,7 +41,7 @@ class PantherPortalTest extends TestCase
         $this->expectExceptionMessage('Unable to flush : Failed!!');
 
         $client = $this->createMock(ClientSpy::class);
-        $client->expects($this->once())->method('flush')->willReturn('Failed!!');
+        $client->expects(self::once())->method('flush')->willReturn('Failed!!');
 
         $panther = new PantherPortal('/foo', 'login', 'pass', 42);
         $panther->setClient($client);

--- a/tests/Command/CleanMediaCommandTest.php
+++ b/tests/Command/CleanMediaCommandTest.php
@@ -60,7 +60,7 @@ class CleanMediaCommandTest extends FilesystemTestCase
         $this->mediaManager = $mediaManager = $this->createMock(MediaManagerInterface::class);
 
         $this->fileSystemLocal = $fileSystemLocal = $this->createMock(Local::class);
-        $this->fileSystemLocal->expects($this->once())->method('getDirectory')->willReturn($this->workspace);
+        $this->fileSystemLocal->expects(self::once())->method('getDirectory')->willReturn($this->workspace);
 
         $this->command = new CleanMediaCommand($this->fileSystemLocal, $this->pool, $this->mediaManager);
 
@@ -78,13 +78,13 @@ class CleanMediaCommandTest extends FilesystemTestCase
             'download' => [],
         ];
 
-        $this->pool->expects($this->once())->method('getContexts')->willReturn(['foo' => $context]);
+        $this->pool->expects(self::once())->method('getContexts')->willReturn(['foo' => $context]);
 
         $output = $this->tester->execute(['command' => $this->command->getName()]);
 
-        $this->assertMatchesRegularExpression('@\'.+\' does not exist\s+done!@', $this->tester->getDisplay());
+        self::assertMatchesRegularExpression('@\'.+\' does not exist\s+done!@', $this->tester->getDisplay());
 
-        $this->assertSame(0, $output);
+        self::assertSame(0, $output);
     }
 
     public function testExecuteEmptyDirectory(): void
@@ -97,13 +97,13 @@ class CleanMediaCommandTest extends FilesystemTestCase
             'download' => [],
         ];
 
-        $this->pool->expects($this->once())->method('getContexts')->willReturn(['foo' => $context]);
+        $this->pool->expects(self::once())->method('getContexts')->willReturn(['foo' => $context]);
 
         $output = $this->tester->execute(['command' => $this->command->getName()]);
 
-        $this->assertMatchesRegularExpression('@Context: foo\s+done!@', $this->tester->getDisplay());
+        self::assertMatchesRegularExpression('@Context: foo\s+done!@', $this->tester->getDisplay());
 
-        $this->assertSame(0, $output);
+        self::assertSame(0, $output);
     }
 
     public function testExecuteFilesExists(): void
@@ -126,18 +126,18 @@ class CleanMediaCommandTest extends FilesystemTestCase
 
         $media = $this->createMock(MediaInterface::class);
 
-        $this->mediaManager->expects($this->once())->method('findOneBy')
-            ->with($this->equalTo(['id' => 1, 'context' => 'foo']))
+        $this->mediaManager->expects(self::once())->method('findOneBy')
+            ->with(self::equalTo(['id' => 1, 'context' => 'foo']))
             ->willReturn([$media]);
-        $this->mediaManager->expects($this->once())->method('findBy')
-            ->with($this->equalTo(['providerReference' => 'qwertz.ext', 'providerName' => ['fooprovider']]))
+        $this->mediaManager->expects(self::once())->method('findBy')
+            ->with(self::equalTo(['providerReference' => 'qwertz.ext', 'providerName' => ['fooprovider']]))
             ->willReturn([$media]);
 
         $output = $this->tester->execute(['command' => $this->command->getName()]);
 
-        $this->assertMatchesRegularExpression('@Context: foo\s+done!@', $this->tester->getDisplay());
+        self::assertMatchesRegularExpression('@Context: foo\s+done!@', $this->tester->getDisplay());
 
-        $this->assertSame(0, $output);
+        self::assertSame(0, $output);
     }
 
     public function testExecuteFilesExistsVerbose(): void
@@ -160,11 +160,11 @@ class CleanMediaCommandTest extends FilesystemTestCase
 
         $media = $this->createMock(MediaInterface::class);
 
-        $this->mediaManager->expects($this->once())->method('findOneBy')
-            ->with($this->equalTo(['id' => 1, 'context' => 'foo']))
+        $this->mediaManager->expects(self::once())->method('findOneBy')
+            ->with(self::equalTo(['id' => 1, 'context' => 'foo']))
             ->willReturn([$media]);
-        $this->mediaManager->expects($this->once())->method('findBy')
-            ->with($this->equalTo(['providerReference' => 'qwertz.ext', 'providerName' => ['fooprovider']]))
+        $this->mediaManager->expects(self::once())->method('findBy')
+            ->with(self::equalTo(['providerReference' => 'qwertz.ext', 'providerName' => ['fooprovider']]))
             ->willReturn([$media]);
 
         $output = $this->tester->execute(
@@ -180,7 +180,7 @@ class CleanMediaCommandTest extends FilesystemTestCase
             ],
             $this->tester->getDisplay()
         );
-        $this->assertSame(0, $output);
+        self::assertSame(0, $output);
     }
 
     public function testExecuteDryRun(): void
@@ -201,11 +201,11 @@ class CleanMediaCommandTest extends FilesystemTestCase
         $this->pool->method('getContexts')->willReturn(['foo' => $context]);
         $this->pool->method('getProviders')->willReturn([$provider]);
 
-        $this->mediaManager->expects($this->once())->method('findOneBy')
-            ->with($this->equalTo(['id' => 1, 'context' => 'foo']))
+        $this->mediaManager->expects(self::once())->method('findOneBy')
+            ->with(self::equalTo(['id' => 1, 'context' => 'foo']))
             ->willReturn(null);
-        $this->mediaManager->expects($this->once())->method('findBy')
-            ->with($this->equalTo(['providerReference' => 'qwertz.ext', 'providerName' => ['fooprovider']]))
+        $this->mediaManager->expects(self::once())->method('findBy')
+            ->with(self::equalTo(['providerReference' => 'qwertz.ext', 'providerName' => ['fooprovider']]))
             ->willReturn([]);
 
         $output = $this->tester->execute(['command' => $this->command->getName(), '--dry-run' => true]);
@@ -218,7 +218,7 @@ class CleanMediaCommandTest extends FilesystemTestCase
             ],
             $this->tester->getDisplay()
         );
-        $this->assertSame(0, $output);
+        self::assertSame(0, $output);
     }
 
     public function testExecute(): void
@@ -239,11 +239,11 @@ class CleanMediaCommandTest extends FilesystemTestCase
         $this->pool->method('getContexts')->willReturn(['foo' => $context]);
         $this->pool->method('getProviders')->willReturn([$provider]);
 
-        $this->mediaManager->expects($this->once())->method('findOneBy')
-            ->with($this->equalTo(['id' => 1, 'context' => 'foo']))
+        $this->mediaManager->expects(self::once())->method('findOneBy')
+            ->with(self::equalTo(['id' => 1, 'context' => 'foo']))
             ->willReturn(null);
-        $this->mediaManager->expects($this->once())->method('findBy')
-            ->with($this->equalTo(['providerReference' => 'qwertz.ext', 'providerName' => ['fooprovider']]))
+        $this->mediaManager->expects(self::once())->method('findBy')
+            ->with(self::equalTo(['providerReference' => 'qwertz.ext', 'providerName' => ['fooprovider']]))
             ->willReturn([]);
 
         $output = $this->tester->execute(['command' => $this->command->getName()]);
@@ -256,7 +256,7 @@ class CleanMediaCommandTest extends FilesystemTestCase
             ],
             $this->tester->getDisplay()
         );
-        $this->assertSame(0, $output);
+        self::assertSame(0, $output);
     }
 
     /**
@@ -278,7 +278,7 @@ class CleanMediaCommandTest extends FilesystemTestCase
             }
         }
 
-        $this->assertTrue($found, sprintf(
+        self::assertTrue($found, sprintf(
             'Unable to find "%s" in "%s" with extractor "%s"',
             implode('", "', $expected),
             $output,

--- a/tests/Command/FixMediaContextCommandTest.php
+++ b/tests/Command/FixMediaContextCommandTest.php
@@ -94,17 +94,17 @@ class FixMediaContextCommandTest extends TestCase
 
         $contextModel = new Context();
 
-        $this->contextManager->expects($this->once())->method('findOneBy')->with($this->equalTo(['id' => 'foo']))->willReturn($contextModel);
+        $this->contextManager->expects(self::once())->method('findOneBy')->with(self::equalTo(['id' => 'foo']))->willReturn($contextModel);
 
         $category = new Category();
 
-        $this->categoryManager->expects($this->once())->method('getRootCategory')->with($this->equalTo($contextModel))->willReturn($category);
+        $this->categoryManager->expects(self::once())->method('getRootCategory')->with(self::equalTo($contextModel))->willReturn($category);
 
         $output = $this->tester->execute(['command' => $this->command->getName()]);
 
-        $this->assertMatchesRegularExpression('@Done!@', $this->tester->getDisplay());
+        self::assertMatchesRegularExpression('@Done!@', $this->tester->getDisplay());
 
-        $this->assertSame(0, $output);
+        self::assertSame(0, $output);
     }
 
     public function testExecuteWithEmptyRoot(): void
@@ -119,19 +119,19 @@ class FixMediaContextCommandTest extends TestCase
 
         $contextModel = new Context();
 
-        $this->contextManager->expects($this->once())->method('findOneBy')->with($this->equalTo(['id' => 'foo']))->willReturn($contextModel);
+        $this->contextManager->expects(self::once())->method('findOneBy')->with(self::equalTo(['id' => 'foo']))->willReturn($contextModel);
 
         $category = new Category();
 
-        $this->categoryManager->expects($this->once())->method('getRootCategory')->with($this->equalTo($contextModel))->willReturn(null);
-        $this->categoryManager->expects($this->once())->method('create')->willReturn($category);
-        $this->categoryManager->expects($this->once())->method('save')->with($this->equalTo($category));
+        $this->categoryManager->expects(self::once())->method('getRootCategory')->with(self::equalTo($contextModel))->willReturn(null);
+        $this->categoryManager->expects(self::once())->method('create')->willReturn($category);
+        $this->categoryManager->expects(self::once())->method('save')->with(self::equalTo($category));
 
         $output = $this->tester->execute(['command' => $this->command->getName()]);
 
-        $this->assertMatchesRegularExpression('@ > default category for \'foo\' is missing, creating one\s+Done!@', $this->tester->getDisplay());
+        self::assertMatchesRegularExpression('@ > default category for \'foo\' is missing, creating one\s+Done!@', $this->tester->getDisplay());
 
-        $this->assertSame(0, $output);
+        self::assertSame(0, $output);
     }
 
     public function testExecuteWithNew(): void
@@ -146,20 +146,20 @@ class FixMediaContextCommandTest extends TestCase
 
         $contextModel = new Context();
 
-        $this->contextManager->expects($this->once())->method('findOneBy')->with($this->equalTo(['id' => 'foo']))->willReturn(null);
-        $this->contextManager->expects($this->once())->method('create')->willReturn($contextModel);
-        $this->contextManager->expects($this->once())->method('save')->with($this->equalTo($contextModel));
+        $this->contextManager->expects(self::once())->method('findOneBy')->with(self::equalTo(['id' => 'foo']))->willReturn(null);
+        $this->contextManager->expects(self::once())->method('create')->willReturn($contextModel);
+        $this->contextManager->expects(self::once())->method('save')->with(self::equalTo($contextModel));
 
         $category = new Category();
 
-        $this->categoryManager->expects($this->once())->method('getRootCategory')->with($this->equalTo($contextModel))->willReturn(null);
-        $this->categoryManager->expects($this->once())->method('create')->willReturn($category);
-        $this->categoryManager->expects($this->once())->method('save')->with($this->equalTo($category));
+        $this->categoryManager->expects(self::once())->method('getRootCategory')->with(self::equalTo($contextModel))->willReturn(null);
+        $this->categoryManager->expects(self::once())->method('create')->willReturn($category);
+        $this->categoryManager->expects(self::once())->method('save')->with(self::equalTo($category));
 
         $output = $this->tester->execute(['command' => $this->command->getName()]);
 
-        $this->assertMatchesRegularExpression('@ > default category for \'foo\' is missing, creating one\s+Done!@', $this->tester->getDisplay());
+        self::assertMatchesRegularExpression('@ > default category for \'foo\' is missing, creating one\s+Done!@', $this->tester->getDisplay());
 
-        $this->assertSame(0, $output);
+        self::assertSame(0, $output);
     }
 }

--- a/tests/Command/RemoveThumbsCommandTest.php
+++ b/tests/Command/RemoveThumbsCommandTest.php
@@ -98,22 +98,22 @@ final class RemoveThumbsCommandTest extends FilesystemTestCase
         $fileProvider
             ->method('getName')
             ->willReturn('fooprovider');
-        $fileProvider->expects($this->once())
+        $fileProvider->expects(self::once())
             ->method('getFormats')
             ->willReturn($formats);
-        $fileProvider->expects($this->exactly(2))
+        $fileProvider->expects(self::exactly(2))
             ->method('removeThumbnails');
-        $fileProvider->expects($this->exactly(2))
+        $fileProvider->expects(self::exactly(2))
             ->method('getFilesystem')
             ->willReturn($this->createMock(Filesystem::class));
 
-        $this->pool->expects($this->once())
+        $this->pool->expects(self::once())
             ->method('getContexts')
             ->willReturn(['foo' => $context]);
-        $this->pool->expects($this->once())
+        $this->pool->expects(self::once())
             ->method('getProviders')
             ->willReturn(['fooprovider' => $fileProvider]);
-        $this->pool->expects($this->once())
+        $this->pool->expects(self::once())
             ->method('getProvider')
             ->willReturn($fileProvider);
 
@@ -142,7 +142,7 @@ final class RemoveThumbsCommandTest extends FilesystemTestCase
             return $medias;
         };
 
-        $this->mediaManager->expects($this->exactly(2))
+        $this->mediaManager->expects(self::exactly(2))
             ->method('findBy')
             ->willReturnCallback($findByReturnCallback);
 
@@ -150,8 +150,8 @@ final class RemoveThumbsCommandTest extends FilesystemTestCase
 
         $statusCode = $this->tester->execute(['command' => $this->command->getName()]);
 
-        $this->assertStringEndsWith('Done (total medias processed: 2).'.\PHP_EOL, $this->tester->getDisplay());
+        self::assertStringEndsWith('Done (total medias processed: 2).'.\PHP_EOL, $this->tester->getDisplay());
 
-        $this->assertSame(0, $statusCode);
+        self::assertSame(0, $statusCode);
     }
 }

--- a/tests/Controller/Api/GalleryControllerTest.php
+++ b/tests/Controller/Api/GalleryControllerTest.php
@@ -40,15 +40,15 @@ class GalleryControllerTest extends TestCase
         $mediaManager = $this->createMock(MediaManagerInterface::class);
         $formFactory = $this->createMock(FormFactoryInterface::class);
 
-        $gManager->expects($this->once())->method('getPager')->willReturn([]);
+        $gManager->expects(self::once())->method('getPager')->willReturn([]);
 
         $gController = new GalleryController($gManager, $mediaManager, $formFactory, 'test');
 
         $paramFetcher = $this->createMock(ParamFetcherInterface::class);
-        $paramFetcher->expects($this->exactly(3))->method('get');
-        $paramFetcher->expects($this->once())->method('all')->willReturn([]);
+        $paramFetcher->expects(self::exactly(3))->method('get');
+        $paramFetcher->expects(self::once())->method('all')->willReturn([]);
 
-        $this->assertSame([], $gController->getGalleriesAction($paramFetcher));
+        self::assertSame([], $gController->getGalleriesAction($paramFetcher));
     }
 
     public function testGetGalleryAction(): void
@@ -58,11 +58,11 @@ class GalleryControllerTest extends TestCase
         $gallery = $this->createMock(GalleryInterface::class);
         $formFactory = $this->createMock(FormFactoryInterface::class);
 
-        $gManager->expects($this->once())->method('findOneBy')->willReturn($gallery);
+        $gManager->expects(self::once())->method('findOneBy')->willReturn($gallery);
 
         $gController = new GalleryController($gManager, $mediaManager, $formFactory, 'test');
 
-        $this->assertSame($gallery, $gController->getGalleryAction(1));
+        self::assertSame($gallery, $gController->getGalleryAction(1));
     }
 
     /**
@@ -78,7 +78,7 @@ class GalleryControllerTest extends TestCase
 
         $formFactory = $this->createMock(FormFactoryInterface::class);
 
-        $gManager->expects($this->once())->method('findOneBy');
+        $gManager->expects(self::once())->method('findOneBy');
 
         $gController = new GalleryController($gManager, $mediaManager, $formFactory, 'test');
 
@@ -106,15 +106,15 @@ class GalleryControllerTest extends TestCase
         $formFactory = $this->createMock(FormFactoryInterface::class);
         $galleryHasMedias = new ArrayCollection([$galleryHasMedia]);
 
-        $gallery->expects($this->once())->method('getGalleryHasMedias')->willReturn($galleryHasMedias);
+        $gallery->expects(self::once())->method('getGalleryHasMedias')->willReturn($galleryHasMedias);
 
-        $gManager->expects($this->once())->method('findOneBy')->willReturn($gallery);
+        $gManager->expects(self::once())->method('findOneBy')->willReturn($gallery);
 
         $mediaManager = $this->createMock(MediaManagerInterface::class);
 
         $gController = new GalleryController($gManager, $mediaManager, $formFactory, 'test');
 
-        $this->assertSame($galleryHasMedias, $gController->getGalleryGalleryhasmediasAction(1));
+        self::assertSame($galleryHasMedias, $gController->getGalleryGalleryhasmediasAction(1));
     }
 
     public function testGetGalleryMediaAction(): void
@@ -123,19 +123,19 @@ class GalleryControllerTest extends TestCase
         $formFactory = $this->createMock(FormFactoryInterface::class);
 
         $galleryHasMedia = $this->createMock(GalleryHasMediaInterface::class);
-        $galleryHasMedia->expects($this->once())->method('getMedia')->willReturn($media);
+        $galleryHasMedia->expects(self::once())->method('getMedia')->willReturn($media);
 
         $gallery = $this->createMock(GalleryInterface::class);
-        $gallery->expects($this->once())->method('getGalleryHasMedias')->willReturn(new ArrayCollection([$galleryHasMedia]));
+        $gallery->expects(self::once())->method('getGalleryHasMedias')->willReturn(new ArrayCollection([$galleryHasMedia]));
 
         $gManager = $this->createMock(GalleryManagerInterface::class);
-        $gManager->expects($this->once())->method('findOneBy')->willReturn($gallery);
+        $gManager->expects(self::once())->method('findOneBy')->willReturn($gallery);
 
         $mediaManager = $this->createMock(MediaManagerInterface::class);
 
         $gController = new GalleryController($gManager, $mediaManager, $formFactory, 'test');
 
-        $this->assertSame([$media], $gController->getGalleryMediasAction(1));
+        self::assertSame([$media], $gController->getGalleryMediasAction(1));
     }
 
     /**
@@ -149,30 +149,30 @@ class GalleryControllerTest extends TestCase
         $media2->method('getId')->willReturn(1);
 
         $galleryHasMedia = $this->createMock(GalleryHasMediaInterface::class);
-        $galleryHasMedia->expects($this->once())->method('getMedia')->willReturn($media2);
+        $galleryHasMedia->expects(self::once())->method('getMedia')->willReturn($media2);
 
         $gallery = $this->createMock(GalleryInterface::class);
-        $gallery->expects($this->once())->method('getGalleryHasMedias')->willReturn(new ArrayCollection([$galleryHasMedia]));
+        $gallery->expects(self::once())->method('getGalleryHasMedias')->willReturn(new ArrayCollection([$galleryHasMedia]));
 
         $galleryManager = $this->createMock(GalleryManagerInterface::class);
-        $galleryManager->expects($this->once())->method('findOneBy')->willReturn($gallery);
+        $galleryManager->expects(self::once())->method('findOneBy')->willReturn($gallery);
 
         $mediaManager = $this->createMock(MediaManagerInterface::class);
-        $mediaManager->expects($this->once())->method('findOneBy')->willReturn($media);
+        $mediaManager->expects(self::once())->method('findOneBy')->willReturn($media);
 
         $form = $this->createMock(Form::class);
-        $form->expects($this->once())->method('handleRequest');
-        $form->expects($this->once())->method('isValid')->willReturn(true);
-        $form->expects($this->once())->method('getData')->willReturn($galleryHasMedia);
+        $form->expects(self::once())->method('handleRequest');
+        $form->expects(self::once())->method('isValid')->willReturn(true);
+        $form->expects(self::once())->method('getData')->willReturn($galleryHasMedia);
 
         $formFactory = $this->createMock(FormFactoryInterface::class);
-        $formFactory->expects($this->once())->method('createNamed')->willReturn($form);
+        $formFactory->expects(self::once())->method('createNamed')->willReturn($form);
 
         $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, GalleryHasMediaInterface::class);
         $view = $galleryController->postGalleryMediaGalleryhasmediaAction(1, 2, new Request());
 
-        $this->assertInstanceOf(View::class, $view);
-        $this->assertSame(200, $view->getResponse()->getStatusCode(), 'Should return 200');
+        self::assertInstanceOf(View::class, $view);
+        self::assertSame(200, $view->getResponse()->getStatusCode(), 'Should return 200');
     }
 
     public function testPostGalleryMediaGalleryhasmediaInvalidAction(): void
@@ -181,24 +181,24 @@ class GalleryControllerTest extends TestCase
         $media->method('getId')->willReturn(1);
 
         $galleryHasMedia = $this->createMock(GalleryHasMediaInterface::class);
-        $galleryHasMedia->expects($this->once())->method('getMedia')->willReturn($media);
+        $galleryHasMedia->expects(self::once())->method('getMedia')->willReturn($media);
 
         $gallery = $this->createMock(GalleryInterface::class);
-        $gallery->expects($this->once())->method('getGalleryHasMedias')->willReturn(new ArrayCollection([$galleryHasMedia]));
+        $gallery->expects(self::once())->method('getGalleryHasMedias')->willReturn(new ArrayCollection([$galleryHasMedia]));
 
         $galleryManager = $this->createMock(GalleryManagerInterface::class);
-        $galleryManager->expects($this->once())->method('findOneBy')->willReturn($gallery);
+        $galleryManager->expects(self::once())->method('findOneBy')->willReturn($gallery);
 
         $mediaManager = $this->createMock(MediaManagerInterface::class);
-        $mediaManager->expects($this->once())->method('findOneBy')->willReturn($media);
+        $mediaManager->expects(self::once())->method('findOneBy')->willReturn($media);
 
         $formFactory = $this->createMock(FormFactoryInterface::class);
 
         $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, GalleryHasMediaInterface::class);
         $view = $galleryController->postGalleryMediaGalleryhasmediaAction(1, 1, new Request());
 
-        $this->assertInstanceOf(View::class, $view);
-        $this->assertSame(400, $view->getResponse()->getStatusCode(), 'Should return 400');
+        self::assertInstanceOf(View::class, $view);
+        self::assertSame(400, $view->getResponse()->getStatusCode(), 'Should return 400');
     }
 
     /**
@@ -210,30 +210,30 @@ class GalleryControllerTest extends TestCase
         $media->method('getId')->willReturn(1);
 
         $galleryHasMedia = $this->createMock(GalleryHasMediaInterface::class);
-        $galleryHasMedia->expects($this->once())->method('getMedia')->willReturn($media);
+        $galleryHasMedia->expects(self::once())->method('getMedia')->willReturn($media);
 
         $gallery = $this->createMock(GalleryInterface::class);
-        $gallery->expects($this->once())->method('getGalleryHasMedias')->willReturn(new ArrayCollection([$galleryHasMedia]));
+        $gallery->expects(self::once())->method('getGalleryHasMedias')->willReturn(new ArrayCollection([$galleryHasMedia]));
 
         $galleryManager = $this->createMock(GalleryManagerInterface::class);
-        $galleryManager->expects($this->once())->method('findOneBy')->willReturn($gallery);
+        $galleryManager->expects(self::once())->method('findOneBy')->willReturn($gallery);
 
         $mediaManager = $this->createMock(MediaManagerInterface::class);
-        $mediaManager->expects($this->once())->method('findOneBy')->willReturn($media);
+        $mediaManager->expects(self::once())->method('findOneBy')->willReturn($media);
 
         $form = $this->createMock(Form::class);
-        $form->expects($this->once())->method('handleRequest');
-        $form->expects($this->once())->method('isValid')->willReturn(true);
-        $form->expects($this->once())->method('getData')->willReturn($galleryHasMedia);
+        $form->expects(self::once())->method('handleRequest');
+        $form->expects(self::once())->method('isValid')->willReturn(true);
+        $form->expects(self::once())->method('getData')->willReturn($galleryHasMedia);
 
         $formFactory = $this->createMock(FormFactoryInterface::class);
-        $formFactory->expects($this->once())->method('createNamed')->willReturn($form);
+        $formFactory->expects(self::once())->method('createNamed')->willReturn($form);
 
         $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, GalleryHasMediaInterface::class);
         $view = $galleryController->putGalleryMediaGalleryhasmediaAction(1, 1, new Request());
 
-        $this->assertInstanceOf(View::class, $view);
-        $this->assertSame(200, $view->getResponse()->getStatusCode(), 'Should return 200');
+        self::assertInstanceOf(View::class, $view);
+        self::assertSame(200, $view->getResponse()->getStatusCode(), 'Should return 200');
     }
 
     public function testPutGalleryMediaGalleryhasmediaInvalidAction(): void
@@ -242,28 +242,28 @@ class GalleryControllerTest extends TestCase
         $media->method('getId')->willReturn(1);
 
         $galleryHasMedia = $this->createMock(GalleryHasMediaInterface::class);
-        $galleryHasMedia->expects($this->once())->method('getMedia')->willReturn($media);
+        $galleryHasMedia->expects(self::once())->method('getMedia')->willReturn($media);
 
         $gallery = $this->createMock(GalleryInterface::class);
-        $gallery->expects($this->once())->method('getGalleryHasMedias')->willReturn(new ArrayCollection([$galleryHasMedia]));
+        $gallery->expects(self::once())->method('getGalleryHasMedias')->willReturn(new ArrayCollection([$galleryHasMedia]));
 
         $galleryManager = $this->createMock(GalleryManagerInterface::class);
-        $galleryManager->expects($this->once())->method('findOneBy')->willReturn($gallery);
+        $galleryManager->expects(self::once())->method('findOneBy')->willReturn($gallery);
 
         $mediaManager = $this->createMock(MediaManagerInterface::class);
-        $mediaManager->expects($this->once())->method('findOneBy')->willReturn($media);
+        $mediaManager->expects(self::once())->method('findOneBy')->willReturn($media);
 
         $form = $this->createMock(Form::class);
-        $form->expects($this->once())->method('handleRequest');
-        $form->expects($this->once())->method('isValid')->willReturn(false);
+        $form->expects(self::once())->method('handleRequest');
+        $form->expects(self::once())->method('isValid')->willReturn(false);
 
         $formFactory = $this->createMock(FormFactoryInterface::class);
-        $formFactory->expects($this->once())->method('createNamed')->willReturn($form);
+        $formFactory->expects(self::once())->method('createNamed')->willReturn($form);
 
         $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, GalleryHasMediaInterface::class);
         $view = $galleryController->putGalleryMediaGalleryhasmediaAction(1, 1, new Request());
 
-        $this->assertInstanceOf(FormInterface::class, $view);
+        self::assertInstanceOf(FormInterface::class, $view);
     }
 
     public function testDeleteGalleryMediaGalleryhasmediaAction(): void
@@ -272,23 +272,23 @@ class GalleryControllerTest extends TestCase
         $media->method('getId')->willReturn(1);
 
         $galleryHasMedia = $this->createMock(GalleryHasMediaInterface::class);
-        $galleryHasMedia->expects($this->once())->method('getMedia')->willReturn($media);
+        $galleryHasMedia->expects(self::once())->method('getMedia')->willReturn($media);
 
         $gallery = $this->createMock(GalleryInterface::class);
         $gallery->method('getGalleryHasMedias')->willReturn(new ArrayCollection([$galleryHasMedia]));
 
         $galleryManager = $this->createMock(GalleryManagerInterface::class);
-        $galleryManager->expects($this->once())->method('findOneBy')->willReturn($gallery);
+        $galleryManager->expects(self::once())->method('findOneBy')->willReturn($gallery);
 
         $mediaManager = $this->createMock(MediaManagerInterface::class);
-        $mediaManager->expects($this->once())->method('findOneBy')->willReturn($media);
+        $mediaManager->expects(self::once())->method('findOneBy')->willReturn($media);
 
         $formFactory = $this->createMock(FormFactoryInterface::class);
 
         $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, GalleryHasMediaInterface::class);
         $view = $galleryController->deleteGalleryMediaGalleryhasmediaAction(1, 1);
 
-        $this->assertSame(['deleted' => true], $view);
+        self::assertSame(['deleted' => true], $view);
     }
 
     public function testDeleteGalleryMediaGalleryhasmediaInvalidAction(): void
@@ -299,23 +299,23 @@ class GalleryControllerTest extends TestCase
         $media2->method('getId')->willReturn(2);
 
         $galleryHasMedia = $this->createMock(GalleryHasMediaInterface::class);
-        $galleryHasMedia->expects($this->once())->method('getMedia')->willReturn($media2);
+        $galleryHasMedia->expects(self::once())->method('getMedia')->willReturn($media2);
 
         $gallery = $this->createMock(GalleryInterface::class);
         $gallery->method('getGalleryHasMedias')->willReturn(new ArrayCollection([$galleryHasMedia]));
 
         $galleryManager = $this->createMock(GalleryManagerInterface::class);
-        $galleryManager->expects($this->once())->method('findOneBy')->willReturn($gallery);
+        $galleryManager->expects(self::once())->method('findOneBy')->willReturn($gallery);
 
         $mediaManager = $this->createMock(MediaManagerInterface::class);
-        $mediaManager->expects($this->once())->method('findOneBy')->willReturn($media);
+        $mediaManager->expects(self::once())->method('findOneBy')->willReturn($media);
 
         $formFactory = $this->createMock(FormFactoryInterface::class);
 
         $galleryController = new GalleryController($galleryManager, $mediaManager, $formFactory, GalleryHasMediaInterface::class);
         $view = $galleryController->deleteGalleryMediaGalleryhasmediaAction(1, 1);
 
-        $this->assertInstanceOf(View::class, $view);
-        $this->assertSame(400, $view->getResponse()->getStatusCode(), 'Should return 400');
+        self::assertInstanceOf(View::class, $view);
+        self::assertSame(400, $view->getResponse()->getStatusCode(), 'Should return 400');
     }
 }

--- a/tests/Controller/Api/MediaControllerTest.php
+++ b/tests/Controller/Api/MediaControllerTest.php
@@ -37,15 +37,15 @@ class MediaControllerTest extends TestCase
         $mManager = $this->createMock(MediaManagerInterface::class);
         $media = $this->createMock(MediaInterface::class);
 
-        $mManager->expects($this->once())->method('getPager')->willReturn([$media]);
+        $mManager->expects(self::once())->method('getPager')->willReturn([$media]);
 
         $mController = $this->createMediaController($mManager);
 
         $paramFetcher = $this->createMock(ParamFetcherInterface::class);
-        $paramFetcher->expects($this->exactly(3))->method('get');
-        $paramFetcher->expects($this->once())->method('all')->willReturn([]);
+        $paramFetcher->expects(self::exactly(3))->method('get');
+        $paramFetcher->expects(self::once())->method('all')->willReturn([]);
 
-        $this->assertSame([$media], $mController->getMediaAction($paramFetcher));
+        self::assertSame([$media], $mController->getMediaAction($paramFetcher));
     }
 
     public function testGetMediumAction(): void
@@ -53,11 +53,11 @@ class MediaControllerTest extends TestCase
         $media = $this->createMock(MediaInterface::class);
 
         $manager = $this->createMock(MediaManagerInterface::class);
-        $manager->expects($this->once())->method('find')->willReturn($media);
+        $manager->expects(self::once())->method('find')->willReturn($media);
 
         $controller = $this->createMediaController($manager);
 
-        $this->assertSame($media, $controller->getMediumAction(1));
+        self::assertSame($media, $controller->getMediumAction(1));
     }
 
     /**
@@ -89,14 +89,14 @@ class MediaControllerTest extends TestCase
         $media = $this->createMock(MediaInterface::class);
 
         $manager = $this->createMock(MediaManagerInterface::class);
-        $manager->expects($this->once())->method('find')->willReturn($media);
+        $manager->expects(self::once())->method('find')->willReturn($media);
 
         $provider = $this->createMock(MediaProviderInterface::class);
-        $provider->expects($this->exactly(2))->method('getHelperProperties')->willReturn(['foo' => 'bar']);
+        $provider->expects(self::exactly(2))->method('getHelperProperties')->willReturn(['foo' => 'bar']);
 
         $pool = $this->createMock(Pool::class);
         $pool->method('getProvider')->willReturn($provider);
-        $pool->expects($this->once())->method('getFormatNamesByContext')->willReturn(['format_name1' => 'value1']);
+        $pool->expects(self::once())->method('getFormatNamesByContext')->willReturn(['format_name1' => 'value1']);
 
         $controller = $this->createMediaController($manager, $pool);
 
@@ -114,7 +114,7 @@ class MediaControllerTest extends TestCase
                 ],
             ],
         ];
-        $this->assertSame($expected, $controller->getMediumFormatsAction(1));
+        self::assertSame($expected, $controller->getMediumFormatsAction(1));
     }
 
     public function testGetMediumBinariesAction(): void
@@ -124,30 +124,30 @@ class MediaControllerTest extends TestCase
         $binaryResponse = $this->createMock(BinaryFileResponse::class);
 
         $manager = $this->createMock(MediaManagerInterface::class);
-        $manager->expects($this->once())->method('find')->willReturn($media);
+        $manager->expects(self::once())->method('find')->willReturn($media);
 
         $provider = $this->createMock(MediaProviderInterface::class);
-        $provider->expects($this->once())->method('getDownloadResponse')->willReturn($binaryResponse);
+        $provider->expects(self::once())->method('getDownloadResponse')->willReturn($binaryResponse);
 
         $pool = $this->createMock(Pool::class);
-        $pool->expects($this->once())->method('getProvider')->willReturn($provider);
+        $pool->expects(self::once())->method('getProvider')->willReturn($provider);
 
         $controller = $this->createMediaController($manager, $pool);
 
-        $this->assertSame($binaryResponse, $controller->getMediumBinaryAction(1, 'format', new Request()));
+        self::assertSame($binaryResponse, $controller->getMediumBinaryAction(1, 'format', new Request()));
     }
 
     public function testDeleteMediumAction(): void
     {
         $manager = $this->createMock(MediaManagerInterface::class);
-        $manager->expects($this->once())->method('delete');
-        $manager->expects($this->once())->method('find')->willReturn($this->createMock(MediaInterface::class));
+        $manager->expects(self::once())->method('delete');
+        $manager->expects(self::once())->method('find')->willReturn($this->createMock(MediaInterface::class));
 
         $controller = $this->createMediaController($manager);
 
         $expected = ['deleted' => true];
 
-        $this->assertSame($expected, $controller->deleteMediumAction(1));
+        self::assertSame($expected, $controller->deleteMediumAction(1));
     }
 
     public function testPutMediumAction(): void
@@ -155,25 +155,25 @@ class MediaControllerTest extends TestCase
         $medium = $this->createMock(MediaInterface::class);
 
         $manager = $this->createMock(MediaManagerInterface::class);
-        $manager->expects($this->once())->method('find')->willReturn($medium);
+        $manager->expects(self::once())->method('find')->willReturn($medium);
 
         $provider = $this->createMock(MediaProviderInterface::class);
-        $provider->expects($this->once())->method('getName');
+        $provider->expects(self::once())->method('getName');
 
         $pool = $this->createMock(Pool::class);
-        $pool->expects($this->once())->method('getProvider')->willReturn($provider);
+        $pool->expects(self::once())->method('getProvider')->willReturn($provider);
 
         $form = $this->createMock(Form::class);
-        $form->expects($this->once())->method('handleRequest');
-        $form->expects($this->once())->method('isValid')->willReturn(true);
-        $form->expects($this->once())->method('getData')->willReturn($medium);
+        $form->expects(self::once())->method('handleRequest');
+        $form->expects(self::once())->method('isValid')->willReturn(true);
+        $form->expects(self::once())->method('getData')->willReturn($medium);
 
         $factory = $this->createMock(FormFactoryInterface::class);
-        $factory->expects($this->once())->method('createNamed')->willReturn($form);
+        $factory->expects(self::once())->method('createNamed')->willReturn($form);
 
         $controller = $this->createMediaController($manager, $pool, $factory);
 
-        $this->assertInstanceOf(View::class, $controller->putMediumAction(1, new Request()));
+        self::assertInstanceOf(View::class, $controller->putMediumAction(1, new Request()));
     }
 
     public function testPutMediumInvalidFormAction(): void
@@ -181,51 +181,51 @@ class MediaControllerTest extends TestCase
         $medium = $this->createMock(MediaInterface::class);
 
         $manager = $this->createMock(MediaManagerInterface::class);
-        $manager->expects($this->once())->method('find')->willReturn($medium);
+        $manager->expects(self::once())->method('find')->willReturn($medium);
 
         $provider = $this->createMock(MediaProviderInterface::class);
-        $provider->expects($this->once())->method('getName');
+        $provider->expects(self::once())->method('getName');
 
         $pool = $this->createMock(Pool::class);
-        $pool->expects($this->once())->method('getProvider')->willReturn($provider);
+        $pool->expects(self::once())->method('getProvider')->willReturn($provider);
 
         $form = $this->createMock(Form::class);
-        $form->expects($this->once())->method('handleRequest');
-        $form->expects($this->once())->method('isValid')->willReturn(false);
+        $form->expects(self::once())->method('handleRequest');
+        $form->expects(self::once())->method('isValid')->willReturn(false);
 
         $factory = $this->createMock(FormFactoryInterface::class);
-        $factory->expects($this->once())->method('createNamed')->willReturn($form);
+        $factory->expects(self::once())->method('createNamed')->willReturn($form);
 
         $controller = $this->createMediaController($manager, $pool, $factory);
 
-        $this->assertInstanceOf(Form::class, $controller->putMediumAction(1, new Request()));
+        self::assertInstanceOf(Form::class, $controller->putMediumAction(1, new Request()));
     }
 
     public function testPostProviderMediumAction(): void
     {
         $medium = $this->createMock(MediaInterface::class);
-        $medium->expects($this->once())->method('setProviderName');
+        $medium->expects(self::once())->method('setProviderName');
 
         $manager = $this->createMock(MediaManagerInterface::class);
-        $manager->expects($this->once())->method('create')->willReturn($medium);
+        $manager->expects(self::once())->method('create')->willReturn($medium);
 
         $provider = $this->createMock(MediaProviderInterface::class);
-        $provider->expects($this->once())->method('getName');
+        $provider->expects(self::once())->method('getName');
 
         $pool = $this->createMock(Pool::class);
-        $pool->expects($this->once())->method('getProvider')->willReturn($provider);
+        $pool->expects(self::once())->method('getProvider')->willReturn($provider);
 
         $form = $this->createMock(Form::class);
-        $form->expects($this->once())->method('handleRequest');
-        $form->expects($this->once())->method('isValid')->willReturn(true);
-        $form->expects($this->once())->method('getData')->willReturn($medium);
+        $form->expects(self::once())->method('handleRequest');
+        $form->expects(self::once())->method('isValid')->willReturn(true);
+        $form->expects(self::once())->method('getData')->willReturn($medium);
 
         $factory = $this->createMock(FormFactoryInterface::class);
-        $factory->expects($this->once())->method('createNamed')->willReturn($form);
+        $factory->expects(self::once())->method('createNamed')->willReturn($form);
 
         $controller = $this->createMediaController($manager, $pool, $factory);
 
-        $this->assertInstanceOf(View::class, $controller->postProviderMediumAction('providerName', new Request()));
+        self::assertInstanceOf(View::class, $controller->postProviderMediumAction('providerName', new Request()));
     }
 
     public function testPostProviderActionNotFound(): void
@@ -233,13 +233,13 @@ class MediaControllerTest extends TestCase
         $this->expectException(NotFoundHttpException::class);
 
         $medium = $this->createMock(MediaInterface::class);
-        $medium->expects($this->once())->method('setProviderName');
+        $medium->expects(self::once())->method('setProviderName');
 
         $manager = $this->createMock(MediaManagerInterface::class);
-        $manager->expects($this->once())->method('create')->willReturn($medium);
+        $manager->expects(self::once())->method('create')->willReturn($medium);
 
         $pool = $this->createMock(Pool::class);
-        $pool->expects($this->once())->method('getProvider')->will($this->throwException(new \RuntimeException('exception on getProvder')));
+        $pool->expects(self::once())->method('getProvider')->will(self::throwException(new \RuntimeException('exception on getProvder')));
 
         $controller = $this->createMediaController($manager, $pool);
         $controller->postProviderMediumAction('non existing provider', new Request());
@@ -248,16 +248,16 @@ class MediaControllerTest extends TestCase
     public function testPutMediumBinaryContentAction(): void
     {
         $media = $this->createMock(MediaInterface::class);
-        $media->expects($this->once())->method('setBinaryContent');
+        $media->expects(self::once())->method('setBinaryContent');
 
         $manager = $this->createMock(MediaManagerInterface::class);
-        $manager->expects($this->once())->method('find')->willReturn($media);
+        $manager->expects(self::once())->method('find')->willReturn($media);
 
         $pool = $this->createMock(Pool::class);
 
         $controller = $this->createMediaController($manager, $pool);
 
-        $this->assertSame($media, $controller->putMediumBinaryContentAction(1, new Request()));
+        self::assertSame($media, $controller->putMediumBinaryContentAction(1, new Request()));
     }
 
     protected function createMediaController(

--- a/tests/Controller/GalleryAdminControllerTest.php
+++ b/tests/Controller/GalleryAdminControllerTest.php
@@ -63,7 +63,7 @@ class GalleryAdminControllerTest extends TestCase
 
     public function testItIsInstantiable(): void
     {
-        $this->assertNotNull($this->controller);
+        self::assertNotNull($this->controller);
     }
 
     public function testListAction(): void
@@ -76,11 +76,11 @@ class GalleryAdminControllerTest extends TestCase
         $this->configureSetFormTheme($formView, ['filterTheme']);
         $this->configureSetCsrfToken('sonata.batch');
         $this->configureRender('templateList', 'renderResponse');
-        $datagrid->expects($this->once())->method('setValue')->with('context', null, 'context');
+        $datagrid->expects(self::once())->method('setValue')->with('context', null, 'context');
         $datagrid->method('getForm')->willReturn($form);
         $form->method('createView')->willReturn($formView);
-        $this->admin->expects($this->once())->method('checkAccess')->with('list');
-        $this->admin->expects($this->once())->method('setListMode')->with('list');
+        $this->admin->expects(self::once())->method('checkAccess')->with('list');
+        $this->admin->expects(self::once())->method('setListMode')->with('list');
         $this->admin->method('getDatagrid')->willReturn($datagrid);
         $this->admin->method('getPersistentParameter')->with('context')->willReturn('context');
         $this->admin->method('getFilterTheme')->willReturn(['filterTheme']);
@@ -111,7 +111,7 @@ class GalleryAdminControllerTest extends TestCase
             ['list', 'templateList'],
         ]);
         $this->admin->method('isChild')->willReturn(false);
-        $this->admin->expects($this->once())->method('setRequest')->with($this->request);
+        $this->admin->expects(self::once())->method('setRequest')->with($this->request);
         $this->admin->method('getCode')->willReturn('admin_code');
     }
 
@@ -138,7 +138,7 @@ class GalleryAdminControllerTest extends TestCase
         $twigRenderer = $this->createMock(FormRenderer::class);
 
         $this->twig->method('getRuntime')->with(FormRenderer::class)->willReturn($twigRenderer);
-        $twigRenderer->expects($this->once())->method('setTheme')->with($formView, $formTheme);
+        $twigRenderer->expects(self::once())->method('setTheme')->with($formView, $formTheme);
     }
 
     private function configureRender(string $template, string $rendered): void
@@ -149,6 +149,6 @@ class GalleryAdminControllerTest extends TestCase
         $this->admin->method('getPersistentParameters')->willReturn(['param' => 'param']);
         $this->container->set('sonata.media.pool', $pool);
         $response->method('getContent')->willReturn($rendered);
-        $this->twig->method('render')->with($template, $this->isType('array'))->willReturn($rendered);
+        $this->twig->method('render')->with($template, self::isType('array'))->willReturn($rendered);
     }
 }

--- a/tests/Controller/MediaAdminControllerTest.php
+++ b/tests/Controller/MediaAdminControllerTest.php
@@ -80,7 +80,6 @@ class MediaAdminControllerTest extends TestCase
         $pool->method('getDefaultContext')->willReturn('default_context');
         $this->admin->expects(self::once())->method('checkAccess')->with('create');
         $this->container->set('sonata.media.pool', $pool);
-        $this->request->query->set('provider', false);
         $this->request->query->set('context', 'context');
 
         $response = $this->controller->createAction($this->request);
@@ -101,7 +100,7 @@ class MediaAdminControllerTest extends TestCase
         $this->admin
             ->method('getIdParameter')
             ->willReturn('id');
-        $this->request->query->set('provider', true);
+        $this->request->query->set('provider', 'provider');
         $response = $this->controller->createAction($this->request);
 
         self::assertInstanceOf(Response::class, $response);
@@ -138,7 +137,7 @@ class MediaAdminControllerTest extends TestCase
         $this->admin->expects(self::once())->method('checkAccess')->with('list');
         $this->admin->expects(self::once())->method('setListMode')->with('mosaic');
         $this->admin->method('getDatagrid')->willReturn($datagrid);
-        $this->admin->method('getPersistentParameter')->with('context', 'context')->willReturn('another_context');
+        $this->admin->method('getPersistentParameter')->with('context')->willReturn('another_context');
         $this->admin->method('getFilterTheme')->willReturn(['filterTheme']);
         $this->request->query->set('_list_mode', 'mosaic');
         $this->request->query->set('filter', []);

--- a/tests/Controller/MediaAdminControllerTest.php
+++ b/tests/Controller/MediaAdminControllerTest.php
@@ -78,15 +78,15 @@ class MediaAdminControllerTest extends TestCase
         );
         $pool->method('getProvidersByContext')->with('context')->willReturn(['provider']);
         $pool->method('getDefaultContext')->willReturn('default_context');
-        $this->admin->expects($this->once())->method('checkAccess')->with('create');
+        $this->admin->expects(self::once())->method('checkAccess')->with('create');
         $this->container->set('sonata.media.pool', $pool);
         $this->request->query->set('provider', false);
         $this->request->query->set('context', 'context');
 
         $response = $this->controller->createAction($this->request);
 
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertSame('renderResponse', $response->getContent());
+        self::assertInstanceOf(Response::class, $response);
+        self::assertSame('renderResponse', $response->getContent());
     }
 
     public function testCreateAction(): void
@@ -94,7 +94,7 @@ class MediaAdminControllerTest extends TestCase
         $this->configureCreateAction(Media::class);
         $this->configureRender('template', 'renderResponse');
         $this->admin
-            ->expects($this->atLeastOnce())
+            ->expects(self::atLeastOnce())
             ->method('checkAccess')
             ->with('create');
 
@@ -104,8 +104,8 @@ class MediaAdminControllerTest extends TestCase
         $this->request->query->set('provider', true);
         $response = $this->controller->createAction($this->request);
 
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertSame('renderResponse', $response->getContent());
+        self::assertInstanceOf(Response::class, $response);
+        self::assertSame('renderResponse', $response->getContent());
     }
 
     public function testListAction(): void
@@ -121,7 +121,7 @@ class MediaAdminControllerTest extends TestCase
         $this->configureSetFormTheme($formView, ['filterTheme']);
         $this->configureSetCsrfToken('sonata.batch');
         $this->configureRender('templateList', 'renderResponse');
-        $datagrid->expects($this->exactly(3))->method('setValue')->withConsecutive(
+        $datagrid->expects(self::exactly(3))->method('setValue')->withConsecutive(
             ['context', null, 'another_context'],
             ['category', null, 1]
         );
@@ -135,8 +135,8 @@ class MediaAdminControllerTest extends TestCase
         $form->method('createView')->willReturn($formView);
         $this->container->set('sonata.media.pool', $pool);
         $this->container->set('sonata.media.manager.category', $categoryManager);
-        $this->admin->expects($this->once())->method('checkAccess')->with('list');
-        $this->admin->expects($this->once())->method('setListMode')->with('mosaic');
+        $this->admin->expects(self::once())->method('checkAccess')->with('list');
+        $this->admin->expects(self::once())->method('setListMode')->with('mosaic');
         $this->admin->method('getDatagrid')->willReturn($datagrid);
         $this->admin->method('getPersistentParameter')->with('context', 'context')->willReturn('another_context');
         $this->admin->method('getFilterTheme')->willReturn(['filterTheme']);
@@ -146,8 +146,8 @@ class MediaAdminControllerTest extends TestCase
 
         $response = $this->controller->listAction($this->request);
 
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertSame('renderResponse', $response->getContent());
+        self::assertInstanceOf(Response::class, $response);
+        self::assertSame('renderResponse', $response->getContent());
     }
 
     private function configureCRUDController(): void
@@ -169,7 +169,7 @@ class MediaAdminControllerTest extends TestCase
             ['list', 'templateList'],
         ]);
         $this->admin->method('isChild')->willReturn(false);
-        $this->admin->expects($this->once())->method('setRequest')->with($this->request);
+        $this->admin->expects(self::once())->method('setRequest')->with($this->request);
         $this->admin->method('getCode')->willReturn('admin_code');
     }
 
@@ -183,12 +183,12 @@ class MediaAdminControllerTest extends TestCase
         $this->admin->method('hasActiveSubClass')->willReturn(false);
         $this->admin->method('getClass')->willReturn($class);
         $this->admin->method('getNewInstance')->willReturn($object);
-        $this->admin->expects($this->once())->method('setSubject')->with($object);
+        $this->admin->expects(self::once())->method('setSubject')->with($object);
         $this->admin->method('getForm')->willReturn($form);
         $this->admin->method('getFormTheme')->willReturn(['formTheme']);
         $form->method('createView')->willReturn($formView);
-        $form->expects($this->once())->method('setData')->with($object);
-        $form->expects($this->once())->method('handleRequest')->with($this->request);
+        $form->expects(self::once())->method('setData')->with($object);
+        $form->expects(self::once())->method('handleRequest')->with($this->request);
         $form->method('isSubmitted')->willReturn(false);
         $form->method('all')->willReturn(['field' => null]);
     }
@@ -209,7 +209,7 @@ class MediaAdminControllerTest extends TestCase
 
         $this->twig->method('getRuntime')->with($rendererClass)->willReturn($twigRenderer);
 
-        $twigRenderer->expects($this->once())->method('setTheme')->with($formView, $formTheme);
+        $twigRenderer->expects(self::once())->method('setTheme')->with($formView, $formTheme);
     }
 
     private function configureSetCsrfToken(string $intention): void
@@ -230,6 +230,6 @@ class MediaAdminControllerTest extends TestCase
         $this->admin->method('getPersistentParameters')->willReturn(['param' => 'param']);
         $this->container->set('sonata.media.pool', $pool);
         $response->method('getContent')->willReturn($rendered);
-        $this->twig->method('render')->with($template, $this->isType('array'))->willReturn($rendered);
+        $this->twig->method('render')->with($template, self::isType('array'))->willReturn($rendered);
     }
 }

--- a/tests/Controller/MediaControllerTest.php
+++ b/tests/Controller/MediaControllerTest.php
@@ -90,11 +90,11 @@ class MediaControllerTest extends TestCase
         $this->container->set('sonata.media.pool', $pool);
         $pool->method('getDownloadMode')->with($media)->willReturn('mode');
         $provider->method('getDownloadResponse')->with($media, 'format', 'mode')->willReturn($response);
-        $response->expects($this->once())->method('prepare')->with($request);
+        $response->expects(self::once())->method('prepare')->with($request);
 
         $result = $this->controller->downloadAction(1, 'format');
 
-        $this->assertSame($response, $result);
+        self::assertSame($response, $result);
     }
 
     public function testViewActionWithNotFoundMedia(): void
@@ -142,8 +142,8 @@ class MediaControllerTest extends TestCase
 
         $response = $this->controller->viewAction(1, 'format');
 
-        $this->assertInstanceOf(Response::class, $response);
-        $this->assertSame('renderResponse', $response->getContent());
+        self::assertInstanceOf(Response::class, $response);
+        self::assertSame('renderResponse', $response->getContent());
     }
 
     private function configureDownloadSecurity(

--- a/tests/DependencyInjection/Compiler/AddProviderCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddProviderCompilerPassTest.php
@@ -92,14 +92,14 @@ class AddProviderCompilerPassTest extends TestCase
         foreach ($calls as $call) {
             if ('addFormat' === $call[0]) {
                 $callFound = true;
-                $this->assertSame(
+                self::assertSame(
                     $expectedCall,
                     $call[1],
                     'Format config of "foo_provider" doesn\'t match the expected config.'
                 );
             }
         }
-        $this->assertTrue(
+        self::assertTrue(
             $callFound,
             'Expected "addFormat" method call on "foo_provider" service was not registered.'
         );

--- a/tests/DependencyInjection/Compiler/ThumbnailCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ThumbnailCompilerPassTest.php
@@ -36,7 +36,7 @@ final class ThumbnailCompilerPassTest extends TestCase
 
         (new ThumbnailCompilerPass())->process($container);
 
-        $this->assertSame($expected, $thumbnailDefinition->hasMethodCall('addResizer'));
+        self::assertSame($expected, $thumbnailDefinition->hasMethodCall('addResizer'));
     }
 
     public function processProvider(): array

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -43,12 +43,12 @@ class ConfigurationTest extends TestCase
 
     public function testProcess(): void
     {
-        $this->assertArrayHasKey('resizers', $this->config);
-        $this->assertArrayHasKey('default', $this->config['resizers']);
-        $this->assertSame('sonata.media.resizer.simple', $this->config['resizers']['default']);
+        self::assertArrayHasKey('resizers', $this->config);
+        self::assertArrayHasKey('default', $this->config['resizers']);
+        self::assertSame('sonata.media.resizer.simple', $this->config['resizers']['default']);
 
-        $this->assertArrayHasKey('adapters', $this->config);
-        $this->assertArrayHasKey('default', $this->config['adapters']);
-        $this->assertSame('sonata.media.adapter.image.gd', $this->config['adapters']['default']);
+        self::assertArrayHasKey('adapters', $this->config);
+        self::assertArrayHasKey('default', $this->config['adapters']);
+        self::assertSame('sonata.media.adapter.image.gd', $this->config['adapters']['default']);
     }
 }

--- a/tests/DependencyInjection/SonataMediaExtensionTest.php
+++ b/tests/DependencyInjection/SonataMediaExtensionTest.php
@@ -114,7 +114,7 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
 
         $this->assertContainerBuilderHasService($serviceId);
         if (\extension_loaded($extension)) {
-            $this->assertInstanceOf($type, $this->container->get($serviceId));
+            self::assertInstanceOf($type, $this->container->get($serviceId));
         }
     }
 
@@ -170,7 +170,7 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
 
         $this->assertContainerBuilderHasService($serviceId);
         if (\extension_loaded('gd')) {
-            $this->assertInstanceOf($type, $this->container->get($serviceId));
+            self::assertInstanceOf($type, $this->container->get($serviceId));
         }
     }
 
@@ -186,7 +186,7 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
     {
         $this->load();
 
-        $this->assertSame(
+        self::assertSame(
             $this->container->getDefinition('sonata.media.security.superadmin_strategy')->getArgument(2),
             ['ROLE_ADMIN', 'ROLE_SUPER_ADMIN']
         );
@@ -196,14 +196,14 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
     {
         $fakeContainer = $this->createMock(ContainerBuilder::class);
 
-        $fakeContainer->expects($this->once())
+        $fakeContainer->expects(self::once())
             ->method('getParameter')
-            ->with($this->equalTo('kernel.bundles'))
+            ->with(self::equalTo('kernel.bundles'))
             ->willReturn($this->container->getParameter('kernel.bundles'));
 
-        $fakeContainer->expects($this->once())
+        $fakeContainer->expects(self::once())
             ->method('getExtensionConfig')
-            ->with($this->equalTo('sonata_admin'))
+            ->with(self::equalTo('sonata_admin'))
             ->willReturn([[
                 'security' => [
                     'role_admin' => 'ROLE_FOO',
@@ -220,7 +220,7 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
             $extension->load($configs, $this->container);
         }
 
-        $this->assertSame(
+        self::assertSame(
             $this->container->getDefinition('sonata.media.security.superadmin_strategy')->getArgument(2),
             ['ROLE_FOO', 'ROLE_BAR']
         );
@@ -232,12 +232,12 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
     public function testLoadWithFilesystemConfigurationV3(array $expected, array $configs): void
     {
         if (!class_exists(Sdk::class)) {
-            $this->markTestSkipped('This test requires aws/aws-sdk-php 3.x.');
+            self::markTestSkipped('This test requires aws/aws-sdk-php 3.x.');
         }
 
         $this->load($configs);
 
-        $this->assertSame(
+        self::assertSame(
             $expected,
             $this->container->getDefinition('sonata.media.adapter.service.s3')->getArgument(0)
         );
@@ -363,7 +363,7 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
     public function testCdnCloudFront(): void
     {
         if (!class_exists(CloudFrontClient::class) || class_exists(Sdk::class)) {
-            $this->markTestSkipped('This test requires "aws/aws-sdk-php:^2.0" to be installed.');
+            self::markTestSkipped('This test requires "aws/aws-sdk-php:^2.0" to be installed.');
         }
 
         $this->load([
@@ -378,21 +378,21 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
         ]);
 
         $this->assertContainerBuilderHasService('sonata.media.cdn.cloudfront.client', CloudFrontClient::class);
-        $this->assertSame(
+        self::assertSame(
             $this->container->getDefinition('sonata.media.cdn.cloudfront.client')->getArgument(0),
             [
                 'key' => 'cloudfront_key',
                 'secret' => 'cloudfront_secret',
             ]
         );
-        $this->assertSame([CloudFrontClient::class, 'factory'], $this->container->getDefinition('sonata.media.cdn.cloudfront.client')->getFactory());
+        self::assertSame([CloudFrontClient::class, 'factory'], $this->container->getDefinition('sonata.media.cdn.cloudfront.client')->getFactory());
         $this->assertContainerBuilderHasService('sonata.media.cdn.cloudfront', CloudFront::class);
     }
 
     public function testCdnCloudFrontVersion3(): void
     {
         if (!class_exists(CloudFrontClient::class) || !class_exists(Sdk::class)) {
-            $this->markTestSkipped('This test requires "aws/aws-sdk-php:^3.0" to be installed.');
+            self::markTestSkipped('This test requires "aws/aws-sdk-php:^3.0" to be installed.');
         }
 
         $this->load([
@@ -409,7 +409,7 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
         ]);
 
         $this->assertContainerBuilderHasService('sonata.media.cdn.cloudfront.client', CloudFrontClient::class);
-        $this->assertSame(
+        self::assertSame(
             $this->container->getDefinition('sonata.media.cdn.cloudfront.client')->getArgument(0),
             [
                 'region' => 'cloudfront_region',
@@ -420,7 +420,7 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
                 ],
             ]
         );
-        $this->assertNull($this->container->getDefinition('sonata.media.cdn.cloudfront.client')->getFactory());
+        self::assertNull($this->container->getDefinition('sonata.media.cdn.cloudfront.client')->getFactory());
         $this->assertContainerBuilderHasService('sonata.media.cdn.cloudfront', CloudFrontVersion3::class);
     }
 

--- a/tests/Document/MediaManagerTest.php
+++ b/tests/Document/MediaManagerTest.php
@@ -38,14 +38,14 @@ class MediaManagerTest extends TestCase
         $media = new Media();
         $this->manager->save($media, 'default', 'media.test');
 
-        $this->assertSame('default', $media->getContext());
-        $this->assertSame('media.test', $media->getProviderName());
+        self::assertSame('default', $media->getContext());
+        self::assertSame('media.test', $media->getProviderName());
 
         $media = new Media();
         $this->manager->save($media, true);
 
-        $this->assertNull($media->getContext());
-        $this->assertNull($media->getProviderName());
+        self::assertNull($media->getContext());
+        self::assertNull($media->getProviderName());
     }
 
     public function testSaveException(): void

--- a/tests/Entity/GalleryManagerTest.php
+++ b/tests/Entity/GalleryManagerTest.php
@@ -30,14 +30,14 @@ class GalleryManagerTest extends TestCase
     public function testGetPager(): void
     {
         $this
-            ->getGalleryManager(function (MockObject $qb): void {
-                $qb->expects($this->once())->method('getRootAliases')->willReturn(['g']);
-                $qb->expects($this->never())->method('andWhere');
-                $qb->expects($this->once())->method('orderBy')->with(
-                    $this->equalTo('g.name'),
-                    $this->equalTo('ASC')
+            ->getGalleryManager(static function (MockObject $qb): void {
+                $qb->expects(self::once())->method('getRootAliases')->willReturn(['g']);
+                $qb->expects(self::never())->method('andWhere');
+                $qb->expects(self::once())->method('orderBy')->with(
+                    self::equalTo('g.name'),
+                    self::equalTo('ASC')
                 );
-                $qb->expects($this->once())->method('setParameters')->with($this->equalTo([]));
+                $qb->expects(self::once())->method('setParameters')->with(self::equalTo([]));
             })
             ->getPager([], 1);
     }
@@ -56,20 +56,20 @@ class GalleryManagerTest extends TestCase
     public function testGetPagerWithMultipleSort(): void
     {
         $this
-            ->getGalleryManager(function (MockObject $qb): void {
-                $qb->expects($this->once())->method('getRootAliases')->willReturn(['g']);
-                $qb->expects($this->never())->method('andWhere');
-                $qb->expects($this->exactly(2))->method('orderBy')->with(
-                    $this->logicalOr(
-                        $this->equalTo('g.name'),
-                        $this->equalTo('g.context')
+            ->getGalleryManager(static function (MockObject $qb): void {
+                $qb->expects(self::once())->method('getRootAliases')->willReturn(['g']);
+                $qb->expects(self::never())->method('andWhere');
+                $qb->expects(self::exactly(2))->method('orderBy')->with(
+                    self::logicalOr(
+                        self::equalTo('g.name'),
+                        self::equalTo('g.context')
                     ),
-                    $this->logicalOr(
-                        $this->equalTo('ASC'),
-                        $this->equalTo('DESC')
+                    self::logicalOr(
+                        self::equalTo('ASC'),
+                        self::equalTo('DESC')
                     )
                 );
-                $qb->expects($this->once())->method('setParameters')->with($this->equalTo([]));
+                $qb->expects(self::once())->method('setParameters')->with(self::equalTo([]));
             })
             ->getPager([], 1, 10, [
                 'name' => 'ASC',
@@ -80,10 +80,10 @@ class GalleryManagerTest extends TestCase
     public function testGetPagerWithEnabledGalleries(): void
     {
         $this
-            ->getGalleryManager(function (MockObject $qb): void {
-                $qb->expects($this->once())->method('getRootAliases')->willReturn(['g']);
-                $qb->expects($this->once())->method('andWhere')->with($this->equalTo('g.enabled = :enabled'));
-                $qb->expects($this->once())->method('setParameters')->with($this->equalTo(['enabled' => true]));
+            ->getGalleryManager(static function (MockObject $qb): void {
+                $qb->expects(self::once())->method('getRootAliases')->willReturn(['g']);
+                $qb->expects(self::once())->method('andWhere')->with(self::equalTo('g.enabled = :enabled'));
+                $qb->expects(self::once())->method('setParameters')->with(self::equalTo(['enabled' => true]));
             })
             ->getPager(['enabled' => true], 1);
     }
@@ -91,10 +91,10 @@ class GalleryManagerTest extends TestCase
     public function testGetPagerWithNoEnabledGalleries(): void
     {
         $this
-            ->getGalleryManager(function (MockObject $qb): void {
-                $qb->expects($this->once())->method('getRootAliases')->willReturn(['g']);
-                $qb->expects($this->once())->method('andWhere')->with($this->equalTo('g.enabled = :enabled'));
-                $qb->expects($this->once())->method('setParameters')->with($this->equalTo(['enabled' => false]));
+            ->getGalleryManager(static function (MockObject $qb): void {
+                $qb->expects(self::once())->method('getRootAliases')->willReturn(['g']);
+                $qb->expects(self::once())->method('andWhere')->with(self::equalTo('g.enabled = :enabled'));
+                $qb->expects(self::once())->method('setParameters')->with(self::equalTo(['enabled' => false]));
             })
             ->getPager(['enabled' => false], 1);
     }

--- a/tests/Entity/MediaManagerTest.php
+++ b/tests/Entity/MediaManagerTest.php
@@ -29,12 +29,11 @@ class MediaManagerTest extends TestCase
 
     public function testGetPager(): void
     {
-        $self = $this;
         $this
-            ->getMediaManager(static function (MockObject $qb) use ($self): void {
-                $qb->expects($self->once())->method('getRootAliases')->willReturn(['g']);
-                $qb->expects($self->never())->method('andWhere');
-                $qb->expects($self->once())->method('setParameters')->with($self->equalTo([]));
+            ->getMediaManager(static function (MockObject $qb): void {
+                $qb->expects(self::once())->method('getRootAliases')->willReturn(['g']);
+                $qb->expects(self::never())->method('andWhere');
+                $qb->expects(self::once())->method('setParameters')->with(self::equalTo([]));
             })
             ->getPager([], 1);
     }
@@ -52,22 +51,21 @@ class MediaManagerTest extends TestCase
 
     public function testGetPagerWithMultipleSort(): void
     {
-        $self = $this;
         $this
-            ->getMediaManager(static function (MockObject $qb) use ($self): void {
-                $qb->expects($self->once())->method('getRootAliases')->willReturn(['g']);
-                $qb->expects($self->never())->method('andWhere');
-                $qb->expects($self->exactly(2))->method('orderBy')->with(
-                    $self->logicalOr(
-                        $self->equalTo('m.name'),
-                        $self->equalTo('m.description')
+            ->getMediaManager(static function (MockObject $qb): void {
+                $qb->expects(self::once())->method('getRootAliases')->willReturn(['g']);
+                $qb->expects(self::never())->method('andWhere');
+                $qb->expects(self::exactly(2))->method('orderBy')->with(
+                    self::logicalOr(
+                        self::equalTo('m.name'),
+                        self::equalTo('m.description')
                     ),
-                    $self->logicalOr(
-                        $self->equalTo('ASC'),
-                        $self->equalTo('DESC')
+                    self::logicalOr(
+                        self::equalTo('ASC'),
+                        self::equalTo('DESC')
                     )
                 );
-                $qb->expects($self->once())->method('setParameters')->with($self->equalTo([]));
+                $qb->expects(self::once())->method('setParameters')->with(self::equalTo([]));
             })
             ->getPager([], 1, 10, [
                 'name' => 'ASC',
@@ -77,24 +75,22 @@ class MediaManagerTest extends TestCase
 
     public function testGetPagerWithEnabledMedia(): void
     {
-        $self = $this;
         $this
-            ->getMediaManager(static function (MockObject $qb) use ($self): void {
-                $qb->expects($self->once())->method('getRootAliases')->willReturn(['g']);
-                $qb->expects($self->once())->method('andWhere')->with($self->equalTo('m.enabled = :enabled'));
-                $qb->expects($self->once())->method('setParameters')->with($self->equalTo(['enabled' => true]));
+            ->getMediaManager(static function (MockObject $qb): void {
+                $qb->expects(self::once())->method('getRootAliases')->willReturn(['g']);
+                $qb->expects(self::once())->method('andWhere')->with(self::equalTo('m.enabled = :enabled'));
+                $qb->expects(self::once())->method('setParameters')->with(self::equalTo(['enabled' => true]));
             })
             ->getPager(['enabled' => true], 1);
     }
 
     public function testGetPagerWithNoEnabledMedias(): void
     {
-        $self = $this;
         $this
-            ->getMediaManager(static function (MockObject $qb) use ($self): void {
-                $qb->expects($self->once())->method('getRootAliases')->willReturn(['g']);
-                $qb->expects($self->once())->method('andWhere')->with($self->equalTo('m.enabled = :enabled'));
-                $qb->expects($self->once())->method('setParameters')->with($self->equalTo(['enabled' => false]));
+            ->getMediaManager(static function (MockObject $qb): void {
+                $qb->expects(self::once())->method('getRootAliases')->willReturn(['g']);
+                $qb->expects(self::once())->method('andWhere')->with(self::equalTo('m.enabled = :enabled'));
+                $qb->expects(self::once())->method('setParameters')->with(self::equalTo(['enabled' => false]));
             })
             ->getPager(['enabled' => false], 1);
     }

--- a/tests/Entity/MediaTest.php
+++ b/tests/Entity/MediaTest.php
@@ -24,16 +24,16 @@ class MediaTest extends TestCase
 
         $media->setProviderMetadata(['thumbnail_url' => 'http://pasloin.com/thumb.png']);
 
-        $this->assertSame($media->getMetadataValue('thumbnail_url'), 'http://pasloin.com/thumb.png', '::getMetadataValue() return the good value');
-        $this->assertSame($media->getMetadataValue('thumbnail_url1', 'default'), 'default', '::getMetadataValue() return the default');
-        $this->assertNull($media->getMetadataValue('thumbnail_url1'), '::getMetadataValue() return the null value');
+        self::assertSame($media->getMetadataValue('thumbnail_url'), 'http://pasloin.com/thumb.png', '::getMetadataValue() return the good value');
+        self::assertSame($media->getMetadataValue('thumbnail_url1', 'default'), 'default', '::getMetadataValue() return the default');
+        self::assertNull($media->getMetadataValue('thumbnail_url1'), '::getMetadataValue() return the null value');
     }
 
     public function testStatusList(): void
     {
         $status = Media::getStatusList();
 
-        $this->assertIsArray($status);
+        self::assertIsArray($status);
     }
 
     public function testSetGet(): void
@@ -56,22 +56,22 @@ class MediaTest extends TestCase
         $media->setContentType('sonata/media');
         $media->setCreatedAt(new \DateTime());
 
-        $this->assertSame(12, $media->getSize());
-        $this->assertSame('description', $media->getDescription());
-        $this->assertTrue($media->getEnabled());
-        $this->assertSame('name', $media->getProviderName());
-        $this->assertSame(2, $media->getLength());
-        $this->assertSame($category, $media->getCategory());
-        $this->assertSame('copyleft', $media->getCopyright());
-        $this->assertSame('Thomas', $media->getAuthorName());
-        $this->assertTrue($media->getCdnIsFlushable());
-        $this->assertSame('identifier_123', $media->getCdnFlushIdentifier());
-        $this->assertInstanceOf('DateTime', $media->getCdnFlushAt());
-        $this->assertInstanceOf('DateTime', $media->getCreatedAt());
-        $this->assertSame('sonata/media', $media->getContentType());
-        $this->assertSame('MediaBundle', (string) $media);
+        self::assertSame(12, $media->getSize());
+        self::assertSame('description', $media->getDescription());
+        self::assertTrue($media->getEnabled());
+        self::assertSame('name', $media->getProviderName());
+        self::assertSame(2, $media->getLength());
+        self::assertSame($category, $media->getCategory());
+        self::assertSame('copyleft', $media->getCopyright());
+        self::assertSame('Thomas', $media->getAuthorName());
+        self::assertTrue($media->getCdnIsFlushable());
+        self::assertSame('identifier_123', $media->getCdnFlushIdentifier());
+        self::assertInstanceOf('DateTime', $media->getCdnFlushAt());
+        self::assertInstanceOf('DateTime', $media->getCreatedAt());
+        self::assertSame('sonata/media', $media->getContentType());
+        self::assertSame('MediaBundle', (string) $media);
 
-        $this->assertNull($media->getMetadataValue('foo'));
+        self::assertNull($media->getMetadataValue('foo'));
     }
 
     public function testGetMediaFileExtension(): void
@@ -79,13 +79,13 @@ class MediaTest extends TestCase
         $media = new Media();
 
         $media->setProviderReference('https://sonata-project.org/bundles/sonatageneral/images/logo-small.png?some-query-string=1');
-        $this->assertSame('png', $media->getExtension(), 'extension should not contain query strings');
+        self::assertSame('png', $media->getExtension(), 'extension should not contain query strings');
 
         $media->setProviderReference('https://sonata-project.org/bundles/sonatageneral/images/logo-small.png#some-hash');
-        $this->assertSame('png', $media->getExtension(), 'extension should not contain hashes');
+        self::assertSame('png', $media->getExtension(), 'extension should not contain hashes');
 
         $media->setProviderReference('https://sonata-project.org/bundles/sonatageneral/images/logo-small.png?some-query-string=1#with-some-hash');
-        $this->assertSame('png', $media->getExtension(), 'extension should not contain query strings or hashes');
+        self::assertSame('png', $media->getExtension(), 'extension should not contain query strings or hashes');
     }
 
     public function testSetCategoryWithoutAnActualCategory(): void

--- a/tests/Filesystem/LocalTest.php
+++ b/tests/Filesystem/LocalTest.php
@@ -25,6 +25,6 @@ class LocalTest extends TestCase
         // check if OS is Mac OS X where /tmp is a symlink to /private/tmp
         $result = 'Darwin' === \PHP_OS ? '/private/tmp' : '/tmp';
 
-        $this->assertSame($result, $local->getDirectory());
+        self::assertSame($result, $local->getDirectory());
     }
 }

--- a/tests/Filesystem/ReplicateTest.php
+++ b/tests/Filesystem/ReplicateTest.php
@@ -25,36 +25,36 @@ class ReplicateTest extends TestCase
         $slave = $this->createMock(Adapter::class);
         $replicate = new Replicate($master, $slave);
 
-        $master->expects($this->once())->method('mtime')->willReturn('master');
-        $slave->expects($this->never())->method('mtime');
-        $this->assertSame('master', $replicate->mtime('foo'));
+        $master->expects(self::once())->method('mtime')->willReturn('master');
+        $slave->expects(self::never())->method('mtime');
+        self::assertSame('master', $replicate->mtime('foo'));
 
-        $master->expects($this->once())->method('delete')->willReturn('master');
-        $slave->expects($this->once())->method('delete')->willReturn('master');
+        $master->expects(self::once())->method('delete')->willReturn('master');
+        $slave->expects(self::once())->method('delete')->willReturn('master');
         $replicate->delete('foo');
 
-        $master->expects($this->once())->method('keys')->willReturn([]);
-        $slave->expects($this->never())->method('keys')->willReturn([]);
-        $this->assertIsArray($replicate->keys());
+        $master->expects(self::once())->method('keys')->willReturn([]);
+        $slave->expects(self::never())->method('keys')->willReturn([]);
+        self::assertIsArray($replicate->keys());
 
-        $master->expects($this->once())->method('exists')->willReturn(true);
-        $slave->expects($this->never())->method('exists');
-        $this->assertTrue($replicate->exists('foo'));
+        $master->expects(self::once())->method('exists')->willReturn(true);
+        $slave->expects(self::never())->method('exists');
+        self::assertTrue($replicate->exists('foo'));
 
-        $master->expects($this->once())->method('write')->willReturn(123);
-        $slave->expects($this->once())->method('write')->willReturn(123);
-        $this->assertTrue($replicate->write('foo', 'contents'));
+        $master->expects(self::once())->method('write')->willReturn(123);
+        $slave->expects(self::once())->method('write')->willReturn(123);
+        self::assertTrue($replicate->write('foo', 'contents'));
 
-        $master->expects($this->once())->method('read')->willReturn('master content');
-        $slave->expects($this->never())->method('read');
-        $this->assertSame('master content', $replicate->read('foo'));
+        $master->expects(self::once())->method('read')->willReturn('master content');
+        $slave->expects(self::never())->method('read');
+        self::assertSame('master content', $replicate->read('foo'));
 
-        $master->expects($this->once())->method('rename');
-        $slave->expects($this->once())->method('rename');
+        $master->expects(self::once())->method('rename');
+        $slave->expects(self::once())->method('rename');
         $replicate->rename('foo', 'bar');
 
-        $master->expects($this->once())->method('isDirectory');
-        $slave->expects($this->never())->method('isDirectory');
+        $master->expects(self::once())->method('isDirectory');
+        $slave->expects(self::never())->method('isDirectory');
         $replicate->isDirectory('foo');
     }
 }

--- a/tests/Fixtures/FilesystemTestCase.php
+++ b/tests/Fixtures/FilesystemTestCase.php
@@ -96,7 +96,7 @@ class FilesystemTestCase extends TestCase
     protected function assertFilePermissions(int $expectedFilePerms, string $filePath): void
     {
         $actualFilePerms = (int) substr(sprintf('%o', fileperms($filePath)), -3);
-        $this->assertSame(
+        self::assertSame(
             $expectedFilePerms,
             $actualFilePerms,
             sprintf('File permissions for %s must be %s. Actual %s', $filePath, $expectedFilePerms, $actualFilePerms)
@@ -121,43 +121,43 @@ class FilesystemTestCase extends TestCase
             return $datas['name'];
         }
 
-        $this->markTestSkipped('Unable to retrieve file group name');
+        self::markTestSkipped('Unable to retrieve file group name');
     }
 
     protected function markAsSkippedIfLinkIsMissing(): void
     {
         if (!\function_exists('link')) {
-            $this->markTestSkipped('link is not supported');
+            self::markTestSkipped('link is not supported');
         }
 
         if ('\\' === \DIRECTORY_SEPARATOR && false === self::$linkOnWindows) {
-            $this->markTestSkipped('link requires "Create hard links" privilege on windows');
+            self::markTestSkipped('link requires "Create hard links" privilege on windows');
         }
     }
 
     protected function markAsSkippedIfSymlinkIsMissing(bool $relative = false): void
     {
         if ('\\' === \DIRECTORY_SEPARATOR && false === self::$symlinkOnWindows) {
-            $this->markTestSkipped('symlink requires "Create symbolic links" privilege on Windows');
+            self::markTestSkipped('symlink requires "Create symbolic links" privilege on Windows');
         }
 
         // https://bugs.php.net/69473
         if ($relative && '\\' === \DIRECTORY_SEPARATOR && 1 === \PHP_ZTS) {
-            $this->markTestSkipped('symlink does not support relative paths on thread safe Windows PHP versions');
+            self::markTestSkipped('symlink does not support relative paths on thread safe Windows PHP versions');
         }
     }
 
     protected function markAsSkippedIfChmodIsMissing(): void
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            $this->markTestSkipped('chmod is not supported on Windows');
+            self::markTestSkipped('chmod is not supported on Windows');
         }
     }
 
     protected function markAsSkippedIfPosixIsMissing(): void
     {
         if (!\function_exists('posix_isatty')) {
-            $this->markTestSkipped('Function posix_isatty is required.');
+            self::markTestSkipped('Function posix_isatty is required.');
         }
     }
 }

--- a/tests/Fixtures/FilesystemTestCase.php
+++ b/tests/Fixtures/FilesystemTestCase.php
@@ -82,7 +82,7 @@ class FilesystemTestCase extends TestCase
 
     protected function tearDown(): void
     {
-        if (!empty($this->longPathNamesWindows)) {
+        if ([] !== $this->longPathNamesWindows) {
             foreach ($this->longPathNamesWindows as $path) {
                 exec('DEL '.$path);
             }

--- a/tests/Fixtures/SonataClassificationBundle/Validator/Constraints/ImageUploadDimensionTest.php
+++ b/tests/Fixtures/SonataClassificationBundle/Validator/Constraints/ImageUploadDimensionTest.php
@@ -23,7 +23,7 @@ final class ImageUploadDimensionTest extends TestCase
     {
         $constraint = new ImageUploadDimension();
 
-        $this->assertSame('class', $constraint->getTargets());
-        $this->assertSame(ImageUploadDimensionValidator::class, $constraint->validatedBy());
+        self::assertSame('class', $constraint->getTargets());
+        self::assertSame(ImageUploadDimensionValidator::class, $constraint->validatedBy());
     }
 }

--- a/tests/Form/DataTransformer/ProviderDataTransformerTest.php
+++ b/tests/Form/DataTransformer/ProviderDataTransformerTest.php
@@ -28,7 +28,7 @@ class ProviderDataTransformerTest extends TestCase
         $pool = $this->createMock(Pool::class);
 
         $transformer = new ProviderDataTransformer($pool, 'stdClass');
-        $this->assertSame('foo', $transformer->reverseTransform('foo'));
+        self::assertSame('foo', $transformer->reverseTransform('foo'));
     }
 
     public function testReverseTransformUnknownProvider(): void
@@ -38,7 +38,7 @@ class ProviderDataTransformerTest extends TestCase
         $pool = new Pool('default');
 
         $media = $this->createMock(MediaInterface::class);
-        $media->expects($this->exactly(3))->method('getProviderName')->willReturn('unknown');
+        $media->expects(self::exactly(3))->method('getProviderName')->willReturn('unknown');
         $media->method('getId')->willReturn(1);
         $media->method('getBinaryContent')->willReturn('xcs');
 
@@ -51,13 +51,13 @@ class ProviderDataTransformerTest extends TestCase
     public function testReverseTransformValidProvider(): void
     {
         $provider = $this->createMock(MediaProviderInterface::class);
-        $provider->expects($this->once())->method('transform');
+        $provider->expects(self::once())->method('transform');
 
         $pool = new Pool('default');
         $pool->addProvider('default', $provider);
 
         $media = $this->createMock(MediaInterface::class);
-        $media->expects($this->exactly(3))->method('getProviderName')->willReturn('default');
+        $media->expects(self::exactly(3))->method('getProviderName')->willReturn('default');
         $media->method('getId')->willReturn(1);
         $media->method('getBinaryContent')->willReturn('xcs');
 
@@ -78,14 +78,14 @@ class ProviderDataTransformerTest extends TestCase
         $media->method('getId')->willReturn(null);
         $media->method('getBinaryContent')->willReturn(null);
         $media->method('getProviderName')->willReturn('default');
-        $media->expects($this->once())->method('setProviderReference')->with(MediaInterface::MISSING_BINARY_REFERENCE);
-        $media->expects($this->once())->method('setProviderStatus')->with(MediaInterface::STATUS_PENDING);
+        $media->expects(self::once())->method('setProviderReference')->with(MediaInterface::MISSING_BINARY_REFERENCE);
+        $media->expects(self::once())->method('setProviderStatus')->with(MediaInterface::STATUS_PENDING);
 
         $transformer = new ProviderDataTransformer($pool, 'stdClass', [
             'new_on_update' => false,
             'empty_on_new' => false,
         ]);
-        $this->assertSame($media, $transformer->reverseTransform($media));
+        self::assertSame($media, $transformer->reverseTransform($media));
     }
 
     public function testReverseTransformWithMediaAndNoBinaryContent(): void
@@ -100,7 +100,7 @@ class ProviderDataTransformerTest extends TestCase
         $media->method('getBinaryContent')->willReturn(null);
 
         $transformer = new ProviderDataTransformer($pool, 'stdClass');
-        $this->assertSame($media, $transformer->reverseTransform($media));
+        self::assertSame($media, $transformer->reverseTransform($media));
     }
 
     /**
@@ -127,13 +127,13 @@ class ProviderDataTransformerTest extends TestCase
     public function testReverseTransformWithThrowingProviderNoThrow(): void
     {
         $provider = $this->createMock(MediaProviderInterface::class);
-        $provider->expects($this->once())->method('transform')->will($this->throwException(new \Exception()));
+        $provider->expects(self::once())->method('transform')->will(self::throwException(new \Exception()));
 
         $pool = new Pool('default');
         $pool->addProvider('default', $provider);
 
         $media = $this->createMock(MediaInterface::class);
-        $media->expects($this->exactly(3))->method('getProviderName')->willReturn('default');
+        $media->expects(self::exactly(3))->method('getProviderName')->willReturn('default');
         $media->method('getId')->willReturn(1);
         $media->method('getBinaryContent')->willReturn(new UploadedFile(__FILE__, 'ProviderDataTransformerTest'));
 
@@ -146,16 +146,16 @@ class ProviderDataTransformerTest extends TestCase
     public function testReverseTransformWithThrowingProviderLogsException(): void
     {
         $provider = $this->createMock(MediaProviderInterface::class);
-        $provider->expects($this->once())->method('transform')->will($this->throwException(new \Exception()));
+        $provider->expects(self::once())->method('transform')->will(self::throwException(new \Exception()));
 
         $pool = new Pool('default');
         $pool->addProvider('default', $provider);
 
         $logger = $this->createMock(LoggerInterface::class);
-        $logger->expects($this->once())->method('error');
+        $logger->expects(self::once())->method('error');
 
         $media = $this->createMock(MediaInterface::class);
-        $media->expects($this->exactly(3))->method('getProviderName')->willReturn('default');
+        $media->expects(self::exactly(3))->method('getProviderName')->willReturn('default');
         $media->method('getId')->willReturn(1);
         $media->method('getBinaryContent')->willReturn(new UploadedFile(__FILE__, 'ProviderDataTransformerTest'));
 

--- a/tests/Form/DataTransformer/ServiceProviderDataTransformerTest.php
+++ b/tests/Form/DataTransformer/ServiceProviderDataTransformerTest.php
@@ -28,18 +28,18 @@ class ServiceProviderDataTransformerTest extends TestCase
         );
 
         $value = new \stdClass();
-        $this->assertSame($value, $transformer->transform($value));
+        self::assertSame($value, $transformer->transform($value));
     }
 
     public function testReverseTransformSkipsProviderIfNotMedia(): void
     {
         $provider = $this->createMock(MediaProviderInterface::class);
-        $provider->expects($this->never())->method('transform');
+        $provider->expects(self::never())->method('transform');
 
         $transformer = new ServiceProviderDataTransformer($provider);
 
         $media = new \stdClass();
-        $this->assertSame($media, $transformer->reverseTransform($media));
+        self::assertSame($media, $transformer->reverseTransform($media));
     }
 
     public function testReverseTransformForwardsToProvider(): void
@@ -47,10 +47,10 @@ class ServiceProviderDataTransformerTest extends TestCase
         $media = $this->createStub(MediaInterface::class);
 
         $provider = $this->createMock(MediaProviderInterface::class);
-        $provider->expects($this->once())->method('transform')->with($media);
+        $provider->expects(self::once())->method('transform')->with($media);
 
         $transformer = new ServiceProviderDataTransformer($provider);
-        $this->assertSame($media, $transformer->reverseTransform($media));
+        self::assertSame($media, $transformer->reverseTransform($media));
     }
 
     public function testReverseTransformWithThrowingProviderNoThrow(): void
@@ -58,7 +58,7 @@ class ServiceProviderDataTransformerTest extends TestCase
         $media = $this->createStub(MediaInterface::class);
 
         $provider = $this->createMock(MediaProviderInterface::class);
-        $provider->expects($this->once())->method('transform')->with($media)->willThrowException(new \Exception());
+        $provider->expects(self::once())->method('transform')->with($media)->willThrowException(new \Exception());
 
         $transformer = new ServiceProviderDataTransformer($provider);
         $transformer->reverseTransform($media);
@@ -70,11 +70,11 @@ class ServiceProviderDataTransformerTest extends TestCase
 
         $exception = new \Exception('foo');
         $provider = $this->createMock(MediaProviderInterface::class);
-        $provider->expects($this->once())->method('transform')->with($media)->willThrowException($exception);
+        $provider->expects(self::once())->method('transform')->with($media)->willThrowException($exception);
 
         $logger = $this->createMock(LoggerInterface::class);
-        $logger->expects($this->once())->method('error')->with(
-            $this->stringStartsWith('Caught Exception Exception: "foo" at'),
+        $logger->expects(self::once())->method('error')->with(
+            self::stringStartsWith('Caught Exception Exception: "foo" at'),
             ['exception' => $exception]
         );
 

--- a/tests/Form/Type/ApiMediaTypeTest.php
+++ b/tests/Form/Type/ApiMediaTypeTest.php
@@ -29,12 +29,12 @@ class ApiMediaTypeTest extends AbstractTypeTest
         $provider = $this->createMock(MediaProviderInterface::class);
 
         $mediaPool = $this->createMock(Pool::class);
-        $mediaPool->expects($this->once())->method('getProvider')->willReturn($provider);
+        $mediaPool->expects(self::once())->method('getProvider')->willReturn($provider);
 
         $type = new ApiMediaType($mediaPool, 'testclass');
 
         $builder = $this->createMock(FormBuilder::class);
-        $builder->expects($this->once())->method('addModelTransformer');
+        $builder->expects(self::once())->method('addModelTransformer');
 
         $type->buildForm($builder, ['provider_name' => 'sonata.media.provider.image']);
     }

--- a/tests/Functional/Controller/TruncateControllerTest.php
+++ b/tests/Functional/Controller/TruncateControllerTest.php
@@ -26,7 +26,7 @@ final class TruncateControllerTest extends TestCase
         $client = new KernelBrowser(new AppKernel());
         $client->request(Request::METHOD_GET, '/u_truncate_test');
 
-        $this->assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
-        $this->assertSame('test', $client->getResponse()->getContent());
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        self::assertSame('test', $client->getResponse()->getContent());
     }
 }

--- a/tests/Functional/RoutingTest.php
+++ b/tests/Functional/RoutingTest.php
@@ -34,9 +34,9 @@ final class RoutingTest extends WebTestCase
 
         $route = $router->getRouteCollection()->get($name);
 
-        $this->assertNotNull($route);
-        $this->assertSame($path, $route->getPath());
-        $this->assertEmpty(array_diff($methods, $route->getMethods()));
+        self::assertNotNull($route);
+        self::assertSame($path, $route->getPath());
+        self::assertEmpty(array_diff($methods, $route->getMethods()));
 
         // define {provider} for data set #17
         $path = str_replace('{provider}', 'test', $path);
@@ -57,10 +57,10 @@ final class RoutingTest extends WebTestCase
             // Check paths like "/api/user/users.json".
             $match = $matcher->match($matchingPath);
 
-            $this->assertSame($name, $match['_route']);
+            self::assertSame($name, $match['_route']);
 
             if ($matchingFormat) {
-                $this->assertSame(ltrim($matchingFormat, '.'), $match['_format']);
+                self::assertSame(ltrim($matchingFormat, '.'), $match['_format']);
             }
 
             $matchingPathWithStrippedFormat = str_replace('.{_format}', '', $path);
@@ -68,10 +68,10 @@ final class RoutingTest extends WebTestCase
             // Check paths like "/api/user/users".
             $match = $matcher->match($matchingPathWithStrippedFormat);
 
-            $this->assertSame($name, $match['_route']);
+            self::assertSame($name, $match['_route']);
 
             if ($matchingFormat) {
-                $this->assertSame(ltrim($matchingFormat, '.'), $match['_format']);
+                self::assertSame(ltrim($matchingFormat, '.'), $match['_format']);
             }
         }
     }

--- a/tests/Generator/DefaultGeneratorTest.php
+++ b/tests/Generator/DefaultGeneratorTest.php
@@ -30,15 +30,15 @@ class DefaultGeneratorTest extends TestCase
         $media->setContext('user');
 
         $media->setId(10);
-        $this->assertSame('user/0001/01', $generator->generatePath($media));
+        self::assertSame('user/0001/01', $generator->generatePath($media));
 
         $media->setId(10000);
-        $this->assertSame('user/0001/11', $generator->generatePath($media));
+        self::assertSame('user/0001/11', $generator->generatePath($media));
 
         $media->setId(12341230);
-        $this->assertSame('user/0124/42', $generator->generatePath($media));
+        self::assertSame('user/0124/42', $generator->generatePath($media));
 
         $media->setId(999999999);
-        $this->assertSame('user/10000/100', $generator->generatePath($media));
+        self::assertSame('user/10000/100', $generator->generatePath($media));
     }
 }

--- a/tests/Generator/IdGeneratorTest.php
+++ b/tests/Generator/IdGeneratorTest.php
@@ -27,15 +27,15 @@ final class IdGeneratorTest extends TestCase
         $media->setContext('user');
 
         $media->setId(10);
-        $this->assertSame('user/0001/01', $generator->generatePath($media));
+        self::assertSame('user/0001/01', $generator->generatePath($media));
 
         $media->setId(10000);
-        $this->assertSame('user/0001/11', $generator->generatePath($media));
+        self::assertSame('user/0001/11', $generator->generatePath($media));
 
         $media->setId(12341230);
-        $this->assertSame('user/0124/42', $generator->generatePath($media));
+        self::assertSame('user/0124/42', $generator->generatePath($media));
 
         $media->setId(999999999);
-        $this->assertSame('user/10000/100', $generator->generatePath($media));
+        self::assertSame('user/10000/100', $generator->generatePath($media));
     }
 }

--- a/tests/Generator/ODMGeneratorTest.php
+++ b/tests/Generator/ODMGeneratorTest.php
@@ -30,7 +30,7 @@ class ODMGeneratorTest extends TestCase
         $media->setContext('user');
 
         $media->setId('550e8400-e29b-41d4-a716-446655440000');
-        $this->assertSame('user/550e/84', $generator->generatePath($media));
+        self::assertSame('user/550e/84', $generator->generatePath($media));
     }
 
     public function testWithValueObjectStringable(): void
@@ -49,6 +49,6 @@ class ODMGeneratorTest extends TestCase
         };
         $media->setId($vo);
 
-        $this->assertSame('user/550e/84', $generator->generatePath($media));
+        self::assertSame('user/550e/84', $generator->generatePath($media));
     }
 }

--- a/tests/Generator/PHPCRGeneratorTest.php
+++ b/tests/Generator/PHPCRGeneratorTest.php
@@ -30,12 +30,12 @@ class PHPCRGeneratorTest extends TestCase
         $media->setContext('user');
 
         $media->setId('nodename');
-        $this->assertSame('user', $generator->generatePath($media));
+        self::assertSame('user', $generator->generatePath($media));
 
         $media->setId('/media/nodename');
-        $this->assertSame('user/media', $generator->generatePath($media));
+        self::assertSame('user/media', $generator->generatePath($media));
 
         $media->setId('/media/sub/path/nodename');
-        $this->assertSame('user/media/sub/path', $generator->generatePath($media));
+        self::assertSame('user/media/sub/path', $generator->generatePath($media));
     }
 }

--- a/tests/Generator/PathGeneratorTest.php
+++ b/tests/Generator/PathGeneratorTest.php
@@ -27,12 +27,12 @@ final class PathGeneratorTest extends TestCase
         $media->setContext('user');
 
         $media->setId('nodename');
-        $this->assertSame('user', $generator->generatePath($media));
+        self::assertSame('user', $generator->generatePath($media));
 
         $media->setId('/media/nodename');
-        $this->assertSame('user/media', $generator->generatePath($media));
+        self::assertSame('user/media', $generator->generatePath($media));
 
         $media->setId('/media/sub/path/nodename');
-        $this->assertSame('user/media/sub/path', $generator->generatePath($media));
+        self::assertSame('user/media/sub/path', $generator->generatePath($media));
     }
 }

--- a/tests/Generator/UuidGeneratorTest.php
+++ b/tests/Generator/UuidGeneratorTest.php
@@ -27,6 +27,6 @@ final class UuidGeneratorTest extends TestCase
         $media->setContext('user');
 
         $media->setId('550e8400-e29b-41d4-a716-446655440000');
-        $this->assertSame('user/550e/84', $generator->generatePath($media));
+        self::assertSame('user/550e/84', $generator->generatePath($media));
     }
 }

--- a/tests/Listener/ORM/MediaEventSubscriberTest.php
+++ b/tests/Listener/ORM/MediaEventSubscriberTest.php
@@ -53,13 +53,13 @@ class MediaEventSubscriberTest extends TestCase
         $container->set('sonata.media.pool', $pool);
         $container->set('sonata.media.manager.category', $catManager);
 
-        $catManager->expects($this->exactly(2))
+        $catManager->expects(self::exactly(2))
             ->method('getRootCategories')
             ->willReturn(['context' => $category]);
 
         $subscriber = new MediaEventSubscriber($container);
 
-        $this->assertContains(Events::onClear, $subscriber->getSubscribedEvents());
+        self::assertContains(Events::onClear, $subscriber->getSubscribedEvents());
 
         $media1 = $this->createMock(Media::class);
         $media1->method('getContext')->willReturn('context');

--- a/tests/Metadata/AmazonMetadataBuilderTest.php
+++ b/tests/Metadata/AmazonMetadataBuilderTest.php
@@ -35,7 +35,7 @@ final class AmazonMetadataBuilderTest extends TestCase
         $filename = '/test/folder/testfile.png';
 
         $amazonmetadatabuilder = new AmazonMetadataBuilder($settings, $mimeTypes);
-        $this->assertSame($expected, $amazonmetadatabuilder->get($media, $filename));
+        self::assertSame($expected, $amazonmetadatabuilder->get($media, $filename));
     }
 
     public function provider(): iterable

--- a/tests/Metadata/NoopMetadataBuilderTest.php
+++ b/tests/Metadata/NoopMetadataBuilderTest.php
@@ -26,6 +26,6 @@ class NoopMetadataBuilderTest extends TestCase
 
         $noopmetadatabuilder = new NoopMetadataBuilder();
 
-        $this->assertSame([], $noopmetadatabuilder->get($media, $filename));
+        self::assertSame([], $noopmetadatabuilder->get($media, $filename));
     }
 }

--- a/tests/Metadata/ProxyMetadataBuilderTest.php
+++ b/tests/Metadata/ProxyMetadataBuilderTest.php
@@ -33,12 +33,12 @@ final class ProxyMetadataBuilderTest extends TestCase
     public function testProxyAmazon(): void
     {
         $amazon = $this->createMock(AmazonMetadataBuilder::class);
-        $amazon->expects($this->once())
+        $amazon->expects(self::once())
             ->method('get')
             ->willReturn(['key' => 'amazon']);
 
         $noop = $this->createMock(NoopMetadataBuilder::class);
-        $noop->expects($this->never())
+        $noop->expects(self::never())
             ->method('get')
             ->willReturn(['key' => 'noop']);
 
@@ -87,18 +87,18 @@ final class ProxyMetadataBuilderTest extends TestCase
 
         $proxymetadatabuilder = new ProxyMetadataBuilder($container);
 
-        $this->assertSame(['key' => 'amazon'], $proxymetadatabuilder->get($media, $filename));
+        self::assertSame(['key' => 'amazon'], $proxymetadatabuilder->get($media, $filename));
     }
 
     public function testProxyLocal(): void
     {
         $amazon = $this->createMock(AmazonMetadataBuilder::class);
-        $amazon->expects($this->never())
+        $amazon->expects(self::never())
             ->method('get')
             ->willReturn(['key' => 'amazon']);
 
         $noop = $this->createMock(NoopMetadataBuilder::class);
-        $noop->expects($this->once())
+        $noop->expects(self::once())
             ->method('get')
             ->willReturn(['key' => 'noop']);
 
@@ -126,18 +126,18 @@ final class ProxyMetadataBuilderTest extends TestCase
 
         $proxymetadatabuilder = new ProxyMetadataBuilder($container);
 
-        $this->assertSame(['key' => 'noop'], $proxymetadatabuilder->get($media, $filename));
+        self::assertSame(['key' => 'noop'], $proxymetadatabuilder->get($media, $filename));
     }
 
     public function testProxyNoProvider(): void
     {
         $amazon = $this->createMock(AmazonMetadataBuilder::class);
-        $amazon->expects($this->never())
+        $amazon->expects(self::never())
             ->method('get')
             ->willReturn(['key' => 'amazon']);
 
         $noop = $this->createMock(NoopMetadataBuilder::class);
-        $noop->expects($this->never())
+        $noop->expects(self::never())
             ->method('get')
             ->willReturn(['key' => 'noop']);
 
@@ -165,18 +165,18 @@ final class ProxyMetadataBuilderTest extends TestCase
 
         $proxymetadatabuilder = new ProxyMetadataBuilder($container);
 
-        $this->assertSame([], $proxymetadatabuilder->get($media, $filename));
+        self::assertSame([], $proxymetadatabuilder->get($media, $filename));
     }
 
     public function testProxyReplicateWithAmazon(): void
     {
         $amazon = $this->createMock(AmazonMetadataBuilder::class);
-        $amazon->expects($this->once())
+        $amazon->expects(self::once())
             ->method('get')
             ->willReturn(['key' => 'amazon']);
 
         $noop = $this->createMock(NoopMetadataBuilder::class);
-        $noop->expects($this->never())
+        $noop->expects(self::never())
             ->method('get')
             ->willReturn(['key' => 'noop']);
 
@@ -227,18 +227,18 @@ final class ProxyMetadataBuilderTest extends TestCase
 
         $proxymetadatabuilder = new ProxyMetadataBuilder($container);
 
-        $this->assertSame(['key' => 'amazon'], $proxymetadatabuilder->get($media, $filename));
+        self::assertSame(['key' => 'amazon'], $proxymetadatabuilder->get($media, $filename));
     }
 
     public function testProxyReplicateWithoutAmazon(): void
     {
         $amazon = $this->createMock(AmazonMetadataBuilder::class);
-        $amazon->expects($this->never())
+        $amazon->expects(self::never())
             ->method('get')
             ->willReturn(['key' => 'amazon']);
 
         $noop = $this->createMock(NoopMetadataBuilder::class);
-        $noop->expects($this->once())
+        $noop->expects(self::once())
             ->method('get')
             ->willReturn(['key' => 'noop']);
 
@@ -268,7 +268,7 @@ final class ProxyMetadataBuilderTest extends TestCase
 
         $proxymetadatabuilder = new ProxyMetadataBuilder($container);
 
-        $this->assertSame(['key' => 'noop'], $proxymetadatabuilder->get($media, $filename));
+        self::assertSame(['key' => 'noop'], $proxymetadatabuilder->get($media, $filename));
     }
 
     private function getContainer(array $services): ContainerInterface

--- a/tests/Model/MediaTest.php
+++ b/tests/Model/MediaTest.php
@@ -25,8 +25,8 @@ class MediaTest extends TestCase
 
         $media->setMetadataValue('name', 'value');
         $metadata = $metadataProperty->getValue($media);
-        $this->assertArrayHasKey('name', $metadata, 'name metadata should be stored in the empty array');
-        $this->assertSame('value', $metadata['name'], 'the string value should be returned');
+        self::assertArrayHasKey('name', $metadata, 'name metadata should be stored in the empty array');
+        self::assertSame('value', $metadata['name'], 'the string value should be returned');
 
         $cropData = [
             'x' => 10,
@@ -36,9 +36,9 @@ class MediaTest extends TestCase
         ];
         $media->setMetadataValue('crop', $cropData);
         $metadata = $metadataProperty->getValue($media);
-        $this->assertArrayHasKey('crop', $metadata, 'crop should be stored in the existing array');
-        $this->assertArrayHasKey('name', $metadata, 'name metadata should still be in the array');
-        $this->assertSame($cropData, $metadata['crop'], 'the crop data array should be returned');
+        self::assertArrayHasKey('crop', $metadata, 'crop should be stored in the existing array');
+        self::assertArrayHasKey('name', $metadata, 'name metadata should still be in the array');
+        self::assertSame($cropData, $metadata['crop'], 'the crop data array should be returned');
 
         return $media;
     }
@@ -52,16 +52,16 @@ class MediaTest extends TestCase
 
         $media->unsetMetadataValue('crop');
         $metadata = $metadataProperty->getValue($media);
-        $this->assertArrayNotHasKey('crop', $metadata, 'crop should not be in the metadata');
+        self::assertArrayNotHasKey('crop', $metadata, 'crop should not be in the metadata');
 
         $media->unsetMetadataValue('name');
         $metadata = $metadataProperty->getValue($media);
-        $this->assertEmpty($metadata, 'crop should not be in the metadata');
+        self::assertEmpty($metadata, 'crop should not be in the metadata');
 
         try {
             $media->unsetMetadataValue('bullshit');
         } catch (\InvalidArgumentException $expected) {
-            $this->fail('an invalid key should be ignored');
+            self::fail('an invalid key should be ignored');
         }
     }
 

--- a/tests/Model/NoDriverManagerTest.php
+++ b/tests/Model/NoDriverManagerTest.php
@@ -32,7 +32,7 @@ class NoDriverManagerTest extends TestCase
 
     public function testIsInstanceOfGalleryManagerInterface()
     {
-        $this->assertInstanceOf(GalleryManagerInterface::class, new NoDriverManager());
+        self::assertInstanceOf(GalleryManagerInterface::class, new NoDriverManager());
     }
 
     public function providerMethods(): array

--- a/tests/PHPCR/MediaManagerTest.php
+++ b/tests/PHPCR/MediaManagerTest.php
@@ -38,14 +38,14 @@ class MediaManagerTest extends TestCase
         $media = new Media();
         $this->manager->save($media, 'default', 'media.test');
 
-        $this->assertSame('default', $media->getContext());
-        $this->assertSame('media.test', $media->getProviderName());
+        self::assertSame('default', $media->getContext());
+        self::assertSame('media.test', $media->getProviderName());
 
         $media = new Media();
         $this->manager->save($media, true);
 
-        $this->assertNull($media->getContext());
-        $this->assertNull($media->getProviderName());
+        self::assertNull($media->getContext());
+        self::assertNull($media->getProviderName());
     }
 
     public function testSaveException(): void

--- a/tests/Provider/AbstractProviderTest.php
+++ b/tests/Provider/AbstractProviderTest.php
@@ -65,7 +65,7 @@ abstract class AbstractProviderTest extends TestCase
     public function testBuildEditForm(): void
     {
         $this->form
-            ->expects($this->atLeastOnce())
+            ->expects(self::atLeastOnce())
             ->method('add');
 
         $this->provider->buildEditForm($this->form);
@@ -74,7 +74,7 @@ abstract class AbstractProviderTest extends TestCase
     public function testBuildCreateForm(): void
     {
         $this->form
-            ->expects($this->atLeastOnce())
+            ->expects(self::atLeastOnce())
             ->method('add');
 
         $this->provider->buildCreateForm($this->form);
@@ -83,7 +83,7 @@ abstract class AbstractProviderTest extends TestCase
     public function testBuildMediaType(): void
     {
         $this->formBuilder
-            ->expects($this->atLeastOnce())
+            ->expects(self::atLeastOnce())
             ->method('add');
 
         $this->provider->buildMediaType($this->formBuilder);
@@ -95,7 +95,7 @@ abstract class AbstractProviderTest extends TestCase
         $stream->method('getContents')->willReturn($content);
 
         $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->once())->method('getBody')->willReturn($stream);
+        $response->expects(self::once())->method('getBody')->willReturn($stream);
 
         return $response;
     }

--- a/tests/Provider/BaseProviderTest.php
+++ b/tests/Provider/BaseProviderTest.php
@@ -41,7 +41,7 @@ class BaseProviderTest extends AbstractProviderTest
         $cdn = $this->createStub(CDNInterface::class);
         $cdn->method('flushPaths')->willReturn((string) mt_rand());
         $cdn->method('getFlushStatus')
-            ->will($this->onConsecutiveCalls(
+            ->will(self::onConsecutiveCalls(
                 CDNInterface::STATUS_OK,
                 CDNInterface::STATUS_TO_FLUSH,
                 CDNInterface::STATUS_WAITING,
@@ -56,7 +56,7 @@ class BaseProviderTest extends AbstractProviderTest
         $thumbnail = $this->createStub(ThumbnailInterface::class);
 
         $provider = new TestProvider('test', $filesystem, $cdn, $generator, $thumbnail);
-        $this->assertInstanceOf(BaseProvider::class, $provider);
+        self::assertInstanceOf(BaseProvider::class, $provider);
 
         return $provider;
     }
@@ -68,28 +68,28 @@ class BaseProviderTest extends AbstractProviderTest
             'edit' => 'edit.twig',
         ]);
 
-        $this->assertIsArray($provider->getTemplates());
-        $this->assertSame('edit.twig', $provider->getTemplate('edit'));
+        self::assertIsArray($provider->getTemplates());
+        self::assertSame('edit.twig', $provider->getTemplate('edit'));
 
-        $this->assertInstanceOf(CDNInterface::class, $provider->getCdn());
+        self::assertInstanceOf(CDNInterface::class, $provider->getCdn());
 
         $provider->addFormat('small', []);
 
-        $this->assertIsArray($provider->getFormat('small'));
+        self::assertIsArray($provider->getFormat('small'));
 
         $media = new Media();
         $media->setContext('test');
 
-        $this->assertSame('admin', $provider->getFormatName($media, 'admin'));
-        $this->assertSame('reference', $provider->getFormatName($media, 'reference'));
-        $this->assertSame('test_small', $provider->getFormatName($media, 'small'));
-        $this->assertSame('test_small', $provider->getFormatName($media, 'test_small'));
+        self::assertSame('admin', $provider->getFormatName($media, 'admin'));
+        self::assertSame('reference', $provider->getFormatName($media, 'reference'));
+        self::assertSame('test_small', $provider->getFormatName($media, 'small'));
+        self::assertSame('test_small', $provider->getFormatName($media, 'test_small'));
     }
 
     public function testGetCdnPath(): void
     {
         $provider = $this->getProvider();
-        $this->assertSame('/uploads/media/my_file.txt', $provider->getCdnPath('my_file.txt', false));
+        self::assertSame('/uploads/media/my_file.txt', $provider->getCdnPath('my_file.txt', false));
     }
 
     public function testFlushCdn(): void
@@ -102,44 +102,44 @@ class BaseProviderTest extends AbstractProviderTest
         $media->setCdnIsFlushable(true);
 
         $media->setContext('test');
-        $this->assertNull($media->getCdnFlushIdentifier());
-        $this->assertNull($media->getCdnStatus());
+        self::assertNull($media->getCdnFlushIdentifier());
+        self::assertNull($media->getCdnStatus());
         $provider->flushCdn($media);
-        $this->assertTrue($media->getCdnIsFlushable());
-        $this->assertNotNull($media->getCdnFlushIdentifier());
-        $this->assertSame(CDNInterface::STATUS_TO_FLUSH, $media->getCdnStatus());
+        self::assertTrue($media->getCdnIsFlushable());
+        self::assertNotNull($media->getCdnFlushIdentifier());
+        self::assertSame(CDNInterface::STATUS_TO_FLUSH, $media->getCdnStatus());
 
         $media->setContext('other');
         $provider->flushCdn($media);
-        $this->assertSame(CDNInterface::STATUS_OK, $media->getCdnStatus());
-        $this->assertNull($media->getCdnFlushIdentifier());
+        self::assertSame(CDNInterface::STATUS_OK, $media->getCdnStatus());
+        self::assertNull($media->getCdnFlushIdentifier());
 
         $media->setContext('test');
         $provider->flushCdn($media);
-        $this->assertSame(CDNInterface::STATUS_TO_FLUSH, $media->getCdnStatus());
-        $this->assertNotNull($media->getCdnFlushIdentifier());
+        self::assertSame(CDNInterface::STATUS_TO_FLUSH, $media->getCdnStatus());
+        self::assertNotNull($media->getCdnFlushIdentifier());
 
         $media->setContext('other');
         $provider->flushCdn($media);
-        $this->assertSame(CDNInterface::STATUS_TO_FLUSH, $media->getCdnStatus());
-        $this->assertNotNull($media->getCdnFlushIdentifier());
+        self::assertSame(CDNInterface::STATUS_TO_FLUSH, $media->getCdnStatus());
+        self::assertNotNull($media->getCdnFlushIdentifier());
         $provider->flushCdn($media);
-        $this->assertSame(CDNInterface::STATUS_WAITING, $media->getCdnStatus());
-        $this->assertNotNull($media->getCdnFlushIdentifier());
+        self::assertSame(CDNInterface::STATUS_WAITING, $media->getCdnStatus());
+        self::assertNotNull($media->getCdnFlushIdentifier());
         $provider->flushCdn($media);
-        $this->assertSame(CDNInterface::STATUS_OK, $media->getCdnStatus());
-        $this->assertNull($media->getCdnFlushIdentifier());
+        self::assertSame(CDNInterface::STATUS_OK, $media->getCdnStatus());
+        self::assertNull($media->getCdnFlushIdentifier());
     }
 
     public function testMetadata(): void
     {
         $provider = $this->getProvider();
 
-        $this->assertSame('test', $provider->getProviderMetadata()->getTitle());
-        $this->assertSame('test.description', $provider->getProviderMetadata()->getDescription());
-        $this->assertNotNull($provider->getProviderMetadata()->getImage());
-        $this->assertSame('fa fa-file', $provider->getProviderMetadata()->getOption('class'));
-        $this->assertSame('SonataMediaBundle', $provider->getProviderMetadata()->getDomain());
+        self::assertSame('test', $provider->getProviderMetadata()->getTitle());
+        self::assertSame('test.description', $provider->getProviderMetadata()->getDescription());
+        self::assertNotNull($provider->getProviderMetadata()->getImage());
+        self::assertSame('fa fa-file', $provider->getProviderMetadata()->getOption('class'));
+        self::assertSame('SonataMediaBundle', $provider->getProviderMetadata()->getDomain());
     }
 
     public function testPostRemove(): void
@@ -156,13 +156,13 @@ class BaseProviderTest extends AbstractProviderTest
 
         $provider->preRemove($media);
 
-        $this->assertArrayHasKey($hash, $prop->getValue($provider));
+        self::assertArrayHasKey($hash, $prop->getValue($provider));
 
         $media->setId(null); // Emulate an object detached from the EntityManager.
         $provider->postRemove($media);
 
-        $this->assertArrayNotHasKey($hash, $prop->getValue($provider));
-        $this->assertSame('/0001/02/1f981a048e7d8b671415d17e9633abc0059df394.png', $provider->prevReferenceImage);
+        self::assertArrayNotHasKey($hash, $prop->getValue($provider));
+        self::assertSame('/0001/02/1f981a048e7d8b671415d17e9633abc0059df394.png', $provider->prevReferenceImage);
 
         $prop->setAccessible(false);
     }

--- a/tests/Provider/DailyMotionProviderTest.php
+++ b/tests/Provider/DailyMotionProviderTest.php
@@ -83,12 +83,12 @@ class DailyMotionProviderTest extends AbstractProviderTest
         $media->setContext('default');
         $media->setProviderMetadata(json_decode('{"type":"video","version":"1.0","provider_name":"Dailymotion","provider_url":"http:\/\/www.dailymotion.com","title":"Thomas Rabaix - les tests fonctionnels - Symfony Live 2009","author_name":"Guillaume Pon\u00e7on","author_url":"http:\/\/www.dailymotion.com\/phptv","width":480,"height":270,"html":"<iframe src=\"http:\/\/www.dailymotion.com\/embed\/video\/x9wjql\" width=\"480\" height=\"270\" frameborder=\"0\"><\/iframe>","thumbnail_url":"http:\/\/ak2.static.dailymotion.com\/static\/video\/711\/536\/16635117:jpeg_preview_large.jpg?20100801072241","thumbnail_width":426.666666667,"thumbnail_height":240}', true));
 
-        $this->assertSame('http://ak2.static.dailymotion.com/static/video/711/536/16635117:jpeg_preview_large.jpg?20100801072241', $this->provider->getReferenceImage($media));
+        self::assertSame('http://ak2.static.dailymotion.com/static/video/711/536/16635117:jpeg_preview_large.jpg?20100801072241', $this->provider->getReferenceImage($media));
 
         $media->setId(1023458);
 
-        $this->assertSame('default/0011/24', $this->provider->generatePath($media));
-        $this->assertSame('/uploads/media/default/0011/24/thumb_1023458_big.jpg', $this->provider->generatePublicUrl($media, 'big'));
+        self::assertSame('default/0011/24', $this->provider->generatePath($media));
+        self::assertSame('/uploads/media/default/0011/24/thumb_1023458_big.jpg', $this->provider->generatePublicUrl($media, 'big'));
     }
 
     public function testThumbnail(): void
@@ -96,10 +96,10 @@ class DailyMotionProviderTest extends AbstractProviderTest
         $request = $this->createStub(RequestInterface::class);
 
         $requestFactory = $this->createMock(RequestFactoryInterface::class);
-        $requestFactory->expects($this->once())->method('createRequest')->willReturn($request);
+        $requestFactory->expects(self::once())->method('createRequest')->willReturn($request);
 
         $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())->method('sendRequest')->with($this->equalTo($request))->willReturn($this->createResponse('content'));
+        $client->expects(self::once())->method('sendRequest')->with(self::equalTo($request))->willReturn($this->createResponse('content'));
 
         $provider = $this->getProvider($client, $requestFactory);
 
@@ -112,15 +112,15 @@ class DailyMotionProviderTest extends AbstractProviderTest
 
         $media->setId(1023458);
 
-        $this->assertTrue($provider->requireThumbnails());
+        self::assertTrue($provider->requireThumbnails());
 
         $provider->addFormat('big', ['width' => 200, 'height' => null, 'constraint' => true]);
 
-        $this->assertNotEmpty($provider->getFormats(), '::getFormats() return an array');
+        self::assertNotEmpty($provider->getFormats(), '::getFormats() return an array');
 
         $provider->generateThumbnails($media);
 
-        $this->assertSame('default/0011/24/thumb_1023458_big.jpg', $provider->generatePrivateUrl($media, 'big'));
+        self::assertSame('default/0011/24/thumb_1023458_big.jpg', $provider->generatePrivateUrl($media, 'big'));
     }
 
     public function testTransformWithSig(): void
@@ -128,10 +128,10 @@ class DailyMotionProviderTest extends AbstractProviderTest
         $request = $this->createStub(RequestInterface::class);
 
         $requestFactory = $this->createMock(RequestFactoryInterface::class);
-        $requestFactory->expects($this->once())->method('createRequest')->willReturn($request);
+        $requestFactory->expects(self::once())->method('createRequest')->willReturn($request);
 
         $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())->method('sendRequest')->with($this->equalTo($request))
+        $client->expects(self::once())->method('sendRequest')->with(self::equalTo($request))
             ->willReturn($this->createResponse(file_get_contents(__DIR__.'/../Fixtures/valid_dailymotion.txt')));
 
         $provider = $this->getProvider($client, $requestFactory);
@@ -145,8 +145,8 @@ class DailyMotionProviderTest extends AbstractProviderTest
         // pre persist the media
         $provider->transform($media);
 
-        $this->assertSame('Thomas Rabaix - les tests fonctionnels - Symfony Live 2009', $media->getName(), '::getName() return the file name');
-        $this->assertSame('x9wjql', $media->getProviderReference(), '::getProviderReference() is set');
+        self::assertSame('Thomas Rabaix - les tests fonctionnels - Symfony Live 2009', $media->getName(), '::getName() return the file name');
+        self::assertSame('x9wjql', $media->getProviderReference(), '::getProviderReference() is set');
     }
 
     /**
@@ -157,10 +157,10 @@ class DailyMotionProviderTest extends AbstractProviderTest
         $request = $this->createStub(RequestInterface::class);
 
         $messageFactory = $this->createMock(RequestFactoryInterface::class);
-        $messageFactory->expects($this->once())->method('createRequest')->willReturn($request);
+        $messageFactory->expects(self::once())->method('createRequest')->willReturn($request);
 
         $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())->method('sendRequest')->with($this->equalTo($request))
+        $client->expects(self::once())->method('sendRequest')->with(self::equalTo($request))
             ->willReturn($this->createResponse(file_get_contents(__DIR__.'/../Fixtures/valid_dailymotion.txt')));
 
         $provider = $this->getProvider($client, $messageFactory);
@@ -174,8 +174,8 @@ class DailyMotionProviderTest extends AbstractProviderTest
         // pre persist the media
         $provider->transform($media);
 
-        $this->assertSame('Thomas Rabaix - les tests fonctionnels - Symfony Live 2009', $media->getName(), '::getName() return the file name');
-        $this->assertSame('x9wjql', $media->getProviderReference(), '::getProviderReference() is set');
+        self::assertSame('Thomas Rabaix - les tests fonctionnels - Symfony Live 2009', $media->getName(), '::getName() return the file name');
+        self::assertSame('x9wjql', $media->getProviderReference(), '::getProviderReference() is set');
     }
 
     public function dataTransformWithUrl(): array
@@ -199,7 +199,7 @@ class DailyMotionProviderTest extends AbstractProviderTest
         $response->setContent(file_get_contents(__DIR__.'/../Fixtures/valid_dailymotion.txt'));
 
         $browser = $this->createMock(Browser::class);
-        $browser->expects($this->once())->method('call')->will($this->throwException(new \RuntimeException('First error on get', 12)));
+        $browser->expects(self::once())->method('call')->will(self::throwException(new \RuntimeException('First error on get', 12)));
 
         $provider = $this->getProvider($browser);
 
@@ -225,7 +225,7 @@ class DailyMotionProviderTest extends AbstractProviderTest
             ->willReturn('message');
 
         $form = $this->createMock(FormMapper::class);
-        $form->expects($this->exactly(8))
+        $form->expects(self::exactly(8))
             ->method('add')
             ->willReturn(null);
 
@@ -246,15 +246,15 @@ class DailyMotionProviderTest extends AbstractProviderTest
 
         $properties = $this->provider->getHelperProperties($media, 'admin');
 
-        $this->assertIsArray($properties);
-        $this->assertSame(100, $properties['height']);
-        $this->assertSame(100, $properties['width']);
+        self::assertIsArray($properties);
+        self::assertSame(100, $properties['height']);
+        self::assertSame(100, $properties['width']);
     }
 
     public function testGetReferenceUrl(): void
     {
         $media = new Media();
         $media->setProviderReference('123456');
-        $this->assertSame('http://www.dailymotion.com/video/123456', $this->provider->getReferenceUrl($media));
+        self::assertSame('http://www.dailymotion.com/video/123456', $this->provider->getReferenceUrl($media));
     }
 }

--- a/tests/Provider/FileProviderTest.php
+++ b/tests/Provider/FileProviderTest.php
@@ -80,12 +80,12 @@ class FileProviderTest extends AbstractProviderTest
         $media->setContext('default');
 
         $media->setId(1023456);
-        $this->assertSame('default/0011/24/ASDASD.txt', $provider->getReferenceImage($media));
+        self::assertSame('default/0011/24/ASDASD.txt', $provider->getReferenceImage($media));
 
-        $this->assertSame('default/0011/24', $provider->generatePath($media));
+        self::assertSame('default/0011/24', $provider->generatePath($media));
 
         // default icon image
-        $this->assertSame('/uploads/media/sonatamedia/files/big/file.png', $provider->generatePublicUrl($media, 'big'));
+        self::assertSame('/uploads/media/sonatamedia/files/big/file.png', $provider->generatePublicUrl($media, 'big'));
     }
 
     public function testHelperProperties(): void
@@ -101,8 +101,8 @@ class FileProviderTest extends AbstractProviderTest
 
         $properties = $provider->getHelperProperties($media, 'admin');
 
-        $this->assertIsArray($properties);
-        $this->assertSame('test.png', $properties['title']);
+        self::assertIsArray($properties);
+        self::assertSame('test.png', $properties['title']);
     }
 
     public function testForm(): void
@@ -115,7 +115,7 @@ class FileProviderTest extends AbstractProviderTest
             ->willReturn('message');
 
         $form = $this->createMock(FormMapper::class);
-        $form->expects($this->exactly(8))
+        $form->expects(self::exactly(8))
             ->method('add')
             ->willReturn(null);
 
@@ -147,13 +147,13 @@ class FileProviderTest extends AbstractProviderTest
 
         $media = new Media();
         $provider->preUpdate($media);
-        $this->assertNull($media->getProviderReference());
+        self::assertNull($media->getProviderReference());
 
         $media->setBinaryContent($file);
         $provider->transform($media);
 
-        $this->assertInstanceOf(\DateTime::class, $media->getUpdatedAt());
-        $this->assertNotNull($media->getProviderReference());
+        self::assertInstanceOf(\DateTime::class, $media->getUpdatedAt());
+        self::assertNotNull($media->getProviderReference());
 
         $provider->postUpdate($media);
 
@@ -166,11 +166,11 @@ class FileProviderTest extends AbstractProviderTest
         // pre persist the media
         $provider->transform($media);
 
-        $this->assertSame('file.txt', $media->getName(), '::getName() return the file name');
-        $this->assertNotNull($media->getProviderReference(), '::getProviderReference() is set');
+        self::assertSame('file.txt', $media->getName(), '::getName() return the file name');
+        self::assertNotNull($media->getProviderReference(), '::getProviderReference() is set');
 
-        $this->assertFalse($provider->generatePrivateUrl($media, 'big'), '::generatePrivateUrl() return false on non reference formate');
-        $this->assertNotNull($provider->generatePrivateUrl($media, 'reference'), '::generatePrivateUrl() return path for reference formate');
+        self::assertFalse($provider->generatePrivateUrl($media, 'big'), '::generatePrivateUrl() return false on non reference formate');
+        self::assertNotNull($provider->generatePrivateUrl($media, 'reference'), '::generatePrivateUrl() return path for reference formate');
     }
 
     public function testDownload(): void
@@ -187,7 +187,7 @@ class FileProviderTest extends AbstractProviderTest
 
         $response = $provider->getDownloadResponse($media, 'reference', 'X-Accel-Redirect');
 
-        $this->assertInstanceOf(BinaryFileResponse::class, $response);
+        self::assertInstanceOf(BinaryFileResponse::class, $response);
     }
 
     /**
@@ -200,7 +200,7 @@ class FileProviderTest extends AbstractProviderTest
 
             $provider->transform($media);
 
-            $this->assertInstanceOf($expected, $media->getBinaryContent());
+            self::assertInstanceOf($expected, $media->getBinaryContent());
         };
 
         $closure();
@@ -247,11 +247,11 @@ class FileProviderTest extends AbstractProviderTest
 
         $binaryContent = $this->createMock(File::class);
 
-        $binaryContent->expects($this->atLeastOnce())
+        $binaryContent->expects(self::atLeastOnce())
             ->method('getRealPath')
             ->willReturn(__DIR__.'/../Fixtures/file.txt');
 
-        $binaryContent->expects($this->never())
+        $binaryContent->expects(self::never())
             ->method('getPathname');
 
         $media
@@ -284,11 +284,11 @@ class FileProviderTest extends AbstractProviderTest
 
         $binaryContent = $this->createMock(File::class);
 
-        $binaryContent->expects($this->atLeastOnce())
+        $binaryContent->expects(self::atLeastOnce())
             ->method('getRealPath')
             ->willReturn(false);
 
-        $binaryContent->expects($this->atLeastOnce())
+        $binaryContent->expects(self::atLeastOnce())
             ->method('getPathname')
             ->willReturn(__DIR__.'/../Fixtures/file.txt');
 
@@ -322,9 +322,9 @@ class FileProviderTest extends AbstractProviderTest
         $executionContext = $this->createMock(ExecutionContextInterface::class);
         $errorElement = $this->createErrorElement($executionContext);
         $executionContext
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('buildViolation')
-            ->with($this->stringContains('The file is too big, max size:'))
+            ->with(self::stringContains('The file is too big, max size:'))
             ->willReturn($this->createConstraintBuilder());
 
         $upload = $this->getMockBuilder(UploadedFile::class)
@@ -351,9 +351,9 @@ class FileProviderTest extends AbstractProviderTest
         $executionContext = $this->createMock(ExecutionContextInterface::class);
         $errorElement = $this->createErrorElement($executionContext);
         $executionContext
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('buildViolation')
-            ->with($this->stringContains('The file is too big, max size:'))
+            ->with(self::stringContains('The file is too big, max size:'))
             ->willReturn($this->createConstraintBuilder());
 
         $upload = $this->getMockBuilder(UploadedFile::class)
@@ -380,7 +380,7 @@ class FileProviderTest extends AbstractProviderTest
         $executionContext = $this->createMock(ExecutionContextInterface::class);
         $errorElement = $this->createErrorElement($executionContext);
         $executionContext
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('buildViolation');
 
         $upload = $this->getMockBuilder(UploadedFile::class)
@@ -408,11 +408,11 @@ class FileProviderTest extends AbstractProviderTest
         $errorElement = $this->createErrorElement($executionContext);
         $constraintBuilder = $this->createConstraintBuilder();
         $constraintBuilder
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('setParameters')
             ->with(['%type%' => 'bar/baz']);
         $executionContext
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('buildViolation')
             ->with('Invalid mime type : %type%')
             ->willReturn($constraintBuilder);
@@ -440,11 +440,11 @@ class FileProviderTest extends AbstractProviderTest
     {
         $provider = $this->getProvider();
 
-        $this->assertSame('file', $provider->getProviderMetadata()->getTitle());
-        $this->assertSame('file.description', $provider->getProviderMetadata()->getDescription());
-        $this->assertNotNull($provider->getProviderMetadata()->getImage());
-        $this->assertSame('fa fa-file-text-o', $provider->getProviderMetadata()->getOption('class'));
-        $this->assertSame('SonataMediaBundle', $provider->getProviderMetadata()->getDomain());
+        self::assertSame('file', $provider->getProviderMetadata()->getTitle());
+        self::assertSame('file.description', $provider->getProviderMetadata()->getDescription());
+        self::assertNotNull($provider->getProviderMetadata()->getImage());
+        self::assertSame('fa fa-file-text-o', $provider->getProviderMetadata()->getOption('class'));
+        self::assertSame('SonataMediaBundle', $provider->getProviderMetadata()->getDomain());
     }
 
     private function createErrorElement(ExecutionContextInterface $executionContext): ErrorElement

--- a/tests/Provider/ImageProviderTest.php
+++ b/tests/Provider/ImageProviderTest.php
@@ -85,21 +85,21 @@ class ImageProviderTest extends AbstractProviderTest
         $media->setId(1023456);
         $media->setContext('default');
 
-        $this->assertSame('default/0011/24/ASDASDAS.png', $provider->getReferenceImage($media));
+        self::assertSame('default/0011/24/ASDASDAS.png', $provider->getReferenceImage($media));
 
-        $this->assertSame('default/0011/24', $provider->generatePath($media));
-        $this->assertSame('/uploads/media/default/0011/24/thumb_1023456_big.png', $provider->generatePublicUrl($media, 'big'));
-        $this->assertSame('/uploads/media/default/0011/24/ASDASDAS.png', $provider->generatePublicUrl($media, 'reference'));
+        self::assertSame('default/0011/24', $provider->generatePath($media));
+        self::assertSame('/uploads/media/default/0011/24/thumb_1023456_big.png', $provider->generatePublicUrl($media, 'big'));
+        self::assertSame('/uploads/media/default/0011/24/ASDASDAS.png', $provider->generatePublicUrl($media, 'reference'));
 
-        $this->assertSame('default/0011/24/ASDASDAS.png', $provider->generatePrivateUrl($media, 'reference'));
-        $this->assertSame('default/0011/24/thumb_1023456_big.png', $provider->generatePrivateUrl($media, 'big'));
+        self::assertSame('default/0011/24/ASDASDAS.png', $provider->generatePrivateUrl($media, 'reference'));
+        self::assertSame('default/0011/24/thumb_1023456_big.png', $provider->generatePrivateUrl($media, 'big'));
     }
 
     public function testHelperOptions(): void
     {
         $this->expectException(\LogicException::class);
 
-        $provider = $this->getProvider([], [], $this->returnValue(new Box(50, 50)));
+        $provider = $this->getProvider([], [], self::returnValue(new Box(50, 50)));
         $media = new Media();
 
         $provider->getHelperProperties($media, 'any_format', ['srcset' => [], 'picture' => []]);
@@ -114,7 +114,7 @@ class ImageProviderTest extends AbstractProviderTest
         $provider = $this->getProvider(
             [],
             [],
-            $this->onConsecutiveCalls(
+            self::onConsecutiveCalls(
                 $largeBox, // first properties call
                 $mediumBox,
                 $largeBox,
@@ -147,51 +147,51 @@ class ImageProviderTest extends AbstractProviderTest
 
         $properties = $provider->getHelperProperties($media, 'default_large');
 
-        $this->assertIsArray($properties);
-        $this->assertSame('test.png', $properties['title']);
-        $this->assertSame(1000, $properties['width']);
-        $this->assertSame($srcSet, $properties['srcset']);
-        $this->assertSame(
+        self::assertIsArray($properties);
+        self::assertSame('test.png', $properties['title']);
+        self::assertSame(1000, $properties['width']);
+        self::assertSame($srcSet, $properties['srcset']);
+        self::assertSame(
             '/uploads/media/default/0001/01/thumb_10_default_large.png',
             $properties['src']
         );
-        $this->assertSame('(max-width: 1000px) 100vw, 1000px', $properties['sizes']);
+        self::assertSame('(max-width: 1000px) 100vw, 1000px', $properties['sizes']);
 
         $properties = $provider->getHelperProperties($media, 'default_large', ['srcset' => ['default_medium']]);
-        $this->assertSame($srcSet, $properties['srcset']);
-        $this->assertSame(
+        self::assertSame($srcSet, $properties['srcset']);
+        self::assertSame(
             '/uploads/media/default/0001/01/thumb_10_default_large.png',
             $properties['src']
         );
-        $this->assertSame('(max-width: 500px) 100vw, 500px', $properties['sizes']);
+        self::assertSame('(max-width: 500px) 100vw, 500px', $properties['sizes']);
 
         $properties = $provider->getHelperProperties($media, 'admin', [
             'width' => 150,
         ]);
-        $this->assertArrayNotHasKey('sizes', $properties);
-        $this->assertArrayNotHasKey('srcset', $properties);
+        self::assertArrayNotHasKey('sizes', $properties);
+        self::assertArrayNotHasKey('srcset', $properties);
 
-        $this->assertSame(150, $properties['width']);
+        self::assertSame(150, $properties['width']);
 
         $properties = $provider->getHelperProperties($media, 'default_large', ['picture' => ['default_medium', 'default_large'], 'class' => 'some-class']);
-        $this->assertArrayHasKey('picture', $properties);
-        $this->assertArrayNotHasKey('srcset', $properties);
-        $this->assertArrayNotHasKey('sizes', $properties);
-        $this->assertArrayHasKey('source', $properties['picture']);
-        $this->assertArrayHasKey('img', $properties['picture']);
-        $this->assertArrayHasKey('class', $properties['picture']['img']);
-        $this->assertArrayHasKey('media', $properties['picture']['source'][0]);
-        $this->assertSame('(max-width: 500px)', $properties['picture']['source'][0]['media']);
+        self::assertArrayHasKey('picture', $properties);
+        self::assertArrayNotHasKey('srcset', $properties);
+        self::assertArrayNotHasKey('sizes', $properties);
+        self::assertArrayHasKey('source', $properties['picture']);
+        self::assertArrayHasKey('img', $properties['picture']);
+        self::assertArrayHasKey('class', $properties['picture']['img']);
+        self::assertArrayHasKey('media', $properties['picture']['source'][0]);
+        self::assertSame('(max-width: 500px)', $properties['picture']['source'][0]['media']);
 
         $properties = $provider->getHelperProperties($media, 'default_large', ['picture' => ['(max-width: 200px)' => 'default_medium', 'default_large'], 'class' => 'some-class']);
-        $this->assertArrayHasKey('picture', $properties);
-        $this->assertArrayNotHasKey('srcset', $properties);
-        $this->assertArrayNotHasKey('sizes', $properties);
-        $this->assertArrayHasKey('source', $properties['picture']);
-        $this->assertArrayHasKey('img', $properties['picture']);
-        $this->assertArrayHasKey('class', $properties['picture']['img']);
-        $this->assertArrayHasKey('media', $properties['picture']['source'][0]);
-        $this->assertSame('(max-width: 200px)', $properties['picture']['source'][0]['media']);
+        self::assertArrayHasKey('picture', $properties);
+        self::assertArrayNotHasKey('srcset', $properties);
+        self::assertArrayNotHasKey('sizes', $properties);
+        self::assertArrayHasKey('source', $properties['picture']);
+        self::assertArrayHasKey('img', $properties['picture']);
+        self::assertArrayHasKey('class', $properties['picture']['img']);
+        self::assertArrayHasKey('media', $properties['picture']['source'][0]);
+        self::assertSame('(max-width: 200px)', $properties['picture']['source'][0]['media']);
     }
 
     public function testThumbnail(): void
@@ -204,15 +204,15 @@ class ImageProviderTest extends AbstractProviderTest
         $media->setId(1023456);
         $media->setContext('default');
 
-        $this->assertTrue($provider->requireThumbnails());
+        self::assertTrue($provider->requireThumbnails());
 
         $provider->addFormat('big', ['width' => 200, 'height' => 100, 'constraint' => true]);
 
-        $this->assertNotEmpty($provider->getFormats(), '::getFormats() return an array');
+        self::assertNotEmpty($provider->getFormats(), '::getFormats() return an array');
 
         $provider->generateThumbnails($media);
 
-        $this->assertSame('default/0011/24/thumb_1023456_big.png', $provider->generatePrivateUrl($media, 'big'));
+        self::assertSame('default/0011/24/thumb_1023456_big.png', $provider->generatePrivateUrl($media, 'big'));
     }
 
     public function testEvent(): void
@@ -231,8 +231,8 @@ class ImageProviderTest extends AbstractProviderTest
         $provider->transform($media);
         $provider->prePersist($media);
 
-        $this->assertSame('logo.png', $media->getName(), '::getName() return the file name');
-        $this->assertNotNull($media->getProviderReference(), '::getProviderReference() is set');
+        self::assertSame('logo.png', $media->getName(), '::getName() return the file name');
+        self::assertNotNull($media->getProviderReference(), '::getProviderReference() is set');
 
         // post persist the media
         $provider->postPersist($media);
@@ -249,18 +249,18 @@ class ImageProviderTest extends AbstractProviderTest
         $media = new Media();
         $media->setBinaryContent($file);
 
-        $this->assertNull($provider->transform($media));
-        $this->assertNull($media->getWidth(), 'Width staid null');
+        self::assertNull($provider->transform($media));
+        self::assertNull($media->getWidth(), 'Width staid null');
     }
 
     public function testMetadata(): void
     {
         $provider = $this->getProvider();
 
-        $this->assertSame('image', $provider->getProviderMetadata()->getTitle());
-        $this->assertSame('image.description', $provider->getProviderMetadata()->getDescription());
-        $this->assertNotNull($provider->getProviderMetadata()->getImage());
-        $this->assertSame('fa fa-picture-o', $provider->getProviderMetadata()->getOption('class'));
-        $this->assertSame('SonataMediaBundle', $provider->getProviderMetadata()->getDomain());
+        self::assertSame('image', $provider->getProviderMetadata()->getTitle());
+        self::assertSame('image.description', $provider->getProviderMetadata()->getDescription());
+        self::assertNotNull($provider->getProviderMetadata()->getImage());
+        self::assertSame('fa fa-picture-o', $provider->getProviderMetadata()->getOption('class'));
+        self::assertSame('SonataMediaBundle', $provider->getProviderMetadata()->getDomain());
     }
 }

--- a/tests/Provider/VimeoProviderTest.php
+++ b/tests/Provider/VimeoProviderTest.php
@@ -86,10 +86,10 @@ class VimeoProviderTest extends AbstractProviderTest
         $media->setProviderMetadata(json_decode('{"type":"video","version":"1.0","provider_name":"Vimeo","provider_url":"http:\/\/vimeo.com\/","title":"Blinky\u2122","author_name":"Ruairi Robinson","author_url":"http:\/\/vimeo.com\/ruairirobinson","is_plus":"1","html":"<iframe src=\"http:\/\/player.vimeo.com\/video\/21216091\" width=\"1920\" height=\"1080\" frameborder=\"0\"><\/iframe>","width":"1920","height":"1080","duration":"771","description":"","thumbnail_url":"http:\/\/b.vimeocdn.com\/ts\/136\/375\/136375440_1280.jpg","thumbnail_width":1280,"thumbnail_height":720,"video_id":"21216091"}', true));
 
         $media->setId(1023457);
-        $this->assertSame('http://b.vimeocdn.com/ts/136/375/136375440_1280.jpg', $provider->getReferenceImage($media));
+        self::assertSame('http://b.vimeocdn.com/ts/136/375/136375440_1280.jpg', $provider->getReferenceImage($media));
 
-        $this->assertSame('default/0011/24', $provider->generatePath($media));
-        $this->assertSame('/uploads/media/default/0011/24/thumb_1023457_big.jpg', $provider->generatePublicUrl($media, 'big'));
+        self::assertSame('default/0011/24', $provider->generatePath($media));
+        self::assertSame('/uploads/media/default/0011/24/thumb_1023457_big.jpg', $provider->generatePublicUrl($media, 'big'));
     }
 
     public function testThumbnail(): void
@@ -97,10 +97,10 @@ class VimeoProviderTest extends AbstractProviderTest
         $request = $this->createStub(RequestInterface::class);
 
         $messageFactory = $this->createMock(RequestFactoryInterface::class);
-        $messageFactory->expects($this->once())->method('createRequest')->willReturn($request);
+        $messageFactory->expects(self::once())->method('createRequest')->willReturn($request);
 
         $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())->method('sendRequest')->with($this->equalTo($request))->willReturn($this->createResponse('content'));
+        $client->expects(self::once())->method('sendRequest')->with(self::equalTo($request))->willReturn($this->createResponse('content'));
 
         $provider = $this->getProvider($client, $messageFactory);
 
@@ -113,15 +113,15 @@ class VimeoProviderTest extends AbstractProviderTest
 
         $media->setId(1023457);
 
-        $this->assertTrue($provider->requireThumbnails());
+        self::assertTrue($provider->requireThumbnails());
 
         $provider->addFormat('big', ['width' => 200, 'height' => 100, 'constraint' => true]);
 
-        $this->assertNotEmpty($provider->getFormats(), '::getFormats() return an array');
+        self::assertNotEmpty($provider->getFormats(), '::getFormats() return an array');
 
         $provider->generateThumbnails($media);
 
-        $this->assertSame('default/0011/24/thumb_1023457_big.jpg', $provider->generatePrivateUrl($media, 'big'));
+        self::assertSame('default/0011/24/thumb_1023457_big.jpg', $provider->generatePrivateUrl($media, 'big'));
     }
 
     public function testTransformWithSig(): void
@@ -129,10 +129,10 @@ class VimeoProviderTest extends AbstractProviderTest
         $request = $this->createStub(RequestInterface::class);
 
         $requestFactory = $this->createMock(RequestFactoryInterface::class);
-        $requestFactory->expects($this->once())->method('createRequest')->willReturn($request);
+        $requestFactory->expects(self::once())->method('createRequest')->willReturn($request);
 
         $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())->method('sendRequest')->with($this->equalTo($request))
+        $client->expects(self::once())->method('sendRequest')->with(self::equalTo($request))
             ->willReturn($this->createResponse(file_get_contents(__DIR__.'/../Fixtures/valid_vimeo.txt')));
 
         $provider = $this->getProvider($client, $requestFactory);
@@ -147,8 +147,8 @@ class VimeoProviderTest extends AbstractProviderTest
         $provider->transform($media);
         $provider->prePersist($media);
 
-        $this->assertSame('Blinky™', $media->getName(), '::getName() return the file name');
-        $this->assertSame('BDYAbAtaDzA', $media->getProviderReference(), '::getProviderReference() is set');
+        self::assertSame('Blinky™', $media->getName(), '::getName() return the file name');
+        self::assertSame('BDYAbAtaDzA', $media->getProviderReference(), '::getProviderReference() is set');
     }
 
     /**
@@ -159,10 +159,10 @@ class VimeoProviderTest extends AbstractProviderTest
         $request = $this->createStub(RequestInterface::class);
 
         $messageFactory = $this->createMock(RequestFactoryInterface::class);
-        $messageFactory->expects($this->once())->method('createRequest')->willReturn($request);
+        $messageFactory->expects(self::once())->method('createRequest')->willReturn($request);
 
         $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())->method('sendRequest')->with($this->equalTo($request))
+        $client->expects(self::once())->method('sendRequest')->with(self::equalTo($request))
             ->willReturn($this->createResponse(file_get_contents(__DIR__.'/../Fixtures/valid_vimeo.txt')));
 
         $provider = $this->getProvider($client, $messageFactory);
@@ -173,8 +173,8 @@ class VimeoProviderTest extends AbstractProviderTest
         $provider->transform($media);
         $provider->prePersist($media);
 
-        $this->assertSame('Blinky™', $media->getName(), '::getName() return the file name');
-        $this->assertSame('012341231', $media->getProviderReference(), '::getProviderReference() is set');
+        self::assertSame('Blinky™', $media->getName(), '::getName() return the file name');
+        self::assertSame('012341231', $media->getProviderReference(), '::getProviderReference() is set');
     }
 
     public function getTransformWithUrlMedia(): array
@@ -203,7 +203,7 @@ class VimeoProviderTest extends AbstractProviderTest
         $response->setContent(file_get_contents(__DIR__.'/../Fixtures/valid_vimeo.txt'));
 
         $browser = $this->createMock(Browser::class);
-        $browser->expects($this->once())->method('call')->will($this->throwException(new \RuntimeException('First error on get', 12)));
+        $browser->expects(self::once())->method('call')->will(self::throwException(new \RuntimeException('First error on get', 12)));
 
         $provider = $this->getProvider($browser);
 
@@ -229,7 +229,7 @@ class VimeoProviderTest extends AbstractProviderTest
             ->willReturn('message');
 
         $form = $this->createMock(FormMapper::class);
-        $form->expects($this->exactly(8))
+        $form->expects(self::exactly(8))
             ->method('add')
             ->willReturn(null);
 
@@ -252,26 +252,26 @@ class VimeoProviderTest extends AbstractProviderTest
 
         $properties = $provider->getHelperProperties($media, 'admin');
 
-        $this->assertIsArray($properties);
-        $this->assertSame(100, $properties['height']);
-        $this->assertSame(100, $properties['width']);
+        self::assertIsArray($properties);
+        self::assertSame(100, $properties['height']);
+        self::assertSame(100, $properties['width']);
     }
 
     public function testGetReferenceUrl(): void
     {
         $media = new Media();
         $media->setProviderReference('123456');
-        $this->assertSame('https://vimeo.com/123456', $this->getProvider()->getReferenceUrl($media));
+        self::assertSame('https://vimeo.com/123456', $this->getProvider()->getReferenceUrl($media));
     }
 
     public function testMetadata(): void
     {
         $provider = $this->getProvider();
 
-        $this->assertSame('vimeo', $provider->getProviderMetadata()->getTitle());
-        $this->assertSame('vimeo.description', $provider->getProviderMetadata()->getDescription());
-        $this->assertNotNull($provider->getProviderMetadata()->getImage());
-        $this->assertSame('fa fa-vimeo-square', $provider->getProviderMetadata()->getOption('class'));
-        $this->assertSame('SonataMediaBundle', $provider->getProviderMetadata()->getDomain());
+        self::assertSame('vimeo', $provider->getProviderMetadata()->getTitle());
+        self::assertSame('vimeo.description', $provider->getProviderMetadata()->getDescription());
+        self::assertNotNull($provider->getProviderMetadata()->getImage());
+        self::assertSame('fa fa-vimeo-square', $provider->getProviderMetadata()->getOption('class'));
+        self::assertSame('SonataMediaBundle', $provider->getProviderMetadata()->getDomain());
     }
 }

--- a/tests/Provider/YouTubeProviderTest.php
+++ b/tests/Provider/YouTubeProviderTest.php
@@ -87,10 +87,10 @@ class YouTubeProviderTest extends AbstractProviderTest
 
         $media->setId(1023457);
 
-        $this->assertSame('http://i3.ytimg.com/vi/BDYAbAtaDzA/hqdefault.jpg', $provider->getReferenceImage($media));
+        self::assertSame('http://i3.ytimg.com/vi/BDYAbAtaDzA/hqdefault.jpg', $provider->getReferenceImage($media));
 
-        $this->assertSame('default/0011/24', $provider->generatePath($media));
-        $this->assertSame('/uploads/media/default/0011/24/thumb_1023457_big.jpg', $provider->generatePublicUrl($media, 'big'));
+        self::assertSame('default/0011/24', $provider->generatePath($media));
+        self::assertSame('/uploads/media/default/0011/24/thumb_1023457_big.jpg', $provider->generatePublicUrl($media, 'big'));
     }
 
     public function testThumbnail(): void
@@ -98,10 +98,10 @@ class YouTubeProviderTest extends AbstractProviderTest
         $request = $this->createStub(RequestInterface::class);
 
         $requestFactory = $this->createMock(RequestFactoryInterface::class);
-        $requestFactory->expects($this->once())->method('createRequest')->willReturn($request);
+        $requestFactory->expects(self::once())->method('createRequest')->willReturn($request);
 
         $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())->method('sendRequest')->with($this->equalTo($request))->willReturn($this->createResponse('content'));
+        $client->expects(self::once())->method('sendRequest')->with(self::equalTo($request))->willReturn($this->createResponse('content'));
 
         $provider = $this->getProvider($client, $requestFactory);
 
@@ -113,15 +113,15 @@ class YouTubeProviderTest extends AbstractProviderTest
 
         $media->setId(1023457);
 
-        $this->assertTrue($provider->requireThumbnails());
+        self::assertTrue($provider->requireThumbnails());
 
         $provider->addFormat('big', ['width' => 200, 'height' => 100, 'constraint' => true]);
 
-        $this->assertNotEmpty($provider->getFormats(), '::getFormats() return an array');
+        self::assertNotEmpty($provider->getFormats(), '::getFormats() return an array');
 
         $provider->generateThumbnails($media);
 
-        $this->assertSame('default/0011/24/thumb_1023457_big.jpg', $provider->generatePrivateUrl($media, 'big'));
+        self::assertSame('default/0011/24/thumb_1023457_big.jpg', $provider->generatePrivateUrl($media, 'big'));
     }
 
     public function testTransformWithSig(): void
@@ -129,10 +129,10 @@ class YouTubeProviderTest extends AbstractProviderTest
         $request = $this->createStub(RequestInterface::class);
 
         $messageFactory = $this->createMock(RequestFactoryInterface::class);
-        $messageFactory->expects($this->once())->method('createRequest')->willReturn($request);
+        $messageFactory->expects(self::once())->method('createRequest')->willReturn($request);
 
         $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())->method('sendRequest')->with($this->equalTo($request))
+        $client->expects(self::once())->method('sendRequest')->with(self::equalTo($request))
             ->willReturn($this->createResponse(file_get_contents(__DIR__.'/../Fixtures/valid_youtube.txt')));
 
         $provider = $this->getProvider($client, $messageFactory);
@@ -146,8 +146,8 @@ class YouTubeProviderTest extends AbstractProviderTest
         // pre persist the media
         $provider->transform($media);
 
-        $this->assertSame('Nono le petit robot', $media->getName(), '::getName() return the file name');
-        $this->assertSame('BDYAbAtaDzA', $media->getProviderReference(), '::getProviderReference() is set');
+        self::assertSame('Nono le petit robot', $media->getName(), '::getName() return the file name');
+        self::assertSame('BDYAbAtaDzA', $media->getProviderReference(), '::getProviderReference() is set');
     }
 
     /**
@@ -158,10 +158,10 @@ class YouTubeProviderTest extends AbstractProviderTest
         $request = $this->createStub(RequestInterface::class);
 
         $messageFactory = $this->createMock(RequestFactoryInterface::class);
-        $messageFactory->expects($this->once())->method('createRequest')->willReturn($request);
+        $messageFactory->expects(self::once())->method('createRequest')->willReturn($request);
 
         $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())->method('sendRequest')->with($this->equalTo($request))
+        $client->expects(self::once())->method('sendRequest')->with(self::equalTo($request))
             ->willReturn($this->createResponse(file_get_contents(__DIR__.'/../Fixtures/valid_youtube.txt')));
 
         $provider = $this->getProvider($client, $messageFactory);
@@ -175,8 +175,8 @@ class YouTubeProviderTest extends AbstractProviderTest
         // pre persist the media
         $provider->transform($media);
 
-        $this->assertSame('Nono le petit robot', $media->getName(), '::getName() return the file name');
-        $this->assertSame('BDYAbAtaDzA', $media->getProviderReference(), '::getProviderReference() is set');
+        self::assertSame('Nono le petit robot', $media->getName(), '::getName() return the file name');
+        self::assertSame('BDYAbAtaDzA', $media->getProviderReference(), '::getProviderReference() is set');
     }
 
     public static function getUrls(): array
@@ -206,7 +206,7 @@ class YouTubeProviderTest extends AbstractProviderTest
         $response->setContent(file_get_contents(__DIR__.'/../Fixtures/valid_youtube.txt'));
 
         $browser = $this->createMock(Browser::class);
-        $browser->expects($this->once())->method('call')->will($this->throwException(new \RuntimeException('First error on get', 12)));
+        $browser->expects(self::once())->method('call')->will(self::throwException(new \RuntimeException('First error on get', 12)));
 
         $provider = $this->getProvider($browser);
 
@@ -232,7 +232,7 @@ class YouTubeProviderTest extends AbstractProviderTest
             ->willReturn('message');
 
         $form = $this->createMock(FormMapper::class);
-        $form->expects($this->exactly(8))
+        $form->expects(self::exactly(8))
             ->method('add')
             ->willReturn(null);
 
@@ -255,26 +255,26 @@ class YouTubeProviderTest extends AbstractProviderTest
 
         $properties = $provider->getHelperProperties($media, 'admin');
 
-        $this->assertIsArray($properties);
-        $this->assertSame(100, $properties['player_parameters']['height']);
-        $this->assertSame(100, $properties['player_parameters']['width']);
+        self::assertIsArray($properties);
+        self::assertSame(100, $properties['player_parameters']['height']);
+        self::assertSame(100, $properties['player_parameters']['width']);
     }
 
     public function testGetReferenceUrl(): void
     {
         $media = new Media();
         $media->setProviderReference('123456');
-        $this->assertSame('https://www.youtube.com/watch?v=123456', $this->getProvider()->getReferenceUrl($media));
+        self::assertSame('https://www.youtube.com/watch?v=123456', $this->getProvider()->getReferenceUrl($media));
     }
 
     public function testMetadata(): void
     {
         $provider = $this->getProvider();
 
-        $this->assertSame('youtube', $provider->getProviderMetadata()->getTitle());
-        $this->assertSame('youtube.description', $provider->getProviderMetadata()->getDescription());
-        $this->assertNotNull($provider->getProviderMetadata()->getImage());
-        $this->assertSame('fa fa-youtube', $provider->getProviderMetadata()->getOption('class'));
-        $this->assertSame('SonataMediaBundle', $provider->getProviderMetadata()->getDomain());
+        self::assertSame('youtube', $provider->getProviderMetadata()->getTitle());
+        self::assertSame('youtube.description', $provider->getProviderMetadata()->getDescription());
+        self::assertNotNull($provider->getProviderMetadata()->getImage());
+        self::assertSame('fa fa-youtube', $provider->getProviderMetadata()->getOption('class'));
+        self::assertSame('SonataMediaBundle', $provider->getProviderMetadata()->getDomain());
     }
 }

--- a/tests/Resizer/ImagineCompatibleResizerTraitTest.php
+++ b/tests/Resizer/ImagineCompatibleResizerTraitTest.php
@@ -31,7 +31,7 @@ class ImagineCompatibleResizerTraitTest extends TestCase
 
         $convertedMode = $method->invokeArgs($objectWithTrait, [$mode]);
 
-        $this->assertSame($result, $convertedMode);
+        self::assertSame($result, $convertedMode);
     }
 
     public static function getModes(): array

--- a/tests/Resizer/SimpleResizerTest.php
+++ b/tests/Resizer/SimpleResizerTest.php
@@ -42,14 +42,14 @@ class SimpleResizerTest extends TestCase
     public function testResize(): void
     {
         $image = $this->createMock(ImageInterface::class);
-        $image->expects($this->once())->method('thumbnail')->willReturn($image);
-        $image->expects($this->once())->method('get')->willReturn(file_get_contents(__DIR__.'/../Fixtures/logo.png'));
+        $image->expects(self::once())->method('thumbnail')->willReturn($image);
+        $image->expects(self::once())->method('get')->willReturn(file_get_contents(__DIR__.'/../Fixtures/logo.png'));
 
         $adapter = $this->createMock(ImagineInterface::class);
         $adapter->method('load')->willReturn($image);
 
         $media = $this->createMock(MediaInterface::class);
-        $media->expects($this->exactly(2))->method('getBox')->willReturn(new Box(535, 132));
+        $media->expects(self::exactly(2))->method('getBox')->willReturn(new Box(535, 132));
 
         $filesystem = new Filesystem(new InMemory());
         $in = $filesystem->get('in', true);
@@ -58,7 +58,7 @@ class SimpleResizerTest extends TestCase
         $out = $filesystem->get('out', true);
 
         $metadata = $this->createMock(MetadataBuilderInterface::class);
-        $metadata->expects($this->once())->method('get')->willReturn([]);
+        $metadata->expects(self::once())->method('get')->willReturn([]);
 
         $resizer = new SimpleResizer($adapter, 'outbound', $metadata);
         $resizer->resize($media, $in, $out, 'bar', ['height' => null, 'width' => 90, 'quality' => 100]);
@@ -72,7 +72,7 @@ class SimpleResizerTest extends TestCase
         $adapter = $this->createMock(ImagineInterface::class);
 
         $media = $this->createMock(MediaInterface::class);
-        $media->expects($this->exactly(2))->method('getBox')->willReturn($mediaSize);
+        $media->expects(self::exactly(2))->method('getBox')->willReturn($mediaSize);
 
         $metadata = $this->createMock(MetadataBuilderInterface::class);
 
@@ -80,10 +80,10 @@ class SimpleResizerTest extends TestCase
 
         $box = $resizer->getBox($media, $settings);
 
-        $this->assertInstanceOf(Box::class, $box);
+        self::assertInstanceOf(Box::class, $box);
 
-        $this->assertSame($result->getWidth(), $box->getWidth());
-        $this->assertSame($result->getHeight(), $box->getHeight());
+        self::assertSame($result->getWidth(), $box->getWidth());
+        self::assertSame($result->getHeight(), $box->getHeight());
     }
 
     public static function getBoxSettings(): array

--- a/tests/Resizer/SquareResizerTest.php
+++ b/tests/Resizer/SquareResizerTest.php
@@ -44,7 +44,7 @@ class SquareResizerTest extends TestCase
         $adapter = $this->createMock(ImagineInterface::class);
 
         $media = $this->createMock(MediaInterface::class);
-        $media->expects($this->once())->method('getBox')->willReturn($mediaSize);
+        $media->expects(self::once())->method('getBox')->willReturn($mediaSize);
 
         $metadata = $this->createMock(MetadataBuilderInterface::class);
 
@@ -52,10 +52,10 @@ class SquareResizerTest extends TestCase
 
         $box = $resizer->getBox($media, $settings);
 
-        $this->assertInstanceOf(Box::class, $box);
+        self::assertInstanceOf(Box::class, $box);
 
-        $this->assertSame($expected->getWidth(), $box->getWidth());
-        $this->assertSame($expected->getHeight(), $box->getHeight());
+        self::assertSame($expected->getWidth(), $box->getWidth());
+        self::assertSame($expected->getHeight(), $box->getHeight());
     }
 
     public static function getBoxSettings(): array

--- a/tests/Security/ForbiddenDownloadStrategyTest.php
+++ b/tests/Security/ForbiddenDownloadStrategyTest.php
@@ -29,7 +29,7 @@ class ForbiddenDownloadStrategyTest extends TestCase
         $translator = $this->createStub(TranslatorInterface::class);
 
         $strategy = new ForbiddenDownloadStrategy($translator);
-        $this->assertFalse($strategy->isGranted($media, $request));
+        self::assertFalse($strategy->isGranted($media, $request));
     }
 
     /**
@@ -43,6 +43,6 @@ class ForbiddenDownloadStrategyTest extends TestCase
         $translator = $this->createStub(LegacyTranslatorInterface::class);
 
         $strategy = new ForbiddenDownloadStrategy($translator);
-        $this->assertFalse($strategy->isGranted($media, $request));
+        self::assertFalse($strategy->isGranted($media, $request));
     }
 }

--- a/tests/Security/PublicDownloadStrategyTest.php
+++ b/tests/Security/PublicDownloadStrategyTest.php
@@ -29,7 +29,7 @@ class PublicDownloadStrategyTest extends TestCase
         $translator = $this->createStub(TranslatorInterface::class);
 
         $strategy = new PublicDownloadStrategy($translator);
-        $this->assertTrue($strategy->isGranted($media, $request));
+        self::assertTrue($strategy->isGranted($media, $request));
     }
 
     /**
@@ -43,6 +43,6 @@ class PublicDownloadStrategyTest extends TestCase
         $translator = $this->createStub(LegacyTranslatorInterface::class);
 
         $strategy = new PublicDownloadStrategy($translator);
-        $this->assertTrue($strategy->isGranted($media, $request));
+        self::assertTrue($strategy->isGranted($media, $request));
     }
 }

--- a/tests/Security/RolesDownloadStrategyTest.php
+++ b/tests/Security/RolesDownloadStrategyTest.php
@@ -37,7 +37,7 @@ class RolesDownloadStrategyTest extends TestCase
             });
 
         $strategy = new RolesDownloadStrategy($translator, $security, ['ROLE_ADMIN']);
-        $this->assertTrue($strategy->isGranted($media, $request));
+        self::assertTrue($strategy->isGranted($media, $request));
     }
 
     public function testIsGrantedFalse(): void
@@ -54,7 +54,7 @@ class RolesDownloadStrategyTest extends TestCase
             });
 
         $strategy = new RolesDownloadStrategy($translator, $security, ['ROLE_ADMIN']);
-        $this->assertFalse($strategy->isGranted($media, $request));
+        self::assertFalse($strategy->isGranted($media, $request));
     }
 
     /**
@@ -75,7 +75,7 @@ class RolesDownloadStrategyTest extends TestCase
             });
 
         $strategy = new RolesDownloadStrategy($translator, $security, ['ROLE_ADMIN']);
-        $this->assertTrue($strategy->isGranted($media, $request));
+        self::assertTrue($strategy->isGranted($media, $request));
     }
 
     /**
@@ -96,6 +96,6 @@ class RolesDownloadStrategyTest extends TestCase
             });
 
         $strategy = new RolesDownloadStrategy($translator, $security, ['ROLE_ADMIN']);
-        $this->assertFalse($strategy->isGranted($media, $request));
+        self::assertFalse($strategy->isGranted($media, $request));
     }
 }

--- a/tests/Security/SessionDownloadStrategyTest.php
+++ b/tests/Security/SessionDownloadStrategyTest.php
@@ -39,7 +39,7 @@ final class SessionDownloadStrategyTest extends TestCase
             ->willReturn(1);
 
         $strategy = new SessionDownloadStrategy($translator, $session, 0);
-        $this->assertFalse($strategy->isGranted($media, $request));
+        self::assertFalse($strategy->isGranted($media, $request));
     }
 
     public function testIsGrantedTrue(): void
@@ -54,7 +54,7 @@ final class SessionDownloadStrategyTest extends TestCase
             ->willReturn(0);
 
         $strategy = new SessionDownloadStrategy($translator, $session, 1);
-        $this->assertTrue($strategy->isGranted($media, $request));
+        self::assertTrue($strategy->isGranted($media, $request));
     }
 
     /**
@@ -74,13 +74,13 @@ final class SessionDownloadStrategyTest extends TestCase
             ->method('get')
             ->willReturn(0);
 
-        $container->expects($this->once())
+        $container->expects(self::once())
             ->method('get')
             ->willReturn($session);
 
         $strategy = new SessionDownloadStrategy($translator, $container, 1);
 
-        $this->assertTrue($strategy->isGranted($media, $request));
+        self::assertTrue($strategy->isGranted($media, $request));
     }
 
     public function testTypeError(): void
@@ -108,7 +108,7 @@ final class SessionDownloadStrategyTest extends TestCase
             ->willReturn(1);
 
         $strategy = new SessionDownloadStrategy($translator, $session, 0);
-        $this->assertFalse($strategy->isGranted($media, $request));
+        self::assertFalse($strategy->isGranted($media, $request));
     }
 
     /**
@@ -127,7 +127,7 @@ final class SessionDownloadStrategyTest extends TestCase
             ->willReturn(0);
 
         $strategy = new SessionDownloadStrategy($translator, $session, 1);
-        $this->assertTrue($strategy->isGranted($media, $request));
+        self::assertTrue($strategy->isGranted($media, $request));
     }
 
     /**
@@ -147,13 +147,13 @@ final class SessionDownloadStrategyTest extends TestCase
             ->method('get')
             ->willReturn(0);
 
-        $container->expects($this->once())
+        $container->expects(self::once())
             ->method('get')
             ->willReturn($session);
 
         $strategy = new SessionDownloadStrategy($translator, $container, 1);
 
-        $this->assertTrue($strategy->isGranted($media, $request));
+        self::assertTrue($strategy->isGranted($media, $request));
     }
 
     /**
@@ -185,6 +185,6 @@ final class SessionDownloadStrategyTest extends TestCase
             ->willReturn(1);
 
         $strategy = new SessionDownloadStrategy($translator, $session, '0');
-        $this->assertFalse($strategy->isGranted($media, $request));
+        self::assertFalse($strategy->isGranted($media, $request));
     }
 }

--- a/tests/Thumbnail/ConsumerThumbnailTest.php
+++ b/tests/Thumbnail/ConsumerThumbnailTest.php
@@ -26,11 +26,11 @@ class ConsumerThumbnailTest extends TestCase
     public function testGenerateDispatchesEvents(): void
     {
         $dispatcher = $this->createMock(EventDispatcherInterface::class);
-        $dispatcher->expects($this->exactly(2))
+        $dispatcher->expects(self::exactly(2))
             ->method('addListener')
             ->withConsecutive(
-                ['kernel.finish_request', $this->anything()],
-                ['console.terminate', $this->anything()]
+                ['kernel.finish_request', self::anything()],
+                ['console.terminate', self::anything()]
             );
 
         $consumer = new ConsumerThumbnail(

--- a/tests/Thumbnail/FormatThumbnailTest.php
+++ b/tests/Thumbnail/FormatThumbnailTest.php
@@ -38,19 +38,19 @@ class FormatThumbnailTest extends TestCase
         ];
 
         $resizer = $this->createMock(ResizerInterface::class);
-        $resizer->expects($this->exactly(2))->method('resize')->willReturn(true);
+        $resizer->expects(self::exactly(2))->method('resize')->willReturn(true);
 
         $provider = $this->createMock(MediaProviderInterface::class);
-        $provider->expects($this->once())->method('requireThumbnails')->willReturn(true);
-        $provider->expects($this->once())->method('getReferenceFile')->willReturn($referenceFile);
-        $provider->expects($this->once())->method('getFormats')->willReturn($formats);
-        $provider->expects($this->exactly(2))->method('getResizer')->willReturn($resizer);
-        $provider->expects($this->exactly(2))->method('generatePrivateUrl')->willReturn('/my/private/path');
-        $provider->expects($this->exactly(2))->method('getFilesystem')->willReturn($filesystem);
+        $provider->expects(self::once())->method('requireThumbnails')->willReturn(true);
+        $provider->expects(self::once())->method('getReferenceFile')->willReturn($referenceFile);
+        $provider->expects(self::once())->method('getFormats')->willReturn($formats);
+        $provider->expects(self::exactly(2))->method('getResizer')->willReturn($resizer);
+        $provider->expects(self::exactly(2))->method('generatePrivateUrl')->willReturn('/my/private/path');
+        $provider->expects(self::exactly(2))->method('getFilesystem')->willReturn($filesystem);
 
         $media = $this->createMock(MediaInterface::class);
-        $media->expects($this->exactly(6))->method('getContext')->willReturn('mycontext');
-        $media->expects($this->exactly(2))->method('getExtension')->willReturn('png');
+        $media->expects(self::exactly(6))->method('getContext')->willReturn('mycontext');
+        $media->expects(self::exactly(2))->method('getExtension')->willReturn('png');
 
         $thumbnail->generate($provider, $media);
     }

--- a/tests/Thumbnail/LiipImagineThumbnailTest.php
+++ b/tests/Thumbnail/LiipImagineThumbnailTest.php
@@ -67,12 +67,12 @@ class LiipImagineThumbnailTest extends TestCase
         )->willReturn('cache/media/default/0011/24/ASDASDAS.png');
 
         $thumbnail->generate($provider, $media);
-        $this->assertSame('default/0011/24/ASDASDAS.png', $thumbnail->generatePublicUrl(
+        self::assertSame('default/0011/24/ASDASDAS.png', $thumbnail->generatePublicUrl(
             $provider,
             $media,
             MediaProviderInterface::FORMAT_ADMIN
         ));
-        $this->assertSame('cache/media/default/0011/24/ASDASDAS.png', $thumbnail->generatePublicUrl(
+        self::assertSame('cache/media/default/0011/24/ASDASDAS.png', $thumbnail->generatePublicUrl(
             $provider,
             $media,
             'mycontext_medium'
@@ -102,7 +102,7 @@ class LiipImagineThumbnailTest extends TestCase
             '/imagine/medium/some/path/42_medium.jpg',
             true
         )->willReturn('some/cdn/path');
-        $this->assertSame(
+        self::assertSame(
             'some/cdn/path',
             $thumbnail->generatePublicUrl($provider, $media, $format)
         );

--- a/tests/Twig/Extension/MediaExtensionTest.php
+++ b/tests/Twig/Extension/MediaExtensionTest.php
@@ -59,14 +59,14 @@ class MediaExtensionTest extends TestCase
         ];
 
         $provider = $this->getProvider();
-        $provider->expects($this->once())->method('generatePublicUrl')->with($media, $format)
+        $provider->expects(self::once())->method('generatePublicUrl')->with($media, $format)
             ->willReturn('http://some.url.com');
 
         $template = $this->getTemplate();
-        $template->expects($this->once())
+        $template->expects(self::once())
             ->method('render')
             ->with(
-                $this->equalTo(
+                self::equalTo(
                     [
                         'media' => $media,
                         'options' => [

--- a/tests/Validator/Constraints/ValidMediaFormatTest.php
+++ b/tests/Validator/Constraints/ValidMediaFormatTest.php
@@ -22,7 +22,7 @@ class ValidMediaFormatTest extends TestCase
     {
         $constraint = new ValidMediaFormat();
 
-        $this->assertSame('class', $constraint->getTargets());
-        $this->assertSame('sonata.media.validator.format', $constraint->validatedBy());
+        self::assertSame('class', $constraint->getTargets());
+        self::assertSame('sonata.media.validator.format', $constraint->validatedBy());
     }
 }

--- a/tests/Validator/FormatValidatorTest.php
+++ b/tests/Validator/FormatValidatorTest.php
@@ -28,11 +28,11 @@ class FormatValidatorTest extends TestCase
         $pool->addContext('test', [], ['format1' => []]);
 
         $gallery = $this->createMock(GalleryInterface::class);
-        $gallery->expects($this->once())->method('getDefaultFormat')->willReturn('format1');
-        $gallery->expects($this->once())->method('getContext')->willReturn('test');
+        $gallery->expects(self::once())->method('getDefaultFormat')->willReturn('format1');
+        $gallery->expects(self::once())->method('getContext')->willReturn('test');
 
         $context = $this->createMock(ExecutionContext::class);
-        $context->expects($this->never())->method('addViolation');
+        $context->expects(self::never())->method('addViolation');
 
         $validator = new FormatValidator($pool);
         $validator->initialize($context);
@@ -46,11 +46,11 @@ class FormatValidatorTest extends TestCase
         $pool->addContext('test', [], ['format1' => []]);
 
         $gallery = $this->createMock(GalleryInterface::class);
-        $gallery->expects($this->once())->method('getDefaultFormat')->willReturn('non_existing_format');
-        $gallery->expects($this->once())->method('getContext')->willReturn('test');
+        $gallery->expects(self::once())->method('getDefaultFormat')->willReturn('non_existing_format');
+        $gallery->expects(self::once())->method('getContext')->willReturn('test');
 
         $context = $this->createMock(ExecutionContext::class);
-        $context->expects($this->once())->method('addViolation');
+        $context->expects(self::once())->method('addViolation');
 
         $validator = new FormatValidator($pool);
         $validator->initialize($context);
@@ -64,11 +64,11 @@ class FormatValidatorTest extends TestCase
         $pool->addContext('test');
 
         $gallery = $this->createMock(GalleryInterface::class);
-        $gallery->expects($this->once())->method('getDefaultFormat')->willReturn('format_that_is_not_reference');
-        $gallery->expects($this->once())->method('getContext')->willReturn('test');
+        $gallery->expects(self::once())->method('getDefaultFormat')->willReturn('format_that_is_not_reference');
+        $gallery->expects(self::once())->method('getContext')->willReturn('test');
 
         $context = $this->createMock(ExecutionContext::class);
-        $context->expects($this->once())->method('addViolation');
+        $context->expects(self::once())->method('addViolation');
 
         $validator = new FormatValidator($pool);
         $validator->initialize($context);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Backport PHPStan configuration from `master`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- PHPStan configuration and dependencies backported from `master` branch.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
