### PR TITLE
Inject requestStack instead of SessionInterface to avoid deprecation

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -17,6 +17,22 @@ custom resizers.
 This integration is deprecated because the php packages are not up to date. On master
 this integration will be removed. There is no replacement for it.
 
+### Deprecate direct session injection
+
+`$session` property in `Security/SessionDownloadStrategy` is deprecated. Use `RequestStack` `$requestStack` instead.
+
+Before:
+
+```php
+    $downloadStrategy = new SessionDownloadStrategy($translator, $session, $times);
+```
+
+After:
+
+```php
+    $downloadStrategy = new SessionDownloadStrategy($translator, $requestStack, $times);
+```
+
 UPGRADE FROM 3.31 to 3.32
 =========================
 

--- a/src/Resources/config/security.xml
+++ b/src/Resources/config/security.xml
@@ -14,7 +14,7 @@
         </service>
         <service id="sonata.media.security.session_strategy" class="Sonata\MediaBundle\Security\SessionDownloadStrategy">
             <argument type="service" id="translator"/>
-            <argument type="service" id="session"/>
+            <argument type="service" id="request_stack"/>
             <argument>1</argument>
         </service>
         <service id="sonata.media.security.connected_strategy" class="Sonata\MediaBundle\Security\RolesDownloadStrategy">

--- a/tests/Security/SessionDownloadStrategyTest.php
+++ b/tests/Security/SessionDownloadStrategyTest.php
@@ -18,6 +18,7 @@ use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Security\SessionDownloadStrategy;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Translation\TranslatorInterface as LegacyTranslatorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -31,18 +32,47 @@ final class SessionDownloadStrategyTest extends TestCase
     {
         $translator = $this->createStub(TranslatorInterface::class);
         $media = $this->createStub(MediaInterface::class);
-        $request = $this->createStub(Request::class);
         $session = $this->createMock(Session::class);
+
+        $request = new Request();
+        $request->setSession($session);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
 
         $session
             ->method('get')
             ->willReturn(1);
 
-        $strategy = new SessionDownloadStrategy($translator, $session, 0);
+        $strategy = new SessionDownloadStrategy($translator, $requestStack, 0);
         self::assertFalse($strategy->isGranted($media, $request));
     }
 
     public function testIsGrantedTrue(): void
+    {
+        $translator = $this->createStub(TranslatorInterface::class);
+        $media = $this->createStub(MediaInterface::class);
+        $session = $this->createMock(Session::class);
+
+        $request = new Request();
+        $request->setSession($session);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $session
+            ->method('get')
+            ->willReturn(0);
+
+        $strategy = new SessionDownloadStrategy($translator, $requestStack, 1);
+        self::assertTrue($strategy->isGranted($media, $request));
+    }
+
+    /**
+     * @group legacy
+     * NEXT_MAJOR: remove this method
+     */
+    public function testIsGrantedTrueWithSession(): void
     {
         $translator = $this->createStub(TranslatorInterface::class);
         $media = $this->createStub(MediaInterface::class);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Direct injection of `SessionInterface` on `SessionDownloadStrategy`, we use `RequestStack` to avoid deprecations.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
