### PR TITLE
Deprecate index and view controller method

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,18 @@ UPGRADE 3.x
 UPGRADE FROM 3.x to 3.x
 =======================
 
+### Media and Gallery Controllers
+
+`viewAction()` and `indexAction()` from media and gallery controllers are deprecated now.
+There is no provided replacement since those actions are suposed to be implemented in app side if you need them.
+
+### Breadcrumbs classes
+
+Breadcrumbs are deprecated, if your application uses them on the frontend side, you should use `sonata-project/seo-bundle` to implement them instead.
+
+UPGRADE FROM 3.32 to 3.33
+=========================
+
 ### Sonata\MediaBundle\Listener\BaseMediaEventSubscriber::getMedia() and its inheritances
 
 Method `getMedia()` returns `null` if the related medium does not implement `Sonata\MediaBundle\Model\MediaInterface`.

--- a/src/Block/Breadcrumb/BaseGalleryBreadcrumbBlockService.php
+++ b/src/Block/Breadcrumb/BaseGalleryBreadcrumbBlockService.php
@@ -17,9 +17,13 @@ use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\SeoBundle\Block\Breadcrumb\BaseBreadcrumbMenuBlockService;
 
 /**
+ * NEXT_MAJOR: remove this file.
+ *
  * Abstract class for media breadcrumbs.
  *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
+ *
+ * @deprecated since sonata-project/media-bundle 3.x, to be removed in 4.0.
  */
 abstract class BaseGalleryBreadcrumbBlockService extends BaseBreadcrumbMenuBlockService
 {

--- a/src/Block/Breadcrumb/GalleryIndexBreadcrumbBlockService.php
+++ b/src/Block/Breadcrumb/GalleryIndexBreadcrumbBlockService.php
@@ -16,11 +16,15 @@ namespace Sonata\MediaBundle\Block\Breadcrumb;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 
 /**
+ * NEXT_MAJOR: remove this file.
+ *
  * BlockService for view gallery.
  *
  * @final since sonata-project/media-bundle 3.21.0
  *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
+ *
+ * @deprecated since sonata-project/media-bundle 3.x, to be removed in 4.0.
  */
 class GalleryIndexBreadcrumbBlockService extends BaseGalleryBreadcrumbBlockService
 {

--- a/src/Block/Breadcrumb/GalleryViewBreadcrumbBlockService.php
+++ b/src/Block/Breadcrumb/GalleryViewBreadcrumbBlockService.php
@@ -17,11 +17,15 @@ use Sonata\BlockBundle\Block\BlockContextInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
+ * NEXT_MAJOR: remove this file.
+ *
  * BlockService for view gallery.
  *
  * @final since sonata-project/media-bundle 3.21.0
  *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
+ *
+ * @deprecated since sonata-project/media-bundle 3.x, to be removed in 4.0.
  */
 class GalleryViewBreadcrumbBlockService extends BaseGalleryBreadcrumbBlockService
 {

--- a/src/Block/Breadcrumb/MediaViewBreadcrumbBlockService.php
+++ b/src/Block/Breadcrumb/MediaViewBreadcrumbBlockService.php
@@ -17,11 +17,15 @@ use Sonata\BlockBundle\Block\BlockContextInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
+ * NEXT_MAJOR: remove this file.
+ *
  * BlockService for view Media.
  *
  * @final since sonata-project/media-bundle 3.21.0
  *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
+ *
+ * @deprecated since sonata-project/media-bundle 3.x, to be removed in 4.0.
  */
 class MediaViewBreadcrumbBlockService extends BaseGalleryBreadcrumbBlockService
 {

--- a/src/Controller/GalleryController.php
+++ b/src/Controller/GalleryController.php
@@ -23,10 +23,19 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class GalleryController extends Controller
 {
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * @return Response
+     *
+     * @deprecated since sonata-project/media-bundle 3.x, to be removed in 4.0.
      */
     public function indexAction()
     {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since 3.x, to be removed in 4.0.',
+            \E_USER_DEPRECATED
+        );
+
         $galleries = $this->get('sonata.media.manager.gallery')->findBy([
             'enabled' => true,
         ]);
@@ -37,14 +46,23 @@ class GalleryController extends Controller
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * @param string $id
      *
      * @throws NotFoundHttpException
      *
      * @return Response
+     *
+     * @deprecated since sonata-project/media-bundle 3.x, to be removed in 4.0.
      */
     public function viewAction($id)
     {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since 3.x, to be removed in 4.0.',
+            \E_USER_DEPRECATED
+        );
+
         $gallery = $this->get('sonata.media.manager.gallery')->findOneBy([
             'id' => $id,
             'enabled' => true,

--- a/src/Controller/MediaController.php
+++ b/src/Controller/MediaController.php
@@ -75,15 +75,24 @@ class MediaController extends Controller
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * @param string $id
      * @param string $format
      *
      * @throws NotFoundHttpException
      *
      * @return Response
+     *
+     * @deprecated since sonata-project/media-bundle 3.x, to be removed in 4.0.
      */
     public function viewAction($id, $format = MediaProviderInterface::FORMAT_REFERENCE)
     {
+        @trigger_error(
+            'The '.__METHOD__.' method is deprecated since 3.x, to be removed in 4.0.',
+            \E_USER_DEPRECATED
+        );
+
         $media = $this->getMedia($id);
 
         if (!$media) {

--- a/tests/Controller/MediaControllerTest.php
+++ b/tests/Controller/MediaControllerTest.php
@@ -97,6 +97,11 @@ class MediaControllerTest extends TestCase
         static::assertSame($response, $result);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testViewActionWithNotFoundMedia(): void
     {
         $this->expectException(NotFoundHttpException::class);
@@ -106,6 +111,11 @@ class MediaControllerTest extends TestCase
         $this->controller->viewAction(1);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testViewActionAccessDenied(): void
     {
         $this->expectException(AccessDeniedException::class);
@@ -122,6 +132,11 @@ class MediaControllerTest extends TestCase
         $this->controller->viewAction(1);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testViewActionRendersView(): void
     {
         $media = $this->createStub(Media::class);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

We should deprecate those methods because they do not provide any value and they can be easily implement in case someone needs to show a media detail and list of galleries.

Breadcrumb were directly related to those actions. Again , if someone need those actions for the frontend of his app. He might need or not the breadcrumbs.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecate controller actions for showing media and galleries.
- Deprecate breadcrumb classes.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
