### PR TITLE
Avoid using container on ProxyMetadataBuilder

### DIFF
--- a/src/Resources/config/gaufrette.php
+++ b/src/Resources/config/gaufrette.php
@@ -66,7 +66,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         ->set('sonata.media.metadata.proxy', ProxyMetadataBuilder::class)
             ->args([
-                new ReferenceConfigurator('service_container'),
+                new ReferenceConfigurator('sonata.media.pool'),
                 (new ReferenceConfigurator('sonata.media.metadata.noop'))->nullOnInvalid(),
                 (new ReferenceConfigurator('sonata.media.metadata.amazon'))->nullOnInvalid(),
             ])

--- a/tests/DependencyInjection/SonataMediaExtensionTest.php
+++ b/tests/DependencyInjection/SonataMediaExtensionTest.php
@@ -79,24 +79,21 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
      *
      * @phpstan-param class-string $type
      */
-    public function testAdapter(string $serviceId, string $extension, string $type): void
+    public function testAdapter(string $serviceId, string $type): void
     {
         $this->load();
 
-        $this->assertContainerBuilderHasService($serviceId);
-        if (\extension_loaded($extension)) {
-            static::assertInstanceOf($type, $this->container->get($serviceId));
-        }
+        $this->assertContainerBuilderHasService($serviceId, $type);
     }
 
     /**
-     * @phpstan-return iterable<array{string, string, class-string}>
+     * @phpstan-return iterable<array{string, class-string}>
      */
     public function dataAdapter(): iterable
     {
-        yield ['sonata.media.adapter.image.gd', 'gd', GdImagine::class];
-        yield ['sonata.media.adapter.image.gmagick', 'gmagick', GmagicImagine::class];
-        yield ['sonata.media.adapter.image.imagick', 'imagick', ImagicImagine::class];
+        yield ['sonata.media.adapter.image.gd', GdImagine::class];
+        yield ['sonata.media.adapter.image.gmagick', GmagicImagine::class];
+        yield ['sonata.media.adapter.image.imagick', ImagicImagine::class];
     }
 
     public function testDefaultResizer(): void
@@ -142,10 +139,7 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
     {
         $this->load();
 
-        $this->assertContainerBuilderHasService($serviceId);
-        if (\extension_loaded('gd')) {
-            static::assertInstanceOf($type, $this->container->get($serviceId));
-        }
+        $this->assertContainerBuilderHasService($serviceId, $type);
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Avoid using container on `ProxyMetadataBuilder`, instead use the media pool.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
