### PR TITLE
Fix support for "kriswallsmith/buzz" <0.16

### DIFF
--- a/src/Client/BuzzClient.php
+++ b/src/Client/BuzzClient.php
@@ -37,6 +37,10 @@ final class BuzzClient implements ClientInterface
 
     public function sendRequest(RequestInterface $request): ResponseInterface
     {
-        return $this->browser->sendRequest($request);
+        if (method_exists($this->browser, 'sendRequest')) {
+            return $this->browser->sendRequest($request);
+        }
+
+        return $this->browser->send($request);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Fix support for "kriswallsmith/buzz" <0.16.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Function `Browser::sendRequest()` was introduced in "kriswallsmith/buzz" ^0.16, but we are using it relying it's always available:
https://github.com/sonata-project/SonataMediaBundle/blob/08bf82969673cd78e166a6c81408716c5587f7a1/src/Client/BuzzClient.php#L40
See https://github.com/kriswallsmith/Buzz/blob/master/CHANGELOG.md#added-6.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Call to undefined function `Buzz\Browser::sendRequest()` with "kriswallsmith/buzz" <0.16.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
