### PR TITLE
Add missing methods to interfaces and abstract classes

### DIFF
--- a/src/Model/GalleryInterface.php
+++ b/src/Model/GalleryInterface.php
@@ -13,6 +13,11 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Model;
 
+/**
+ * NEXT_MAJOR: Replace the `reorderGalleryHasMedia()` method with `reorderGalleryItems()`.
+ *
+ * @method void reorderGalleryHasMedia()
+ */
 interface GalleryInterface
 {
     /**

--- a/src/Model/Media.php
+++ b/src/Model/Media.php
@@ -19,9 +19,6 @@ use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 
-/**
- * @method void setCategory($category)
- */
 abstract class Media implements MediaInterface
 {
     /**

--- a/src/Model/MediaInterface.php
+++ b/src/Model/MediaInterface.php
@@ -15,6 +15,11 @@ namespace Sonata\MediaBundle\Model;
 
 use Imagine\Image\Box;
 
+/**
+ * @method void                   setCategory(?CategoryInterface $category)
+ * @method CategoryInterface|null getCategory()
+ * @method string                 __toString()
+ */
 interface MediaInterface
 {
     public const STATUS_OK = 1;
@@ -24,6 +29,9 @@ interface MediaInterface
     public const STATUS_ENCODING = 5;
 
     public const MISSING_BINARY_REFERENCE = 'missing_binary_content';
+
+    // NEXY_MAJOR: Uncomment this method.
+    // public function __toString(): string;
 
     /**
      * @param mixed $binaryContent

--- a/src/Provider/BaseVideoProvider.php
+++ b/src/Provider/BaseVideoProvider.php
@@ -29,6 +29,9 @@ use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;
 
+/**
+ * @method string getReferenceUrl(MediaInterface $media)
+ */
 abstract class BaseVideoProvider extends BaseProvider
 {
     /**

--- a/src/Provider/MediaProviderInterface.php
+++ b/src/Provider/MediaProviderInterface.php
@@ -16,11 +16,15 @@ namespace Sonata\MediaBundle\Provider;
 use Gaufrette\Filesystem;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\Form\Validator\ErrorElement;
+use Sonata\MediaBundle\CDN\CDNInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Resizer\ResizerInterface;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @method CDNInterface getCdn()
+ */
 interface MediaProviderInterface
 {
     // This format is used to display thumbnails in Sonata Admin
@@ -207,4 +211,7 @@ interface MediaProviderInterface
      * @param bool $force
      */
     public function updateMetadata(MediaInterface $media, $force = false);
+
+    // NEXT_MAJOR: Uncomment this method.
+    // public function getCdn(): CDNInterface;
 }

--- a/tests/Fixtures/SonataClassificationBundle/Model/CategoryInterface.php
+++ b/tests/Fixtures/SonataClassificationBundle/Model/CategoryInterface.php
@@ -15,6 +15,11 @@ namespace Sonata\ClassificationBundle\Model;
 
 interface CategoryInterface
 {
+    /**
+     * @return mixed
+     */
+    public function getId();
+
     public function getContext(): ?ContextInterface;
 
     /**

--- a/tests/Fixtures/SonataClassificationBundle/Model/ContextInterface.php
+++ b/tests/Fixtures/SonataClassificationBundle/Model/ContextInterface.php
@@ -15,6 +15,11 @@ namespace Sonata\ClassificationBundle\Model;
 
 interface ContextInterface
 {
+    /**
+     * @return mixed
+     */
+    public function getId();
+
     public function getName(): ?string;
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Add missing methods to interfaces and abstract classes.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Part of #2035.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Missing method declarations in interfaces and abstract classes, through `@method` annotation in order to respect BC.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
