### PR TITLE
Add getName on blocks for SonataPageBundle

### DIFF
--- a/src/Block/FeatureMediaBlockService.php
+++ b/src/Block/FeatureMediaBlockService.php
@@ -29,6 +29,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class FeatureMediaBlockService extends MediaBlockService
 {
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function getName()
     {
         return 'Feature Media';

--- a/src/Block/FeatureMediaBlockService.php
+++ b/src/Block/FeatureMediaBlockService.php
@@ -29,6 +29,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class FeatureMediaBlockService extends MediaBlockService
 {
+    public function getName()
+    {
+        return 'Feature Media';
+    }
+
     public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults([

--- a/src/Block/GalleryBlockService.php
+++ b/src/Block/GalleryBlockService.php
@@ -92,6 +92,11 @@ class GalleryBlockService extends AbstractBlockService
         return $this->galleryAdmin;
     }
 
+    public function getName()
+    {
+        return 'Media Gallery';
+    }
+
     public function configureSettings(OptionsResolver $resolver)
     {
         $resolver->setDefaults([

--- a/src/Block/GalleryBlockService.php
+++ b/src/Block/GalleryBlockService.php
@@ -92,6 +92,9 @@ class GalleryBlockService extends AbstractBlockService
         return $this->galleryAdmin;
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function getName()
     {
         return 'Media Gallery';

--- a/src/Block/GalleryListBlockService.php
+++ b/src/Block/GalleryListBlockService.php
@@ -58,6 +58,9 @@ class GalleryListBlockService extends AbstractBlockService
         $this->pool = $pool;
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function getName()
     {
         return 'Media Gallery List';

--- a/src/Block/GalleryListBlockService.php
+++ b/src/Block/GalleryListBlockService.php
@@ -58,6 +58,11 @@ class GalleryListBlockService extends AbstractBlockService
         $this->pool = $pool;
     }
 
+    public function getName()
+    {
+        return 'Media Gallery List';
+    }
+
     /**
      * NEXT_MAJOR: Remove this method.
      *

--- a/tests/Block/FeatureMediaBlockServiceTest.php
+++ b/tests/Block/FeatureMediaBlockServiceTest.php
@@ -34,6 +34,11 @@ class FeatureMediaBlockServiceTest extends BlockServiceTestCase
         );
     }
 
+    public function testName(): void
+    {
+        self::assertSame('Feature Media', $this->blockService->getName());
+    }
+
     public function testDefaultSettings(): void
     {
         $blockContext = $this->getBlockContext($this->blockService);

--- a/tests/Block/GalleryBlockServiceTest.php
+++ b/tests/Block/GalleryBlockServiceTest.php
@@ -40,6 +40,11 @@ class GalleryBlockServiceTest extends BlockServiceTestCase
         );
     }
 
+    public function testName(): void
+    {
+        self::assertSame('Media Gallery', $this->blockService->getName());
+    }
+
     public function testExecute(): void
     {
         $block = $this->createStub(Block::class);

--- a/tests/Block/GalleryListBlockServiceTest.php
+++ b/tests/Block/GalleryListBlockServiceTest.php
@@ -33,6 +33,18 @@ class GalleryListBlockServiceTest extends BlockServiceTestCase
 
         $this->galleryManager = $this->createMock(GalleryManagerInterface::class);
         $this->pool = $this->createMock(Pool::class);
+
+        $this->blockService = new GalleryListBlockService(
+            $this->twig,
+            null,
+            $this->galleryManager,
+            $this->pool
+        );
+    }
+
+    public function testName(): void
+    {
+        self::assertSame('Media Gallery List', $this->blockService->getName());
     }
 
     public function testExecute(): void
@@ -53,8 +65,6 @@ class GalleryListBlockServiceTest extends BlockServiceTestCase
 
         $blockContext = new BlockContext($block, $settings);
 
-        $blockService = new GalleryListBlockService($this->twig, null, $this->galleryManager, $this->pool);
-
         $this->twig
             ->expects(self::once())
             ->method('render')
@@ -65,13 +75,12 @@ class GalleryListBlockServiceTest extends BlockServiceTestCase
                 'settings' => $settings,
             ]);
 
-        $blockService->execute($blockContext);
+        $this->blockService->execute($blockContext);
     }
 
     public function testDefaultSettings(): void
     {
-        $blockService = new GalleryListBlockService($this->twig, null, $this->galleryManager, $this->pool);
-        $blockContext = $this->getBlockContext($blockService);
+        $blockContext = $this->getBlockContext($this->blockService);
 
         $this->assertSettings([
             'number' => 15,


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1962 .

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added name for blocks so they can be recognized on SonataPageBundle.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
