### PR TITLE
Deprecate unused argument 3 in `Replicate::write()`

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -8,6 +8,7 @@ UPGRADE FROM 3.x to 3.x
 
 Added implementation for `Gaufrette\Adapter\FileFactory` and `Gaufrette\Adapter\StreamFactory`.
 Method `createFileStream()` is deprecated in favor of `createStream()`.
+Argument 3 (`?array $metadata = null`) in method `write()` is deprecated.
 
 ### Sonata\MediaBundle\Thumbnail\ResizableThumbnailInterface
 

--- a/src/Filesystem/Replicate.php
+++ b/src/Filesystem/Replicate.php
@@ -108,13 +108,24 @@ class Replicate implements AdapterInterface, FileFactory, MetadataSupporter, Str
         return $this->primary->exists($key);
     }
 
+    /**
+     * NEXT_MAJOR: Remove argument 3.
+     */
     public function write($key, $content, ?array $metadata = null)
     {
+        if (3 === \func_num_args()) {
+            @trigger_error(sprintf(
+                'Argument 3 in "%s()" method is deprecated since sonata-project/media-bundle 3.x'
+                .' and will be removed in version 4.0.',
+                __METHOD__
+            ), \E_USER_DEPRECATED);
+        }
+
         $ok = true;
         $return = false;
 
         try {
-            $return = $this->primary->write($key, $content, $metadata);
+            $return = $this->primary->write($key, $content);
         } catch (\Exception $e) {
             if ($this->logger) {
                 $this->logger->critical(sprintf('Unable to write %s, error: %s', $key, $e->getMessage()));
@@ -124,7 +135,7 @@ class Replicate implements AdapterInterface, FileFactory, MetadataSupporter, Str
         }
 
         try {
-            $return = $this->secondary->write($key, $content, $metadata);
+            $return = $this->secondary->write($key, $content);
         } catch (\Exception $e) {
             if ($this->logger) {
                 $this->logger->critical(sprintf('Unable to write %s, error: %s', $key, $e->getMessage()));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Deprecate unused argument 3 in `Replicate::write()`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Unused argument 3 in `Replicate::write()`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
