### PR TITLE
Fix some return types

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,11 @@ UPGRADE 3.x
 UPGRADE FROM 3.x to 3.x
 =======================
 
+### Sonata\MediaBundle\Listener\BaseMediaEventSubscriber::getMedia() and its inheritances
+
+Method `getMedia()` returns `null` if the related medium does not implement `Sonata\MediaBundle\Model\MediaInterface`.
+Before this change, under the same situation this method was returning the invalid object.
+
 ### Sonata\MediaBundle\Filesystem\Replicate
 
 Added implementation for `Gaufrette\Adapter\FileFactory` and `Gaufrette\Adapter\StreamFactory`.

--- a/src/Listener/BaseMediaEventSubscriber.php
+++ b/src/Listener/BaseMediaEventSubscriber.php
@@ -42,66 +42,82 @@ abstract class BaseMediaEventSubscriber implements EventSubscriber
 
     public function postUpdate(EventArgs $args)
     {
-        if (!($provider = $this->getProvider($args))) {
+        $media = $this->getMedia($args);
+
+        if (null === $media) {
             return;
         }
 
-        $provider->postUpdate($this->getMedia($args));
+        $this->getProvider($args)->postUpdate($media);
     }
 
     public function postRemove(EventArgs $args)
     {
-        if (!($provider = $this->getProvider($args))) {
+        $media = $this->getMedia($args);
+
+        if (null === $media) {
             return;
         }
 
-        $provider->postRemove($this->getMedia($args));
+        $this->getProvider($args)->postRemove($media);
     }
 
     public function postPersist(EventArgs $args)
     {
-        if (!($provider = $this->getProvider($args))) {
+        $media = $this->getMedia($args);
+
+        if (null === $media) {
             return;
         }
 
-        $provider->postPersist($this->getMedia($args));
+        $this->getProvider($args)->postPersist($media);
     }
 
     public function preUpdate(EventArgs $args)
     {
-        if (!($provider = $this->getProvider($args))) {
+        $media = $this->getMedia($args);
+
+        if (null === $media) {
             return;
         }
 
-        $provider->transform($this->getMedia($args));
-        $provider->preUpdate($this->getMedia($args));
+        $provider = $this->getProvider($args);
+
+        $provider->transform($media);
+        $provider->preUpdate($media);
 
         $this->recomputeSingleEntityChangeSet($args);
     }
 
     public function preRemove(EventArgs $args)
     {
-        if (!($provider = $this->getProvider($args))) {
+        $media = $this->getMedia($args);
+
+        if (null === $media) {
             return;
         }
 
-        $provider->preRemove($this->getMedia($args));
+        $this->getProvider($args)->preRemove($this->getMedia($args));
     }
 
     public function prePersist(EventArgs $args)
     {
-        if (!($provider = $this->getProvider($args))) {
+        $media = $this->getMedia($args);
+
+        if (null === $media) {
             return;
         }
 
-        $provider->transform($this->getMedia($args));
-        $provider->prePersist($this->getMedia($args));
+        $provider = $this->getProvider($args);
+
+        $provider->transform($media);
+        $provider->prePersist($media);
     }
 
     abstract protected function recomputeSingleEntityChangeSet(EventArgs $args);
 
     /**
-     * @return MediaInterface
+     * @return MediaInterface|null
      */
     abstract protected function getMedia(EventArgs $args);
 
@@ -111,10 +127,6 @@ abstract class BaseMediaEventSubscriber implements EventSubscriber
     protected function getProvider(EventArgs $args)
     {
         $media = $this->getMedia($args);
-
-        if (!$media instanceof MediaInterface) {
-            return;
-        }
 
         return $this->getPool()->getProvider($media->getProviderName());
     }

--- a/src/Listener/ODM/MediaEventSubscriber.php
+++ b/src/Listener/ODM/MediaEventSubscriber.php
@@ -16,6 +16,7 @@ namespace Sonata\MediaBundle\Listener\ODM;
 use Doctrine\Common\EventArgs;
 use Doctrine\ODM\MongoDB\Events;
 use Sonata\MediaBundle\Listener\BaseMediaEventSubscriber;
+use Sonata\MediaBundle\Model\MediaInterface;
 
 /**
  * @final since sonata-project/media-bundle 3.21.0
@@ -46,6 +47,12 @@ class MediaEventSubscriber extends BaseMediaEventSubscriber
 
     protected function getMedia(EventArgs $args)
     {
-        return $args->getDocument();
+        $media = $args->getDocument();
+
+        if (!$media instanceof MediaInterface) {
+            return null;
+        }
+
+        return $media;
     }
 }

--- a/src/Listener/ORM/MediaEventSubscriber.php
+++ b/src/Listener/ORM/MediaEventSubscriber.php
@@ -62,7 +62,7 @@ class MediaEventSubscriber extends BaseMediaEventSubscriber
         $media = $args->getEntity();
 
         if (!$media instanceof MediaInterface) {
-            return $media;
+            return null;
         }
 
         if ($this->container->has('sonata.media.manager.category') && !$media->getCategory()) {

--- a/src/Listener/PHPCR/MediaEventSubscriber.php
+++ b/src/Listener/PHPCR/MediaEventSubscriber.php
@@ -14,8 +14,11 @@ declare(strict_types=1);
 namespace Sonata\MediaBundle\Listener\PHPCR;
 
 use Doctrine\Common\EventArgs;
+use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\Event;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Sonata\MediaBundle\Listener\BaseMediaEventSubscriber;
+use Sonata\MediaBundle\Model\MediaInterface;
 
 /**
  * @final since sonata-project/media-bundle 3.21.0
@@ -34,10 +37,12 @@ class MediaEventSubscriber extends BaseMediaEventSubscriber
         ];
     }
 
+    /**
+     * @param LifecycleEventArgs $args
+     */
     protected function recomputeSingleEntityChangeSet(EventArgs $args)
     {
-        /* @var $args \Doctrine\Persistence\Event\LifecycleEventArgs */
-        /** @var $dm \Doctrine\ODM\PHPCR\DocumentManager */
+        /** @var DocumentManager $dm */
         $dm = $args->getObjectManager();
 
         $dm->getUnitOfWork()->computeSingleDocumentChangeSet(
@@ -45,8 +50,17 @@ class MediaEventSubscriber extends BaseMediaEventSubscriber
         );
     }
 
+    /**
+     * @param LifecycleEventArgs $args
+     */
     protected function getMedia(EventArgs $args)
     {
-        return $args->getObject();
+        $media = $args->getObject();
+
+        if (!$media instanceof MediaInterface) {
+            return null;
+        }
+
+        return $media;
     }
 }

--- a/src/Provider/FileProvider.php
+++ b/src/Provider/FileProvider.php
@@ -210,9 +210,17 @@ class FileProvider extends BaseProvider implements FileProviderInterface
 
     public function generatePrivateUrl(MediaInterface $media, $format)
     {
-        if (MediaProviderInterface::FORMAT_REFERENCE === $format) {
+        if (self::FORMAT_REFERENCE === $format) {
             return $this->getReferenceImage($media);
         }
+
+        // throw new \InvalidArgumentException(sprintf(
+        //     'Argument 2 passed to "%s()" only accepts the value "%s", "%s" given.',
+        //     __METHOD__,
+        //     self::FORMAT_REFERENCE,
+        //     $format
+        // ));
+        // NEXT_MAJOR: Uncomment the previous exception and remove the `return false` statement.
 
         return false;
     }

--- a/tests/Listener/ORM/MediaEventSubscriberTest.php
+++ b/tests/Listener/ORM/MediaEventSubscriberTest.php
@@ -63,6 +63,7 @@ class MediaEventSubscriberTest extends TestCase
 
         $media1 = $this->createMock(Media::class);
         $media1->method('getContext')->willReturn('context');
+        $media1->method('getProviderName')->willReturn('provider');
 
         $args1 = $this->createMock(LifecycleEventArgs::class);
         $args1->method('getEntity')->willReturn($media1);
@@ -73,6 +74,7 @@ class MediaEventSubscriberTest extends TestCase
 
         $media2 = $this->createMock(Media::class);
         $media2->method('getContext')->willReturn('context');
+        $media2->method('getProviderName')->willReturn('provider');
 
         $args2 = $this->createMock(LifecycleEventArgs::class);
         $args2->method('getEntity')->willReturn($media2);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Fix some return types.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes try to respect BC.

See #1991.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Return type at `BaseMediaEventSubscriber::getProvider()`.

### Changed
- Return `null` from `BaseMediaEventSubscriber::getMedia()` if the related media does not implement `MediaInterface`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
