### PR TITLE
Remove placeholders from translations

### DIFF
--- a/src/Resources/translations/SonataMediaBundle.bg.xliff
+++ b/src/Resources/translations/SonataMediaBundle.bg.xliff
@@ -78,17 +78,9 @@
         <source>description.forbidden_download_strategy</source>
         <target>Медиата е недостъпна.</target>
       </trans-unit>
-      <trans-unit id="description.session_download_strategy">
-        <source>description.session_download_strategy</source>
-        <target>description.session_download_strategy</target>
-      </trans-unit>
       <trans-unit id="filter.label_name">
         <source>filter.label_name</source>
         <target>Име</target>
-      </trans-unit>
-      <trans-unit id="form.label_category">
-        <source>form.label_category</source>
-        <target>form.label_category</target>
       </trans-unit>
       <trans-unit id="filter.label_provider_reference">
         <source>filter.label_provider_reference</source>
@@ -105,26 +97,6 @@
       <trans-unit id="filter.label_provider_name">
         <source>filter.label_provider_name</source>
         <target>Име на източника</target>
-      </trans-unit>
-      <trans-unit id="filter.label_category">
-        <source>filter.label_category</source>
-        <target>filter.label_category</target>
-      </trans-unit>
-      <trans-unit id="filter.label_author_name">
-        <source>filter.label_author_name</source>
-        <target>filter.label_author_name</target>
-      </trans-unit>
-      <trans-unit id="filter.label_width">
-        <source>filter.label_width</source>
-        <target>filter.label_width</target>
-      </trans-unit>
-      <trans-unit id="filter.label_height">
-        <source>filter.label_height</source>
-        <target>filter.label_height</target>
-      </trans-unit>
-      <trans-unit id="filter.label_content_type">
-        <source>filter.label_content_type</source>
-        <target>filter.label_content_type</target>
       </trans-unit>
       <trans-unit id="form.label_enabled">
         <source>form.label_enabled</source>
@@ -307,10 +279,6 @@
         <source>list.label_name</source>
         <target>Име</target>
       </trans-unit>
-      <trans-unit id="list.label_author_name">
-        <source>list.label_author_name</source>
-        <target>list.label_author_name</target>
-      </trans-unit>
       <trans-unit id="list.label_context">
         <source>list.label_context</source>
         <target>Контекст</target>
@@ -326,10 +294,6 @@
       <trans-unit id="list.label_custom">
         <source>list.label_custom</source>
         <target>Ръчно</target>
-      </trans-unit>
-      <trans-unit id="list.label_author">
-        <source>list.label_author</source>
-        <target>list.label_author</target>
       </trans-unit>
       <trans-unit id="sidemenu.link_edit_media">
         <source>sidemenu.link_edit_media</source>
@@ -403,26 +367,6 @@
         <source>no_linked_media</source>
         <target>Няма медиа към този обект</target>
       </trans-unit>
-      <trans-unit id="widget_label_type">
-        <source>widget_label_type</source>
-        <target>widget_label_type</target>
-      </trans-unit>
-      <trans-unit id="widget_label_context">
-        <source>widget_label_context</source>
-        <target>widget_label_context</target>
-      </trans-unit>
-      <trans-unit id="widget_headline_information">
-        <source>widget_headline_information</source>
-        <target>widget_headline_information</target>
-      </trans-unit>
-      <trans-unit id="widget_label_unlink">
-        <source>widget_label_unlink</source>
-        <target>widget_label_unlink</target>
-      </trans-unit>
-      <trans-unit id="widget_label_binary_content">
-        <source>widget_label_binary_content</source>
-        <target>widget_label_binary_content</target>
-      </trans-unit>
       <trans-unit id="sonata_media_gallery_index">
         <source>sonata_media_gallery_index</source>
         <target>Галерия</target>
@@ -434,126 +378,6 @@
       <trans-unit id="list.label_size">
         <source>list.label_size</source>
         <target>Размер</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.media">
-        <source>sonata.media.block.media</source>
-        <target>sonata.media.block.media</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.feature_media">
-        <source>sonata.media.block.feature_media</source>
-        <target>sonata.media.block.feature_media</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.gallery">
-        <source>sonata.media.block.gallery</source>
-        <target>sonata.media.block.gallery</target>
-      </trans-unit>
-      <trans-unit id="form.label_title">
-        <source>form.label_title</source>
-        <target>form.label_title</target>
-      </trans-unit>
-      <trans-unit id="form.label_content">
-        <source>form.label_content</source>
-        <target>form.label_content</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation">
-        <source>form.label_orientation</source>
-        <target>form.label_orientation</target>
-      </trans-unit>
-      <trans-unit id="form.label_gallery">
-        <source>form.label_gallery</source>
-        <target>form.label_gallery</target>
-      </trans-unit>
-      <trans-unit id="form.label_format">
-        <source>form.label_format</source>
-        <target>form.label_format</target>
-      </trans-unit>
-      <trans-unit id="form.label_pause_time">
-        <source>form.label_pause_time</source>
-        <target>form.label_pause_time</target>
-      </trans-unit>
-      <trans-unit id="form.label_start_paused">
-        <source>form.label_start_paused</source>
-        <target>form.label_start_paused</target>
-      </trans-unit>
-      <trans-unit id="form.label_wrap">
-        <source>form.label_wrap</source>
-        <target>form.label_wrap</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation_left">
-        <source>form.label_orientation_left</source>
-        <target>form.label_orientation_left</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation_right">
-        <source>form.label_orientation_right</source>
-        <target>form.label_orientation_right</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.gallery_list">
-        <source>sonata.media.block.gallery_list</source>
-        <target>sonata.media.block.gallery_list</target>
-      </trans-unit>
-      <trans-unit id="label_gallery_enabled">
-        <source>label_gallery_enabled</source>
-        <target>label_gallery_enabled</target>
-      </trans-unit>
-      <trans-unit id="label_gallery_disabled">
-        <source>label_gallery_disabled</source>
-        <target>label_gallery_disabled</target>
-      </trans-unit>
-      <trans-unit id="no_galleries_found">
-        <source>no_galleries_found</source>
-        <target>no_galleries_found</target>
-      </trans-unit>
-      <trans-unit id="view_all_galleries">
-        <source>view_all_galleries</source>
-        <target>view_all_galleries</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode">
-        <source>form.label_mode</source>
-        <target>form.label_mode</target>
-      </trans-unit>
-      <trans-unit id="form.label_number">
-        <source>form.label_number</source>
-        <target>form.label_number</target>
-      </trans-unit>
-      <trans-unit id="form.label_order">
-        <source>form.label_order</source>
-        <target>form.label_order</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_name">
-        <source>form.label_order_name</source>
-        <target>form.label_order_name</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_created_at">
-        <source>form.label_order_created_at</source>
-        <target>form.label_order_created_at</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_updated_at">
-        <source>form.label_order_updated_at</source>
-        <target>form.label_order_updated_at</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort">
-        <source>form.label_sort</source>
-        <target>form.label_sort</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort_asc">
-        <source>form.label_sort_asc</source>
-        <target>form.label_sort_asc</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort_desc">
-        <source>form.label_sort_desc</source>
-        <target>form.label_sort_desc</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode_public">
-        <source>form.label_mode_public</source>
-        <target>form.label_mode_public</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode_admin">
-        <source>form.label_mode_admin</source>
-        <target>form.label_mode_admin</target>
-      </trans-unit>
-      <trans-unit id="form.label_class">
-        <source>form.label_class</source>
-        <target>form.label_class</target>
       </trans-unit>
     </body>
   </file>

--- a/src/Resources/translations/SonataMediaBundle.ca.xliff
+++ b/src/Resources/translations/SonataMediaBundle.ca.xliff
@@ -102,10 +102,6 @@
         <source>filter.label_provider_name</source>
         <target>Nom proveïdor</target>
       </trans-unit>
-      <trans-unit id="filter.label_category">
-        <source>filter.label_category</source>
-        <target>filter.label_category</target>
-      </trans-unit>
       <trans-unit id="filter.label_author_name">
         <source>filter.label_author_name</source>
         <target>Nom autor</target>
@@ -322,10 +318,6 @@
       <trans-unit id="list.label_custom">
         <source>list.label_custom</source>
         <target>Personalitzar</target>
-      </trans-unit>
-      <trans-unit id="list.label_author">
-        <source>list.label_author</source>
-        <target>list.label_author</target>
       </trans-unit>
       <trans-unit id="sidemenu.link_edit_media">
         <source>sidemenu.link_edit_media</source>

--- a/src/Resources/translations/SonataMediaBundle.cs.xliff
+++ b/src/Resources/translations/SonataMediaBundle.cs.xliff
@@ -323,10 +323,6 @@
         <source>list.label_custom</source>
         <target>Custom</target>
       </trans-unit>
-      <trans-unit id="list.label_author">
-        <source>list.label_author</source>
-        <target>list.label_author</target>
-      </trans-unit>
       <trans-unit id="sidemenu.link_edit_media">
         <source>sidemenu.link_edit_media</source>
         <target>Upravit</target>

--- a/src/Resources/translations/SonataMediaBundle.de.xliff
+++ b/src/Resources/translations/SonataMediaBundle.de.xliff
@@ -90,10 +90,6 @@
         <source>description.forbidden_download_strategy</source>
         <target>Das Medium kann durch niemanden aufgerufen werden.</target>
       </trans-unit>
-      <trans-unit id="description.session_download_strategy">
-        <source>description.session_download_strategy</source>
-        <target>description.session_download_strategy</target>
-      </trans-unit>
       <trans-unit id="filter.label_name">
         <source>filter.label_name</source>
         <target>Name</target>

--- a/src/Resources/translations/SonataMediaBundle.en.xliff
+++ b/src/Resources/translations/SonataMediaBundle.en.xliff
@@ -104,7 +104,7 @@
       </trans-unit>
       <trans-unit id="filter.label_category">
         <source>filter.label_category</source>
-        <target>filter.label_category</target>
+        <target>Category</target>
       </trans-unit>
       <trans-unit id="filter.label_author_name">
         <source>filter.label_author_name</source>
@@ -325,7 +325,7 @@
       </trans-unit>
       <trans-unit id="list.label_author">
         <source>list.label_author</source>
-        <target>list.label_author</target>
+        <target>Author</target>
       </trans-unit>
       <trans-unit id="sidemenu.link_edit_media">
         <source>sidemenu.link_edit_media</source>

--- a/src/Resources/translations/SonataMediaBundle.es.xliff
+++ b/src/Resources/translations/SonataMediaBundle.es.xliff
@@ -78,10 +78,6 @@
         <source>description.forbidden_download_strategy</source>
         <target>El archivo de multimedia no se puede descargar.</target>
       </trans-unit>
-      <trans-unit id="description.session_download_strategy">
-        <source>description.session_download_strategy</source>
-        <target>description.session_download_strategy</target>
-      </trans-unit>
       <trans-unit id="filter.label_name">
         <source>filter.label_name</source>
         <target>Nombre</target>
@@ -327,10 +323,6 @@
         <source>list.label_custom</source>
         <target>Personalizado</target>
       </trans-unit>
-      <trans-unit id="list.label_author">
-        <source>list.label_author</source>
-        <target>list.label_author</target>
-      </trans-unit>
       <trans-unit id="sidemenu.link_edit_media">
         <source>sidemenu.link_edit_media</source>
         <target>Editar</target>
@@ -414,126 +406,6 @@
       <trans-unit id="list.label_size">
         <source>list.label_size</source>
         <target>Tamaño</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.media">
-        <source>sonata.media.block.media</source>
-        <target>sonata.media.block.media</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.feature_media">
-        <source>sonata.media.block.feature_media</source>
-        <target>sonata.media.block.feature_media</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.gallery">
-        <source>sonata.media.block.gallery</source>
-        <target>sonata.media.block.gallery</target>
-      </trans-unit>
-      <trans-unit id="form.label_title">
-        <source>form.label_title</source>
-        <target>form.label_title</target>
-      </trans-unit>
-      <trans-unit id="form.label_content">
-        <source>form.label_content</source>
-        <target>form.label_content</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation">
-        <source>form.label_orientation</source>
-        <target>form.label_orientation</target>
-      </trans-unit>
-      <trans-unit id="form.label_gallery">
-        <source>form.label_gallery</source>
-        <target>form.label_gallery</target>
-      </trans-unit>
-      <trans-unit id="form.label_format">
-        <source>form.label_format</source>
-        <target>form.label_format</target>
-      </trans-unit>
-      <trans-unit id="form.label_pause_time">
-        <source>form.label_pause_time</source>
-        <target>form.label_pause_time</target>
-      </trans-unit>
-      <trans-unit id="form.label_start_paused">
-        <source>form.label_start_paused</source>
-        <target>form.label_start_paused</target>
-      </trans-unit>
-      <trans-unit id="form.label_wrap">
-        <source>form.label_wrap</source>
-        <target>form.label_wrap</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation_left">
-        <source>form.label_orientation_left</source>
-        <target>form.label_orientation_left</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation_right">
-        <source>form.label_orientation_right</source>
-        <target>form.label_orientation_right</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.gallery_list">
-        <source>sonata.media.block.gallery_list</source>
-        <target>sonata.media.block.gallery_list</target>
-      </trans-unit>
-      <trans-unit id="label_gallery_enabled">
-        <source>label_gallery_enabled</source>
-        <target>label_gallery_enabled</target>
-      </trans-unit>
-      <trans-unit id="label_gallery_disabled">
-        <source>label_gallery_disabled</source>
-        <target>label_gallery_disabled</target>
-      </trans-unit>
-      <trans-unit id="no_galleries_found">
-        <source>no_galleries_found</source>
-        <target>no_galleries_found</target>
-      </trans-unit>
-      <trans-unit id="view_all_galleries">
-        <source>view_all_galleries</source>
-        <target>view_all_galleries</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode">
-        <source>form.label_mode</source>
-        <target>form.label_mode</target>
-      </trans-unit>
-      <trans-unit id="form.label_number">
-        <source>form.label_number</source>
-        <target>form.label_number</target>
-      </trans-unit>
-      <trans-unit id="form.label_order">
-        <source>form.label_order</source>
-        <target>form.label_order</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_name">
-        <source>form.label_order_name</source>
-        <target>form.label_order_name</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_created_at">
-        <source>form.label_order_created_at</source>
-        <target>form.label_order_created_at</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_updated_at">
-        <source>form.label_order_updated_at</source>
-        <target>form.label_order_updated_at</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort">
-        <source>form.label_sort</source>
-        <target>form.label_sort</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort_asc">
-        <source>form.label_sort_asc</source>
-        <target>form.label_sort_asc</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort_desc">
-        <source>form.label_sort_desc</source>
-        <target>form.label_sort_desc</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode_public">
-        <source>form.label_mode_public</source>
-        <target>form.label_mode_public</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode_admin">
-        <source>form.label_mode_admin</source>
-        <target>form.label_mode_admin</target>
-      </trans-unit>
-      <trans-unit id="form.label_class">
-        <source>form.label_class</source>
-        <target>form.label_class</target>
       </trans-unit>
     </body>
   </file>

--- a/src/Resources/translations/SonataMediaBundle.fa.xliff
+++ b/src/Resources/translations/SonataMediaBundle.fa.xliff
@@ -78,10 +78,6 @@
         <source>description.forbidden_download_strategy</source>
         <target>رسانه برای هیچ کس در دسترس نیست</target>
       </trans-unit>
-      <trans-unit id="description.session_download_strategy">
-        <source>description.session_download_strategy</source>
-        <target>description.session_download_strategy</target>
-      </trans-unit>
       <trans-unit id="filter.label_name">
         <source>filter.label_name</source>
         <target>نام</target>
@@ -395,26 +391,6 @@
         <source>no_linked_media</source>
         <target>رسانه ای به شی مربوط نشده</target>
       </trans-unit>
-      <trans-unit id="widget_label_type">
-        <source>widget_label_type</source>
-        <target>widget_label_type</target>
-      </trans-unit>
-      <trans-unit id="widget_label_context">
-        <source>widget_label_context</source>
-        <target>widget_label_context</target>
-      </trans-unit>
-      <trans-unit id="widget_headline_information">
-        <source>widget_headline_information</source>
-        <target>widget_headline_information</target>
-      </trans-unit>
-      <trans-unit id="widget_label_unlink">
-        <source>widget_label_unlink</source>
-        <target>widget_label_unlink</target>
-      </trans-unit>
-      <trans-unit id="widget_label_binary_content">
-        <source>widget_label_binary_content</source>
-        <target>widget_label_binary_content</target>
-      </trans-unit>
       <trans-unit id="sonata_media_gallery_index">
         <source>sonata_media_gallery_index</source>
         <target>گالری</target>
@@ -438,126 +414,6 @@
       <trans-unit id="form.label_provider_reference">
         <source>form.label_provider_reference</source>
         <target>منبع پروایدر</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.media">
-        <source>sonata.media.block.media</source>
-        <target>sonata.media.block.media</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.feature_media">
-        <source>sonata.media.block.feature_media</source>
-        <target>sonata.media.block.feature_media</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.gallery">
-        <source>sonata.media.block.gallery</source>
-        <target>sonata.media.block.gallery</target>
-      </trans-unit>
-      <trans-unit id="form.label_title">
-        <source>form.label_title</source>
-        <target>form.label_title</target>
-      </trans-unit>
-      <trans-unit id="form.label_content">
-        <source>form.label_content</source>
-        <target>form.label_content</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation">
-        <source>form.label_orientation</source>
-        <target>form.label_orientation</target>
-      </trans-unit>
-      <trans-unit id="form.label_gallery">
-        <source>form.label_gallery</source>
-        <target>form.label_gallery</target>
-      </trans-unit>
-      <trans-unit id="form.label_format">
-        <source>form.label_format</source>
-        <target>form.label_format</target>
-      </trans-unit>
-      <trans-unit id="form.label_pause_time">
-        <source>form.label_pause_time</source>
-        <target>form.label_pause_time</target>
-      </trans-unit>
-      <trans-unit id="form.label_start_paused">
-        <source>form.label_start_paused</source>
-        <target>form.label_start_paused</target>
-      </trans-unit>
-      <trans-unit id="form.label_wrap">
-        <source>form.label_wrap</source>
-        <target>form.label_wrap</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation_left">
-        <source>form.label_orientation_left</source>
-        <target>form.label_orientation_left</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation_right">
-        <source>form.label_orientation_right</source>
-        <target>form.label_orientation_right</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.gallery_list">
-        <source>sonata.media.block.gallery_list</source>
-        <target>sonata.media.block.gallery_list</target>
-      </trans-unit>
-      <trans-unit id="label_gallery_enabled">
-        <source>label_gallery_enabled</source>
-        <target>label_gallery_enabled</target>
-      </trans-unit>
-      <trans-unit id="label_gallery_disabled">
-        <source>label_gallery_disabled</source>
-        <target>label_gallery_disabled</target>
-      </trans-unit>
-      <trans-unit id="no_galleries_found">
-        <source>no_galleries_found</source>
-        <target>no_galleries_found</target>
-      </trans-unit>
-      <trans-unit id="view_all_galleries">
-        <source>view_all_galleries</source>
-        <target>view_all_galleries</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode">
-        <source>form.label_mode</source>
-        <target>form.label_mode</target>
-      </trans-unit>
-      <trans-unit id="form.label_number">
-        <source>form.label_number</source>
-        <target>form.label_number</target>
-      </trans-unit>
-      <trans-unit id="form.label_order">
-        <source>form.label_order</source>
-        <target>form.label_order</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_name">
-        <source>form.label_order_name</source>
-        <target>form.label_order_name</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_created_at">
-        <source>form.label_order_created_at</source>
-        <target>form.label_order_created_at</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_updated_at">
-        <source>form.label_order_updated_at</source>
-        <target>form.label_order_updated_at</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort">
-        <source>form.label_sort</source>
-        <target>form.label_sort</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort_asc">
-        <source>form.label_sort_asc</source>
-        <target>form.label_sort_asc</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort_desc">
-        <source>form.label_sort_desc</source>
-        <target>form.label_sort_desc</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode_public">
-        <source>form.label_mode_public</source>
-        <target>form.label_mode_public</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode_admin">
-        <source>form.label_mode_admin</source>
-        <target>form.label_mode_admin</target>
-      </trans-unit>
-      <trans-unit id="form.label_class">
-        <source>form.label_class</source>
-        <target>form.label_class</target>
       </trans-unit>
     </body>
   </file>

--- a/src/Resources/translations/SonataMediaBundle.fi.xliff
+++ b/src/Resources/translations/SonataMediaBundle.fi.xliff
@@ -78,10 +78,6 @@
         <source>description.forbidden_download_strategy</source>
         <target>Media ei ole kenenkään käytettävissä.</target>
       </trans-unit>
-      <trans-unit id="description.session_download_strategy">
-        <source>description.session_download_strategy</source>
-        <target>description.session_download_strategy</target>
-      </trans-unit>
       <trans-unit id="filter.label_name">
         <source>filter.label_name</source>
         <target>Nimi</target>
@@ -101,26 +97,6 @@
       <trans-unit id="filter.label_provider_name">
         <source>filter.label_provider_name</source>
         <target>Mediatoimittajan nimi</target>
-      </trans-unit>
-      <trans-unit id="filter.label_category">
-        <source>filter.label_category</source>
-        <target>filter.label_category</target>
-      </trans-unit>
-      <trans-unit id="filter.label_author_name">
-        <source>filter.label_author_name</source>
-        <target>filter.label_author_name</target>
-      </trans-unit>
-      <trans-unit id="filter.label_width">
-        <source>filter.label_width</source>
-        <target>filter.label_width</target>
-      </trans-unit>
-      <trans-unit id="filter.label_height">
-        <source>filter.label_height</source>
-        <target>filter.label_height</target>
-      </trans-unit>
-      <trans-unit id="filter.label_content_type">
-        <source>filter.label_content_type</source>
-        <target>filter.label_content_type</target>
       </trans-unit>
       <trans-unit id="form.label_enabled">
         <source>form.label_enabled</source>
@@ -303,10 +279,6 @@
         <source>list.label_name</source>
         <target>Nimi</target>
       </trans-unit>
-      <trans-unit id="list.label_author_name">
-        <source>list.label_author_name</source>
-        <target>list.label_author_name</target>
-      </trans-unit>
       <trans-unit id="list.label_context">
         <source>list.label_context</source>
         <target>Konteksti</target>
@@ -322,10 +294,6 @@
       <trans-unit id="list.label_custom">
         <source>list.label_custom</source>
         <target>Mukautettu</target>
-      </trans-unit>
-      <trans-unit id="list.label_author">
-        <source>list.label_author</source>
-        <target>list.label_author</target>
       </trans-unit>
       <trans-unit id="sidemenu.link_edit_media">
         <source>sidemenu.link_edit_media</source>
@@ -399,26 +367,6 @@
         <source>no_linked_media</source>
         <target>Objektiin ei ole linkitetty mitään mediaa</target>
       </trans-unit>
-      <trans-unit id="widget_label_type">
-        <source>widget_label_type</source>
-        <target>widget_label_type</target>
-      </trans-unit>
-      <trans-unit id="widget_label_context">
-        <source>widget_label_context</source>
-        <target>widget_label_context</target>
-      </trans-unit>
-      <trans-unit id="widget_headline_information">
-        <source>widget_headline_information</source>
-        <target>widget_headline_information</target>
-      </trans-unit>
-      <trans-unit id="widget_label_unlink">
-        <source>widget_label_unlink</source>
-        <target>widget_label_unlink</target>
-      </trans-unit>
-      <trans-unit id="widget_label_binary_content">
-        <source>widget_label_binary_content</source>
-        <target>widget_label_binary_content</target>
-      </trans-unit>
       <trans-unit id="sonata_media_gallery_index">
         <source>sonata_media_gallery_index</source>
         <target>Galleria</target>
@@ -442,126 +390,6 @@
       <trans-unit id="form.label_provider_reference">
         <source>form.label_provider_reference</source>
         <target>Viittaus mediatoimittajaan</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.media">
-        <source>sonata.media.block.media</source>
-        <target>sonata.media.block.media</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.feature_media">
-        <source>sonata.media.block.feature_media</source>
-        <target>sonata.media.block.feature_media</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.gallery">
-        <source>sonata.media.block.gallery</source>
-        <target>sonata.media.block.gallery</target>
-      </trans-unit>
-      <trans-unit id="form.label_title">
-        <source>form.label_title</source>
-        <target>form.label_title</target>
-      </trans-unit>
-      <trans-unit id="form.label_content">
-        <source>form.label_content</source>
-        <target>form.label_content</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation">
-        <source>form.label_orientation</source>
-        <target>form.label_orientation</target>
-      </trans-unit>
-      <trans-unit id="form.label_gallery">
-        <source>form.label_gallery</source>
-        <target>form.label_gallery</target>
-      </trans-unit>
-      <trans-unit id="form.label_format">
-        <source>form.label_format</source>
-        <target>form.label_format</target>
-      </trans-unit>
-      <trans-unit id="form.label_pause_time">
-        <source>form.label_pause_time</source>
-        <target>form.label_pause_time</target>
-      </trans-unit>
-      <trans-unit id="form.label_start_paused">
-        <source>form.label_start_paused</source>
-        <target>form.label_start_paused</target>
-      </trans-unit>
-      <trans-unit id="form.label_wrap">
-        <source>form.label_wrap</source>
-        <target>form.label_wrap</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation_left">
-        <source>form.label_orientation_left</source>
-        <target>form.label_orientation_left</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation_right">
-        <source>form.label_orientation_right</source>
-        <target>form.label_orientation_right</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.gallery_list">
-        <source>sonata.media.block.gallery_list</source>
-        <target>sonata.media.block.gallery_list</target>
-      </trans-unit>
-      <trans-unit id="label_gallery_enabled">
-        <source>label_gallery_enabled</source>
-        <target>label_gallery_enabled</target>
-      </trans-unit>
-      <trans-unit id="label_gallery_disabled">
-        <source>label_gallery_disabled</source>
-        <target>label_gallery_disabled</target>
-      </trans-unit>
-      <trans-unit id="no_galleries_found">
-        <source>no_galleries_found</source>
-        <target>no_galleries_found</target>
-      </trans-unit>
-      <trans-unit id="view_all_galleries">
-        <source>view_all_galleries</source>
-        <target>view_all_galleries</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode">
-        <source>form.label_mode</source>
-        <target>form.label_mode</target>
-      </trans-unit>
-      <trans-unit id="form.label_number">
-        <source>form.label_number</source>
-        <target>form.label_number</target>
-      </trans-unit>
-      <trans-unit id="form.label_order">
-        <source>form.label_order</source>
-        <target>form.label_order</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_name">
-        <source>form.label_order_name</source>
-        <target>form.label_order_name</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_created_at">
-        <source>form.label_order_created_at</source>
-        <target>form.label_order_created_at</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_updated_at">
-        <source>form.label_order_updated_at</source>
-        <target>form.label_order_updated_at</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort">
-        <source>form.label_sort</source>
-        <target>form.label_sort</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort_asc">
-        <source>form.label_sort_asc</source>
-        <target>form.label_sort_asc</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort_desc">
-        <source>form.label_sort_desc</source>
-        <target>form.label_sort_desc</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode_public">
-        <source>form.label_mode_public</source>
-        <target>form.label_mode_public</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode_admin">
-        <source>form.label_mode_admin</source>
-        <target>form.label_mode_admin</target>
-      </trans-unit>
-      <trans-unit id="form.label_class">
-        <source>form.label_class</source>
-        <target>form.label_class</target>
       </trans-unit>
     </body>
   </file>

--- a/src/Resources/translations/SonataMediaBundle.fr.xliff
+++ b/src/Resources/translations/SonataMediaBundle.fr.xliff
@@ -78,10 +78,6 @@
         <source>description.forbidden_download_strategy</source>
         <target>Le média peut être récupéré par personne.</target>
       </trans-unit>
-      <trans-unit id="description.session_download_strategy">
-        <source>description.session_download_strategy</source>
-        <target>description.session_download_strategy</target>
-      </trans-unit>
       <trans-unit id="filter.label_name">
         <source>filter.label_name</source>
         <target>Nom</target>

--- a/src/Resources/translations/SonataMediaBundle.hu.xliff
+++ b/src/Resources/translations/SonataMediaBundle.hu.xliff
@@ -78,10 +78,6 @@
         <source>description.forbidden_download_strategy</source>
         <target>A tartalmat senki sem tekintheti meg.</target>
       </trans-unit>
-      <trans-unit id="description.session_download_strategy">
-        <source>description.session_download_strategy</source>
-        <target>description.session_download_strategy</target>
-      </trans-unit>
       <trans-unit id="filter.label_name">
         <source>filter.label_name</source>
         <target>Név</target>
@@ -454,114 +450,6 @@
       <trans-unit id="sonata.media.block.gallery">
         <source>sonata.media.block.gallery</source>
         <target>Galéria</target>
-      </trans-unit>
-      <trans-unit id="form.label_title">
-        <source>form.label_title</source>
-        <target>form.label_title</target>
-      </trans-unit>
-      <trans-unit id="form.label_content">
-        <source>form.label_content</source>
-        <target>form.label_content</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation">
-        <source>form.label_orientation</source>
-        <target>form.label_orientation</target>
-      </trans-unit>
-      <trans-unit id="form.label_gallery">
-        <source>form.label_gallery</source>
-        <target>form.label_gallery</target>
-      </trans-unit>
-      <trans-unit id="form.label_format">
-        <source>form.label_format</source>
-        <target>form.label_format</target>
-      </trans-unit>
-      <trans-unit id="form.label_pause_time">
-        <source>form.label_pause_time</source>
-        <target>form.label_pause_time</target>
-      </trans-unit>
-      <trans-unit id="form.label_start_paused">
-        <source>form.label_start_paused</source>
-        <target>form.label_start_paused</target>
-      </trans-unit>
-      <trans-unit id="form.label_wrap">
-        <source>form.label_wrap</source>
-        <target>form.label_wrap</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation_left">
-        <source>form.label_orientation_left</source>
-        <target>form.label_orientation_left</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation_right">
-        <source>form.label_orientation_right</source>
-        <target>form.label_orientation_right</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.gallery_list">
-        <source>sonata.media.block.gallery_list</source>
-        <target>sonata.media.block.gallery_list</target>
-      </trans-unit>
-      <trans-unit id="label_gallery_enabled">
-        <source>label_gallery_enabled</source>
-        <target>label_gallery_enabled</target>
-      </trans-unit>
-      <trans-unit id="label_gallery_disabled">
-        <source>label_gallery_disabled</source>
-        <target>label_gallery_disabled</target>
-      </trans-unit>
-      <trans-unit id="no_galleries_found">
-        <source>no_galleries_found</source>
-        <target>no_galleries_found</target>
-      </trans-unit>
-      <trans-unit id="view_all_galleries">
-        <source>view_all_galleries</source>
-        <target>view_all_galleries</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode">
-        <source>form.label_mode</source>
-        <target>form.label_mode</target>
-      </trans-unit>
-      <trans-unit id="form.label_number">
-        <source>form.label_number</source>
-        <target>form.label_number</target>
-      </trans-unit>
-      <trans-unit id="form.label_order">
-        <source>form.label_order</source>
-        <target>form.label_order</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_name">
-        <source>form.label_order_name</source>
-        <target>form.label_order_name</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_created_at">
-        <source>form.label_order_created_at</source>
-        <target>form.label_order_created_at</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_updated_at">
-        <source>form.label_order_updated_at</source>
-        <target>form.label_order_updated_at</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort">
-        <source>form.label_sort</source>
-        <target>form.label_sort</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort_asc">
-        <source>form.label_sort_asc</source>
-        <target>form.label_sort_asc</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort_desc">
-        <source>form.label_sort_desc</source>
-        <target>form.label_sort_desc</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode_public">
-        <source>form.label_mode_public</source>
-        <target>form.label_mode_public</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode_admin">
-        <source>form.label_mode_admin</source>
-        <target>form.label_mode_admin</target>
-      </trans-unit>
-      <trans-unit id="form.label_class">
-        <source>form.label_class</source>
-        <target>form.label_class</target>
       </trans-unit>
     </body>
   </file>

--- a/src/Resources/translations/SonataMediaBundle.ja.xliff
+++ b/src/Resources/translations/SonataMediaBundle.ja.xliff
@@ -78,10 +78,6 @@
         <source>description.forbidden_download_strategy</source>
         <target>このメディアは誰でも取得することができません。</target>
       </trans-unit>
-      <trans-unit id="description.session_download_strategy">
-        <source>description.session_download_strategy</source>
-        <target>description.session_download_strategy</target>
-      </trans-unit>
       <trans-unit id="filter.label_name">
         <source>filter.label_name</source>
         <target>名前</target>
@@ -367,26 +363,6 @@
         <source>no_linked_media</source>
         <target>オブジェクトにリンクしているメディアがありません</target>
       </trans-unit>
-      <trans-unit id="widget_label_type">
-        <source>widget_label_type</source>
-        <target>widget_label_type</target>
-      </trans-unit>
-      <trans-unit id="widget_label_context">
-        <source>widget_label_context</source>
-        <target>widget_label_context</target>
-      </trans-unit>
-      <trans-unit id="widget_headline_information">
-        <source>widget_headline_information</source>
-        <target>widget_headline_information</target>
-      </trans-unit>
-      <trans-unit id="widget_label_unlink">
-        <source>widget_label_unlink</source>
-        <target>widget_label_unlink</target>
-      </trans-unit>
-      <trans-unit id="widget_label_binary_content">
-        <source>widget_label_binary_content</source>
-        <target>widget_label_binary_content</target>
-      </trans-unit>
       <trans-unit id="sonata_media_gallery_index">
         <source>sonata_media_gallery_index</source>
         <target>ギャラリー</target>
@@ -410,126 +386,6 @@
       <trans-unit id="form.label_provider_reference">
         <source>form.label_provider_reference</source>
         <target>Provider Reference</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.media">
-        <source>sonata.media.block.media</source>
-        <target>sonata.media.block.media</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.feature_media">
-        <source>sonata.media.block.feature_media</source>
-        <target>sonata.media.block.feature_media</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.gallery">
-        <source>sonata.media.block.gallery</source>
-        <target>sonata.media.block.gallery</target>
-      </trans-unit>
-      <trans-unit id="form.label_title">
-        <source>form.label_title</source>
-        <target>form.label_title</target>
-      </trans-unit>
-      <trans-unit id="form.label_content">
-        <source>form.label_content</source>
-        <target>form.label_content</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation">
-        <source>form.label_orientation</source>
-        <target>form.label_orientation</target>
-      </trans-unit>
-      <trans-unit id="form.label_gallery">
-        <source>form.label_gallery</source>
-        <target>form.label_gallery</target>
-      </trans-unit>
-      <trans-unit id="form.label_format">
-        <source>form.label_format</source>
-        <target>form.label_format</target>
-      </trans-unit>
-      <trans-unit id="form.label_pause_time">
-        <source>form.label_pause_time</source>
-        <target>form.label_pause_time</target>
-      </trans-unit>
-      <trans-unit id="form.label_start_paused">
-        <source>form.label_start_paused</source>
-        <target>form.label_start_paused</target>
-      </trans-unit>
-      <trans-unit id="form.label_wrap">
-        <source>form.label_wrap</source>
-        <target>form.label_wrap</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation_left">
-        <source>form.label_orientation_left</source>
-        <target>form.label_orientation_left</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation_right">
-        <source>form.label_orientation_right</source>
-        <target>form.label_orientation_right</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.gallery_list">
-        <source>sonata.media.block.gallery_list</source>
-        <target>sonata.media.block.gallery_list</target>
-      </trans-unit>
-      <trans-unit id="label_gallery_enabled">
-        <source>label_gallery_enabled</source>
-        <target>label_gallery_enabled</target>
-      </trans-unit>
-      <trans-unit id="label_gallery_disabled">
-        <source>label_gallery_disabled</source>
-        <target>label_gallery_disabled</target>
-      </trans-unit>
-      <trans-unit id="no_galleries_found">
-        <source>no_galleries_found</source>
-        <target>no_galleries_found</target>
-      </trans-unit>
-      <trans-unit id="view_all_galleries">
-        <source>view_all_galleries</source>
-        <target>view_all_galleries</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode">
-        <source>form.label_mode</source>
-        <target>form.label_mode</target>
-      </trans-unit>
-      <trans-unit id="form.label_number">
-        <source>form.label_number</source>
-        <target>form.label_number</target>
-      </trans-unit>
-      <trans-unit id="form.label_order">
-        <source>form.label_order</source>
-        <target>form.label_order</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_name">
-        <source>form.label_order_name</source>
-        <target>form.label_order_name</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_created_at">
-        <source>form.label_order_created_at</source>
-        <target>form.label_order_created_at</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_updated_at">
-        <source>form.label_order_updated_at</source>
-        <target>form.label_order_updated_at</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort">
-        <source>form.label_sort</source>
-        <target>form.label_sort</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort_asc">
-        <source>form.label_sort_asc</source>
-        <target>form.label_sort_asc</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort_desc">
-        <source>form.label_sort_desc</source>
-        <target>form.label_sort_desc</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode_public">
-        <source>form.label_mode_public</source>
-        <target>form.label_mode_public</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode_admin">
-        <source>form.label_mode_admin</source>
-        <target>form.label_mode_admin</target>
-      </trans-unit>
-      <trans-unit id="form.label_class">
-        <source>form.label_class</source>
-        <target>form.label_class</target>
       </trans-unit>
     </body>
   </file>

--- a/src/Resources/translations/SonataMediaBundle.lt.xliff
+++ b/src/Resources/translations/SonataMediaBundle.lt.xliff
@@ -50,10 +50,6 @@
         <source>breadcrumb.link_gallery_create</source>
         <target>Sukurti</target>
       </trans-unit>
-      <trans-unit id="breadcrumb.link_media_show">
-        <source>breadcrumb.link_media_show</source>
-        <target>breadcrumb.link_media_show</target>
-      </trans-unit>
       <trans-unit id="breadcrumb.link_gallery_list">
         <source>breadcrumb.link_gallery_list</source>
         <target>Galerijos</target>
@@ -78,17 +74,9 @@
         <source>description.forbidden_download_strategy</source>
         <target>Niekas negali pasiekti Media.</target>
       </trans-unit>
-      <trans-unit id="description.session_download_strategy">
-        <source>description.session_download_strategy</source>
-        <target>description.session_download_strategy</target>
-      </trans-unit>
       <trans-unit id="filter.label_name">
         <source>filter.label_name</source>
         <target>Pavadinimas</target>
-      </trans-unit>
-      <trans-unit id="form.label_category">
-        <source>form.label_category</source>
-        <target>form.label_category</target>
       </trans-unit>
       <trans-unit id="filter.label_provider_reference">
         <source>filter.label_provider_reference</source>
@@ -105,26 +93,6 @@
       <trans-unit id="filter.label_provider_name">
         <source>filter.label_provider_name</source>
         <target>Tiekėjo pavadinimas</target>
-      </trans-unit>
-      <trans-unit id="filter.label_category">
-        <source>filter.label_category</source>
-        <target>filter.label_category</target>
-      </trans-unit>
-      <trans-unit id="filter.label_author_name">
-        <source>filter.label_author_name</source>
-        <target>filter.label_author_name</target>
-      </trans-unit>
-      <trans-unit id="filter.label_width">
-        <source>filter.label_width</source>
-        <target>filter.label_width</target>
-      </trans-unit>
-      <trans-unit id="filter.label_height">
-        <source>filter.label_height</source>
-        <target>filter.label_height</target>
-      </trans-unit>
-      <trans-unit id="filter.label_content_type">
-        <source>filter.label_content_type</source>
-        <target>filter.label_content_type</target>
       </trans-unit>
       <trans-unit id="form.label_enabled">
         <source>form.label_enabled</source>
@@ -177,10 +145,6 @@
       <trans-unit id="label.size">
         <source>label.size</source>
         <target>Dydis</target>
-      </trans-unit>
-      <trans-unit id="label.length">
-        <source>label.length</source>
-        <target>label.length</target>
       </trans-unit>
       <trans-unit id="label.width">
         <source>label.width</source>
@@ -307,10 +271,6 @@
         <source>list.label_name</source>
         <target>Pavadinimas</target>
       </trans-unit>
-      <trans-unit id="list.label_author_name">
-        <source>list.label_author_name</source>
-        <target>list.label_author_name</target>
-      </trans-unit>
       <trans-unit id="list.label_context">
         <source>list.label_context</source>
         <target>Kontekstas</target>
@@ -326,10 +286,6 @@
       <trans-unit id="list.label_custom">
         <source>list.label_custom</source>
         <target>Individualizuota</target>
-      </trans-unit>
-      <trans-unit id="list.label_author">
-        <source>list.label_author</source>
-        <target>list.label_author</target>
       </trans-unit>
       <trans-unit id="sidemenu.link_edit_media">
         <source>sidemenu.link_edit_media</source>
@@ -374,166 +330,6 @@
       <trans-unit id="title.formats">
         <source>title.formats</source>
         <target>Formatai</target>
-      </trans-unit>
-      <trans-unit id="link_media">
-        <source>link_media</source>
-        <target>link_media</target>
-      </trans-unit>
-      <trans-unit id="no_linked_media">
-        <source>no_linked_media</source>
-        <target>no_linked_media</target>
-      </trans-unit>
-      <trans-unit id="widget_label_type">
-        <source>widget_label_type</source>
-        <target>widget_label_type</target>
-      </trans-unit>
-      <trans-unit id="widget_label_context">
-        <source>widget_label_context</source>
-        <target>widget_label_context</target>
-      </trans-unit>
-      <trans-unit id="widget_headline_information">
-        <source>widget_headline_information</source>
-        <target>widget_headline_information</target>
-      </trans-unit>
-      <trans-unit id="widget_label_unlink">
-        <source>widget_label_unlink</source>
-        <target>widget_label_unlink</target>
-      </trans-unit>
-      <trans-unit id="widget_label_binary_content">
-        <source>widget_label_binary_content</source>
-        <target>widget_label_binary_content</target>
-      </trans-unit>
-      <trans-unit id="sonata_media_gallery_index">
-        <source>sonata_media_gallery_index</source>
-        <target>sonata_media_gallery_index</target>
-      </trans-unit>
-      <trans-unit id="list.label_description">
-        <source>list.label_description</source>
-        <target>list.label_description</target>
-      </trans-unit>
-      <trans-unit id="list.label_size">
-        <source>list.label_size</source>
-        <target>list.label_size</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.media">
-        <source>sonata.media.block.media</source>
-        <target>sonata.media.block.media</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.feature_media">
-        <source>sonata.media.block.feature_media</source>
-        <target>sonata.media.block.feature_media</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.gallery">
-        <source>sonata.media.block.gallery</source>
-        <target>sonata.media.block.gallery</target>
-      </trans-unit>
-      <trans-unit id="form.label_title">
-        <source>form.label_title</source>
-        <target>form.label_title</target>
-      </trans-unit>
-      <trans-unit id="form.label_content">
-        <source>form.label_content</source>
-        <target>form.label_content</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation">
-        <source>form.label_orientation</source>
-        <target>form.label_orientation</target>
-      </trans-unit>
-      <trans-unit id="form.label_gallery">
-        <source>form.label_gallery</source>
-        <target>form.label_gallery</target>
-      </trans-unit>
-      <trans-unit id="form.label_format">
-        <source>form.label_format</source>
-        <target>form.label_format</target>
-      </trans-unit>
-      <trans-unit id="form.label_pause_time">
-        <source>form.label_pause_time</source>
-        <target>form.label_pause_time</target>
-      </trans-unit>
-      <trans-unit id="form.label_start_paused">
-        <source>form.label_start_paused</source>
-        <target>form.label_start_paused</target>
-      </trans-unit>
-      <trans-unit id="form.label_wrap">
-        <source>form.label_wrap</source>
-        <target>form.label_wrap</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation_left">
-        <source>form.label_orientation_left</source>
-        <target>form.label_orientation_left</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation_right">
-        <source>form.label_orientation_right</source>
-        <target>form.label_orientation_right</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.gallery_list">
-        <source>sonata.media.block.gallery_list</source>
-        <target>sonata.media.block.gallery_list</target>
-      </trans-unit>
-      <trans-unit id="label_gallery_enabled">
-        <source>label_gallery_enabled</source>
-        <target>label_gallery_enabled</target>
-      </trans-unit>
-      <trans-unit id="label_gallery_disabled">
-        <source>label_gallery_disabled</source>
-        <target>label_gallery_disabled</target>
-      </trans-unit>
-      <trans-unit id="no_galleries_found">
-        <source>no_galleries_found</source>
-        <target>no_galleries_found</target>
-      </trans-unit>
-      <trans-unit id="view_all_galleries">
-        <source>view_all_galleries</source>
-        <target>view_all_galleries</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode">
-        <source>form.label_mode</source>
-        <target>form.label_mode</target>
-      </trans-unit>
-      <trans-unit id="form.label_number">
-        <source>form.label_number</source>
-        <target>form.label_number</target>
-      </trans-unit>
-      <trans-unit id="form.label_order">
-        <source>form.label_order</source>
-        <target>form.label_order</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_name">
-        <source>form.label_order_name</source>
-        <target>form.label_order_name</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_created_at">
-        <source>form.label_order_created_at</source>
-        <target>form.label_order_created_at</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_updated_at">
-        <source>form.label_order_updated_at</source>
-        <target>form.label_order_updated_at</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort">
-        <source>form.label_sort</source>
-        <target>form.label_sort</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort_asc">
-        <source>form.label_sort_asc</source>
-        <target>form.label_sort_asc</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort_desc">
-        <source>form.label_sort_desc</source>
-        <target>form.label_sort_desc</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode_public">
-        <source>form.label_mode_public</source>
-        <target>form.label_mode_public</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode_admin">
-        <source>form.label_mode_admin</source>
-        <target>form.label_mode_admin</target>
-      </trans-unit>
-      <trans-unit id="form.label_class">
-        <source>form.label_class</source>
-        <target>form.label_class</target>
       </trans-unit>
     </body>
   </file>

--- a/src/Resources/translations/SonataMediaBundle.nl.xliff
+++ b/src/Resources/translations/SonataMediaBundle.nl.xliff
@@ -78,10 +78,6 @@
         <source>description.forbidden_download_strategy</source>
         <target>Dit media item kan door niemand bekeken worden.</target>
       </trans-unit>
-      <trans-unit id="description.session_download_strategy">
-        <source>description.session_download_strategy</source>
-        <target>description.session_download_strategy</target>
-      </trans-unit>
       <trans-unit id="filter.label_name">
         <source>filter.label_name</source>
         <target>Naam</target>
@@ -410,10 +406,6 @@
       <trans-unit id="widget_headline_information">
         <source>widget_headline_information</source>
         <target>Informatie</target>
-      </trans-unit>
-      <trans-unit id="widget_label_unlink">
-        <source>widget_label_unlink</source>
-        <target>widget_label_unlink</target>
       </trans-unit>
       <trans-unit id="widget_label_binary_content">
         <source>widget_label_binary_content</source>

--- a/src/Resources/translations/SonataMediaBundle.pl.xliff
+++ b/src/Resources/translations/SonataMediaBundle.pl.xliff
@@ -50,10 +50,6 @@
         <source>breadcrumb.link_gallery_create</source>
         <target>Utwórz</target>
       </trans-unit>
-      <trans-unit id="breadcrumb.link_media_show">
-        <source>breadcrumb.link_media_show</source>
-        <target>breadcrumb.link_media_show</target>
-      </trans-unit>
       <trans-unit id="breadcrumb.link_gallery_list">
         <source>breadcrumb.link_gallery_list</source>
         <target>Galerie</target>
@@ -78,17 +74,9 @@
         <source>description.forbidden_download_strategy</source>
         <target>Nikt nie może pobrać mediów.</target>
       </trans-unit>
-      <trans-unit id="description.session_download_strategy">
-        <source>description.session_download_strategy</source>
-        <target>description.session_download_strategy</target>
-      </trans-unit>
       <trans-unit id="filter.label_name">
         <source>filter.label_name</source>
         <target>Nazwa</target>
-      </trans-unit>
-      <trans-unit id="form.label_category">
-        <source>form.label_category</source>
-        <target>form.label_category</target>
       </trans-unit>
       <trans-unit id="filter.label_provider_reference">
         <source>filter.label_provider_reference</source>
@@ -106,37 +94,9 @@
         <source>filter.label_provider_name</source>
         <target>Nazwa dostawcy</target>
       </trans-unit>
-      <trans-unit id="filter.label_category">
-        <source>filter.label_category</source>
-        <target>filter.label_category</target>
-      </trans-unit>
-      <trans-unit id="filter.label_author_name">
-        <source>filter.label_author_name</source>
-        <target>filter.label_author_name</target>
-      </trans-unit>
-      <trans-unit id="filter.label_width">
-        <source>filter.label_width</source>
-        <target>filter.label_width</target>
-      </trans-unit>
-      <trans-unit id="filter.label_height">
-        <source>filter.label_height</source>
-        <target>filter.label_height</target>
-      </trans-unit>
-      <trans-unit id="filter.label_content_type">
-        <source>filter.label_content_type</source>
-        <target>filter.label_content_type</target>
-      </trans-unit>
       <trans-unit id="form.label_enabled">
         <source>form.label_enabled</source>
         <target>Włączony</target>
-      </trans-unit>
-      <trans-unit id="form.label_media">
-        <source>form.label_media</source>
-        <target>form.label_media</target>
-      </trans-unit>
-      <trans-unit id="form.label_position">
-        <source>form.label_position</source>
-        <target>form.label_position</target>
       </trans-unit>
       <trans-unit id="form.label_context">
         <source>form.label_context</source>
@@ -177,10 +137,6 @@
       <trans-unit id="label.size">
         <source>label.size</source>
         <target>Rozmiar</target>
-      </trans-unit>
-      <trans-unit id="label.length">
-        <source>label.length</source>
-        <target>label.length</target>
       </trans-unit>
       <trans-unit id="label.width">
         <source>label.width</source>
@@ -303,22 +259,6 @@
         <source>list.label_enabled</source>
         <target>Włączony</target>
       </trans-unit>
-      <trans-unit id="list.label_name">
-        <source>list.label_name</source>
-        <target>list.label_name</target>
-      </trans-unit>
-      <trans-unit id="list.label_author_name">
-        <source>list.label_author_name</source>
-        <target>list.label_author_name</target>
-      </trans-unit>
-      <trans-unit id="list.label_context">
-        <source>list.label_context</source>
-        <target>list.label_context</target>
-      </trans-unit>
-      <trans-unit id="list.label_default_format">
-        <source>list.label_default_format</source>
-        <target>list.label_default_format</target>
-      </trans-unit>
       <trans-unit id="list.label__action">
         <source>list.label__action</source>
         <target>Akcja</target>
@@ -326,10 +266,6 @@
       <trans-unit id="list.label_custom">
         <source>list.label_custom</source>
         <target>Własny</target>
-      </trans-unit>
-      <trans-unit id="list.label_author">
-        <source>list.label_author</source>
-        <target>list.label_author</target>
       </trans-unit>
       <trans-unit id="sidemenu.link_edit_media">
         <source>sidemenu.link_edit_media</source>
@@ -374,166 +310,6 @@
       <trans-unit id="title.formats">
         <source>title.formats</source>
         <target>Formaty</target>
-      </trans-unit>
-      <trans-unit id="link_media">
-        <source>link_media</source>
-        <target>link_media</target>
-      </trans-unit>
-      <trans-unit id="no_linked_media">
-        <source>no_linked_media</source>
-        <target>no_linked_media</target>
-      </trans-unit>
-      <trans-unit id="widget_label_type">
-        <source>widget_label_type</source>
-        <target>widget_label_type</target>
-      </trans-unit>
-      <trans-unit id="widget_label_context">
-        <source>widget_label_context</source>
-        <target>widget_label_context</target>
-      </trans-unit>
-      <trans-unit id="widget_label_unlink">
-        <source>widget_label_unlink</source>
-        <target>widget_label_unlink</target>
-      </trans-unit>
-      <trans-unit id="widget_label_binary_content">
-        <source>widget_label_binary_content</source>
-        <target>widget_label_binary_content</target>
-      </trans-unit>
-      <trans-unit id="widget_headline_information">
-        <source>widget_headline_information</source>
-        <target>widget_headline_information</target>
-      </trans-unit>
-      <trans-unit id="sonata_media_gallery_index">
-        <source>sonata_media_gallery_index</source>
-        <target>sonata_media_gallery_index</target>
-      </trans-unit>
-      <trans-unit id="list.label_description">
-        <source>list.label_description</source>
-        <target>list.label_description</target>
-      </trans-unit>
-      <trans-unit id="list.label_size">
-        <source>list.label_size</source>
-        <target>list.label_size</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.media">
-        <source>sonata.media.block.media</source>
-        <target>sonata.media.block.media</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.feature_media">
-        <source>sonata.media.block.feature_media</source>
-        <target>sonata.media.block.feature_media</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.gallery">
-        <source>sonata.media.block.gallery</source>
-        <target>sonata.media.block.gallery</target>
-      </trans-unit>
-      <trans-unit id="form.label_title">
-        <source>form.label_title</source>
-        <target>form.label_title</target>
-      </trans-unit>
-      <trans-unit id="form.label_content">
-        <source>form.label_content</source>
-        <target>form.label_content</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation">
-        <source>form.label_orientation</source>
-        <target>form.label_orientation</target>
-      </trans-unit>
-      <trans-unit id="form.label_gallery">
-        <source>form.label_gallery</source>
-        <target>form.label_gallery</target>
-      </trans-unit>
-      <trans-unit id="form.label_format">
-        <source>form.label_format</source>
-        <target>form.label_format</target>
-      </trans-unit>
-      <trans-unit id="form.label_pause_time">
-        <source>form.label_pause_time</source>
-        <target>form.label_pause_time</target>
-      </trans-unit>
-      <trans-unit id="form.label_start_paused">
-        <source>form.label_start_paused</source>
-        <target>form.label_start_paused</target>
-      </trans-unit>
-      <trans-unit id="form.label_wrap">
-        <source>form.label_wrap</source>
-        <target>form.label_wrap</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation_left">
-        <source>form.label_orientation_left</source>
-        <target>form.label_orientation_left</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation_right">
-        <source>form.label_orientation_right</source>
-        <target>form.label_orientation_right</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.gallery_list">
-        <source>sonata.media.block.gallery_list</source>
-        <target>sonata.media.block.gallery_list</target>
-      </trans-unit>
-      <trans-unit id="label_gallery_enabled">
-        <source>label_gallery_enabled</source>
-        <target>label_gallery_enabled</target>
-      </trans-unit>
-      <trans-unit id="label_gallery_disabled">
-        <source>label_gallery_disabled</source>
-        <target>label_gallery_disabled</target>
-      </trans-unit>
-      <trans-unit id="no_galleries_found">
-        <source>no_galleries_found</source>
-        <target>no_galleries_found</target>
-      </trans-unit>
-      <trans-unit id="view_all_galleries">
-        <source>view_all_galleries</source>
-        <target>view_all_galleries</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode">
-        <source>form.label_mode</source>
-        <target>form.label_mode</target>
-      </trans-unit>
-      <trans-unit id="form.label_number">
-        <source>form.label_number</source>
-        <target>form.label_number</target>
-      </trans-unit>
-      <trans-unit id="form.label_order">
-        <source>form.label_order</source>
-        <target>form.label_order</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_name">
-        <source>form.label_order_name</source>
-        <target>form.label_order_name</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_created_at">
-        <source>form.label_order_created_at</source>
-        <target>form.label_order_created_at</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_updated_at">
-        <source>form.label_order_updated_at</source>
-        <target>form.label_order_updated_at</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort">
-        <source>form.label_sort</source>
-        <target>form.label_sort</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort_asc">
-        <source>form.label_sort_asc</source>
-        <target>form.label_sort_asc</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort_desc">
-        <source>form.label_sort_desc</source>
-        <target>form.label_sort_desc</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode_public">
-        <source>form.label_mode_public</source>
-        <target>form.label_mode_public</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode_admin">
-        <source>form.label_mode_admin</source>
-        <target>form.label_mode_admin</target>
-      </trans-unit>
-      <trans-unit id="form.label_class">
-        <source>form.label_class</source>
-        <target>form.label_class</target>
       </trans-unit>
     </body>
   </file>

--- a/src/Resources/translations/SonataMediaBundle.pt_BR.xliff
+++ b/src/Resources/translations/SonataMediaBundle.pt_BR.xliff
@@ -78,10 +78,6 @@
         <source>description.forbidden_download_strategy</source>
         <target>A mídia pode ser recuperada por ninguém.</target>
       </trans-unit>
-      <trans-unit id="description.session_download_strategy">
-        <source>description.session_download_strategy</source>
-        <target>description.session_download_strategy</target>
-      </trans-unit>
       <trans-unit id="filter.label_name">
         <source>filter.label_name</source>
         <target>Nome</target>
@@ -97,10 +93,6 @@
       <trans-unit id="filter.label_context">
         <source>filter.label_context</source>
         <target>Contexto</target>
-      </trans-unit>
-      <trans-unit id="form.label_category">
-        <source>form.label_category</source>
-        <target>form.label_category</target>
       </trans-unit>
       <trans-unit id="filter.label_provider_name">
         <source>filter.label_provider_name</source>
@@ -138,18 +130,6 @@
         <source>form.label_author_name</source>
         <target>Autor</target>
       </trans-unit>
-      <trans-unit id="filter.label_width">
-        <source>filter.label_width</source>
-        <target>filter.label_width</target>
-      </trans-unit>
-      <trans-unit id="filter.label_height">
-        <source>filter.label_height</source>
-        <target>filter.label_height</target>
-      </trans-unit>
-      <trans-unit id="filter.label_content_type">
-        <source>filter.label_content_type</source>
-        <target>filter.label_content_type</target>
-      </trans-unit>
       <trans-unit id="form.label_cdn_is_flushable">
         <source>form.label_cdn_is_flushable</source>
         <target>Atualizar CDN</target>
@@ -169,10 +149,6 @@
       <trans-unit id="label.size">
         <source>label.size</source>
         <target>Tamanho</target>
-      </trans-unit>
-      <trans-unit id="label.length">
-        <source>label.length</source>
-        <target>label.length</target>
       </trans-unit>
       <trans-unit id="label.width">
         <source>label.width</source>
@@ -299,10 +275,6 @@
         <source>list.label_name</source>
         <target>Nome</target>
       </trans-unit>
-      <trans-unit id="list.label_author_name">
-        <source>list.label_author_name</source>
-        <target>list.label_author_name</target>
-      </trans-unit>
       <trans-unit id="list.label_context">
         <source>list.label_context</source>
         <target>Contexto</target>
@@ -318,10 +290,6 @@
       <trans-unit id="list.label_custom">
         <source>list.label_custom</source>
         <target>Personalizado</target>
-      </trans-unit>
-      <trans-unit id="list.label_author">
-        <source>list.label_author</source>
-        <target>list.label_author</target>
       </trans-unit>
       <trans-unit id="sidemenu.link_edit_media">
         <source>sidemenu.link_edit_media</source>
@@ -374,158 +342,6 @@
       <trans-unit id="no_linked_media">
         <source>no_linked_media</source>
         <target>Nenhuma mídia linkada para o objeto</target>
-      </trans-unit>
-      <trans-unit id="widget_label_type">
-        <source>widget_label_type</source>
-        <target>widget_label_type</target>
-      </trans-unit>
-      <trans-unit id="widget_label_context">
-        <source>widget_label_context</source>
-        <target>widget_label_context</target>
-      </trans-unit>
-      <trans-unit id="widget_headline_information">
-        <source>widget_headline_information</source>
-        <target>widget_headline_information</target>
-      </trans-unit>
-      <trans-unit id="widget_label_unlink">
-        <source>widget_label_unlink</source>
-        <target>widget_label_unlink</target>
-      </trans-unit>
-      <trans-unit id="widget_label_binary_content">
-        <source>widget_label_binary_content</source>
-        <target>widget_label_binary_content</target>
-      </trans-unit>
-      <trans-unit id="sonata_media_gallery_index">
-        <source>sonata_media_gallery_index</source>
-        <target>sonata_media_gallery_index</target>
-      </trans-unit>
-      <trans-unit id="list.label_description">
-        <source>list.label_description</source>
-        <target>list.label_description</target>
-      </trans-unit>
-      <trans-unit id="list.label_size">
-        <source>list.label_size</source>
-        <target>list.label_size</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.media">
-        <source>sonata.media.block.media</source>
-        <target>sonata.media.block.media</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.feature_media">
-        <source>sonata.media.block.feature_media</source>
-        <target>sonata.media.block.feature_media</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.gallery">
-        <source>sonata.media.block.gallery</source>
-        <target>sonata.media.block.gallery</target>
-      </trans-unit>
-      <trans-unit id="form.label_title">
-        <source>form.label_title</source>
-        <target>form.label_title</target>
-      </trans-unit>
-      <trans-unit id="form.label_content">
-        <source>form.label_content</source>
-        <target>form.label_content</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation">
-        <source>form.label_orientation</source>
-        <target>form.label_orientation</target>
-      </trans-unit>
-      <trans-unit id="form.label_gallery">
-        <source>form.label_gallery</source>
-        <target>form.label_gallery</target>
-      </trans-unit>
-      <trans-unit id="form.label_format">
-        <source>form.label_format</source>
-        <target>form.label_format</target>
-      </trans-unit>
-      <trans-unit id="form.label_pause_time">
-        <source>form.label_pause_time</source>
-        <target>form.label_pause_time</target>
-      </trans-unit>
-      <trans-unit id="form.label_start_paused">
-        <source>form.label_start_paused</source>
-        <target>form.label_start_paused</target>
-      </trans-unit>
-      <trans-unit id="form.label_wrap">
-        <source>form.label_wrap</source>
-        <target>form.label_wrap</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation_left">
-        <source>form.label_orientation_left</source>
-        <target>form.label_orientation_left</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation_right">
-        <source>form.label_orientation_right</source>
-        <target>form.label_orientation_right</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.gallery_list">
-        <source>sonata.media.block.gallery_list</source>
-        <target>sonata.media.block.gallery_list</target>
-      </trans-unit>
-      <trans-unit id="label_gallery_enabled">
-        <source>label_gallery_enabled</source>
-        <target>label_gallery_enabled</target>
-      </trans-unit>
-      <trans-unit id="label_gallery_disabled">
-        <source>label_gallery_disabled</source>
-        <target>label_gallery_disabled</target>
-      </trans-unit>
-      <trans-unit id="no_galleries_found">
-        <source>no_galleries_found</source>
-        <target>no_galleries_found</target>
-      </trans-unit>
-      <trans-unit id="view_all_galleries">
-        <source>view_all_galleries</source>
-        <target>view_all_galleries</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode">
-        <source>form.label_mode</source>
-        <target>form.label_mode</target>
-      </trans-unit>
-      <trans-unit id="form.label_number">
-        <source>form.label_number</source>
-        <target>form.label_number</target>
-      </trans-unit>
-      <trans-unit id="form.label_order">
-        <source>form.label_order</source>
-        <target>form.label_order</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_name">
-        <source>form.label_order_name</source>
-        <target>form.label_order_name</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_created_at">
-        <source>form.label_order_created_at</source>
-        <target>form.label_order_created_at</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_updated_at">
-        <source>form.label_order_updated_at</source>
-        <target>form.label_order_updated_at</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort">
-        <source>form.label_sort</source>
-        <target>form.label_sort</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort_asc">
-        <source>form.label_sort_asc</source>
-        <target>form.label_sort_asc</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort_desc">
-        <source>form.label_sort_desc</source>
-        <target>form.label_sort_desc</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode_public">
-        <source>form.label_mode_public</source>
-        <target>form.label_mode_public</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode_admin">
-        <source>form.label_mode_admin</source>
-        <target>form.label_mode_admin</target>
-      </trans-unit>
-      <trans-unit id="form.label_class">
-        <source>form.label_class</source>
-        <target>form.label_class</target>
       </trans-unit>
     </body>
   </file>

--- a/src/Resources/translations/SonataMediaBundle.ro.xliff
+++ b/src/Resources/translations/SonataMediaBundle.ro.xliff
@@ -78,10 +78,6 @@
         <source>description.forbidden_download_strategy</source>
         <target>Media nu este disponibil pentru nimeni.</target>
       </trans-unit>
-      <trans-unit id="description.session_download_strategy">
-        <source>description.session_download_strategy</source>
-        <target>description.session_download_strategy</target>
-      </trans-unit>
       <trans-unit id="filter.label_name">
         <source>filter.label_name</source>
         <target>Nume</target>
@@ -109,18 +105,6 @@
       <trans-unit id="filter.label_author_name">
         <source>filter.label_author_name</source>
         <target>Nume autor</target>
-      </trans-unit>
-      <trans-unit id="filter.label_width">
-        <source>filter.label_width</source>
-        <target>filter.label_width</target>
-      </trans-unit>
-      <trans-unit id="filter.label_height">
-        <source>filter.label_height</source>
-        <target>filter.label_height</target>
-      </trans-unit>
-      <trans-unit id="filter.label_content_type">
-        <source>filter.label_content_type</source>
-        <target>filter.label_content_type</target>
       </trans-unit>
       <trans-unit id="form.label_enabled">
         <source>form.label_enabled</source>
@@ -399,26 +383,6 @@
         <source>no_linked_media</source>
         <target>Nici un media atașat la obiect</target>
       </trans-unit>
-      <trans-unit id="widget_label_type">
-        <source>widget_label_type</source>
-        <target>widget_label_type</target>
-      </trans-unit>
-      <trans-unit id="widget_label_context">
-        <source>widget_label_context</source>
-        <target>widget_label_context</target>
-      </trans-unit>
-      <trans-unit id="widget_headline_information">
-        <source>widget_headline_information</source>
-        <target>widget_headline_information</target>
-      </trans-unit>
-      <trans-unit id="widget_label_unlink">
-        <source>widget_label_unlink</source>
-        <target>widget_label_unlink</target>
-      </trans-unit>
-      <trans-unit id="widget_label_binary_content">
-        <source>widget_label_binary_content</source>
-        <target>widget_label_binary_content</target>
-      </trans-unit>
       <trans-unit id="sonata_media_gallery_index">
         <source>sonata_media_gallery_index</source>
         <target>Galerie</target>
@@ -442,126 +406,6 @@
       <trans-unit id="form.label_provider_reference">
         <source>form.label_provider_reference</source>
         <target>Cheie de referință</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.media">
-        <source>sonata.media.block.media</source>
-        <target>sonata.media.block.media</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.feature_media">
-        <source>sonata.media.block.feature_media</source>
-        <target>sonata.media.block.feature_media</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.gallery">
-        <source>sonata.media.block.gallery</source>
-        <target>sonata.media.block.gallery</target>
-      </trans-unit>
-      <trans-unit id="form.label_title">
-        <source>form.label_title</source>
-        <target>form.label_title</target>
-      </trans-unit>
-      <trans-unit id="form.label_content">
-        <source>form.label_content</source>
-        <target>form.label_content</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation">
-        <source>form.label_orientation</source>
-        <target>form.label_orientation</target>
-      </trans-unit>
-      <trans-unit id="form.label_gallery">
-        <source>form.label_gallery</source>
-        <target>form.label_gallery</target>
-      </trans-unit>
-      <trans-unit id="form.label_format">
-        <source>form.label_format</source>
-        <target>form.label_format</target>
-      </trans-unit>
-      <trans-unit id="form.label_pause_time">
-        <source>form.label_pause_time</source>
-        <target>form.label_pause_time</target>
-      </trans-unit>
-      <trans-unit id="form.label_start_paused">
-        <source>form.label_start_paused</source>
-        <target>form.label_start_paused</target>
-      </trans-unit>
-      <trans-unit id="form.label_wrap">
-        <source>form.label_wrap</source>
-        <target>form.label_wrap</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation_left">
-        <source>form.label_orientation_left</source>
-        <target>form.label_orientation_left</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation_right">
-        <source>form.label_orientation_right</source>
-        <target>form.label_orientation_right</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.gallery_list">
-        <source>sonata.media.block.gallery_list</source>
-        <target>sonata.media.block.gallery_list</target>
-      </trans-unit>
-      <trans-unit id="label_gallery_enabled">
-        <source>label_gallery_enabled</source>
-        <target>label_gallery_enabled</target>
-      </trans-unit>
-      <trans-unit id="label_gallery_disabled">
-        <source>label_gallery_disabled</source>
-        <target>label_gallery_disabled</target>
-      </trans-unit>
-      <trans-unit id="no_galleries_found">
-        <source>no_galleries_found</source>
-        <target>no_galleries_found</target>
-      </trans-unit>
-      <trans-unit id="view_all_galleries">
-        <source>view_all_galleries</source>
-        <target>view_all_galleries</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode">
-        <source>form.label_mode</source>
-        <target>form.label_mode</target>
-      </trans-unit>
-      <trans-unit id="form.label_number">
-        <source>form.label_number</source>
-        <target>form.label_number</target>
-      </trans-unit>
-      <trans-unit id="form.label_order">
-        <source>form.label_order</source>
-        <target>form.label_order</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_name">
-        <source>form.label_order_name</source>
-        <target>form.label_order_name</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_created_at">
-        <source>form.label_order_created_at</source>
-        <target>form.label_order_created_at</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_updated_at">
-        <source>form.label_order_updated_at</source>
-        <target>form.label_order_updated_at</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort">
-        <source>form.label_sort</source>
-        <target>form.label_sort</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort_asc">
-        <source>form.label_sort_asc</source>
-        <target>form.label_sort_asc</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort_desc">
-        <source>form.label_sort_desc</source>
-        <target>form.label_sort_desc</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode_public">
-        <source>form.label_mode_public</source>
-        <target>form.label_mode_public</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode_admin">
-        <source>form.label_mode_admin</source>
-        <target>form.label_mode_admin</target>
-      </trans-unit>
-      <trans-unit id="form.label_class">
-        <source>form.label_class</source>
-        <target>form.label_class</target>
       </trans-unit>
     </body>
   </file>

--- a/src/Resources/translations/SonataMediaBundle.uk.xliff
+++ b/src/Resources/translations/SonataMediaBundle.uk.xliff
@@ -78,10 +78,6 @@
         <source>description.forbidden_download_strategy</source>
         <target>Медіа не доступний нікому.</target>
       </trans-unit>
-      <trans-unit id="description.session_download_strategy">
-        <source>description.session_download_strategy</source>
-        <target>description.session_download_strategy</target>
-      </trans-unit>
       <trans-unit id="filter.label_name">
         <source>filter.label_name</source>
         <target>Назва</target>
@@ -347,26 +343,6 @@
         <source>no_linked_media</source>
         <target>Немає медіа, зв'язаних з обєктом</target>
       </trans-unit>
-      <trans-unit id="widget_label_type">
-        <source>widget_label_type</source>
-        <target>widget_label_type</target>
-      </trans-unit>
-      <trans-unit id="widget_label_context">
-        <source>widget_label_context</source>
-        <target>widget_label_context</target>
-      </trans-unit>
-      <trans-unit id="widget_headline_information">
-        <source>widget_headline_information</source>
-        <target>widget_headline_information</target>
-      </trans-unit>
-      <trans-unit id="widget_label_unlink">
-        <source>widget_label_unlink</source>
-        <target>widget_label_unlink</target>
-      </trans-unit>
-      <trans-unit id="widget_label_binary_content">
-        <source>widget_label_binary_content</source>
-        <target>widget_label_binary_content</target>
-      </trans-unit>
       <trans-unit id="sonata_media_gallery_index">
         <source>sonata_media_gallery_index</source>
         <target>Галерея</target>
@@ -378,126 +354,6 @@
       <trans-unit id="list.label_size">
         <source>list.label_size</source>
         <target>Розмір</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.media">
-        <source>sonata.media.block.media</source>
-        <target>sonata.media.block.media</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.feature_media">
-        <source>sonata.media.block.feature_media</source>
-        <target>sonata.media.block.feature_media</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.gallery">
-        <source>sonata.media.block.gallery</source>
-        <target>sonata.media.block.gallery</target>
-      </trans-unit>
-      <trans-unit id="form.label_title">
-        <source>form.label_title</source>
-        <target>form.label_title</target>
-      </trans-unit>
-      <trans-unit id="form.label_content">
-        <source>form.label_content</source>
-        <target>form.label_content</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation">
-        <source>form.label_orientation</source>
-        <target>form.label_orientation</target>
-      </trans-unit>
-      <trans-unit id="form.label_gallery">
-        <source>form.label_gallery</source>
-        <target>form.label_gallery</target>
-      </trans-unit>
-      <trans-unit id="form.label_format">
-        <source>form.label_format</source>
-        <target>form.label_format</target>
-      </trans-unit>
-      <trans-unit id="form.label_pause_time">
-        <source>form.label_pause_time</source>
-        <target>form.label_pause_time</target>
-      </trans-unit>
-      <trans-unit id="form.label_start_paused">
-        <source>form.label_start_paused</source>
-        <target>form.label_start_paused</target>
-      </trans-unit>
-      <trans-unit id="form.label_wrap">
-        <source>form.label_wrap</source>
-        <target>form.label_wrap</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation_left">
-        <source>form.label_orientation_left</source>
-        <target>form.label_orientation_left</target>
-      </trans-unit>
-      <trans-unit id="form.label_orientation_right">
-        <source>form.label_orientation_right</source>
-        <target>form.label_orientation_right</target>
-      </trans-unit>
-      <trans-unit id="sonata.media.block.gallery_list">
-        <source>sonata.media.block.gallery_list</source>
-        <target>sonata.media.block.gallery_list</target>
-      </trans-unit>
-      <trans-unit id="label_gallery_enabled">
-        <source>label_gallery_enabled</source>
-        <target>label_gallery_enabled</target>
-      </trans-unit>
-      <trans-unit id="label_gallery_disabled">
-        <source>label_gallery_disabled</source>
-        <target>label_gallery_disabled</target>
-      </trans-unit>
-      <trans-unit id="no_galleries_found">
-        <source>no_galleries_found</source>
-        <target>no_galleries_found</target>
-      </trans-unit>
-      <trans-unit id="view_all_galleries">
-        <source>view_all_galleries</source>
-        <target>view_all_galleries</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode">
-        <source>form.label_mode</source>
-        <target>form.label_mode</target>
-      </trans-unit>
-      <trans-unit id="form.label_number">
-        <source>form.label_number</source>
-        <target>form.label_number</target>
-      </trans-unit>
-      <trans-unit id="form.label_order">
-        <source>form.label_order</source>
-        <target>form.label_order</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_name">
-        <source>form.label_order_name</source>
-        <target>form.label_order_name</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_created_at">
-        <source>form.label_order_created_at</source>
-        <target>form.label_order_created_at</target>
-      </trans-unit>
-      <trans-unit id="form.label_order_updated_at">
-        <source>form.label_order_updated_at</source>
-        <target>form.label_order_updated_at</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort">
-        <source>form.label_sort</source>
-        <target>form.label_sort</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort_asc">
-        <source>form.label_sort_asc</source>
-        <target>form.label_sort_asc</target>
-      </trans-unit>
-      <trans-unit id="form.label_sort_desc">
-        <source>form.label_sort_desc</source>
-        <target>form.label_sort_desc</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode_public">
-        <source>form.label_mode_public</source>
-        <target>form.label_mode_public</target>
-      </trans-unit>
-      <trans-unit id="form.label_mode_admin">
-        <source>form.label_mode_admin</source>
-        <target>form.label_mode_admin</target>
-      </trans-unit>
-      <trans-unit id="form.label_class">
-        <source>form.label_class</source>
-        <target>form.label_class</target>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because the placeholders are fake translations.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Part of https://github.com/sonata-project/dev-kit/issues/1614
