### PR TITLE
Deprecate Pixlr integration

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,11 @@ UPGRADE 3.x
 UPGRADE FROM 3.x to 3.x
 =======================
 
+### Deprecate Pixlr integration
+
+Integration with Pixlr is deprecated now. There is no replacement since
+the bundle is trying to focus on media management and not on the edit part.
+
 ### Media and Gallery Controllers
 
 `viewAction()` and `indexAction()` from media and gallery controllers are deprecated now.

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -441,11 +441,18 @@ class Configuration implements ConfigurationInterface
             ->end();
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     private function addExtraSection(ArrayNodeDefinition $node): void
     {
         $node
             ->children()
                 ->arrayNode('pixlr')
+                    ->setDeprecated(...$this->getBackwardCompatibleArgumentsForSetDeprecated(
+                        'The node "%node%" is deprecated and will be removed in version 4.0.',
+                        '3.x'
+                    ))
                     ->info('More info at https://pixlr.com/')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/src/Extra/Pixlr.php
+++ b/src/Extra/Pixlr.php
@@ -27,7 +27,11 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Templating\EngineInterface;
 
 /**
+ * NEXT_MAJOR: Remove this file.
+ *
  * @final since sonata-project/media-bundle 3.21.0
+ *
+ * @deprecated since sonata-project/media-bundle 3.x, to be removed in 4.0.
  */
 class Pixlr
 {

--- a/src/Resources/views/Extra/pixlr_editor.html.twig
+++ b/src/Resources/views/Extra/pixlr_editor.html.twig
@@ -9,6 +9,8 @@ file that was distributed with this source code.
 
 #}
 
+{% deprecated 'The "pixlr_editor.html.twig" template is deprecated since sonata-project/media-bundle 3.x' %}
+
 {% extends "@SonataAdmin/empty_layout.html.twig" %}
 
 {% block title %}Pixlr Editor{% endblock title %}

--- a/src/Resources/views/Extra/pixlr_exit.html.twig
+++ b/src/Resources/views/Extra/pixlr_exit.html.twig
@@ -9,6 +9,8 @@ file that was distributed with this source code.
 
 #}
 
+{% deprecated 'The "pixlr_exit.html.twig" template is deprecated since sonata-project/media-bundle 3.x' %}
+
 <!DOCTYPE html>
 <html class="no-js">
     <head>

--- a/src/Twig/GlobalVariables.php
+++ b/src/Twig/GlobalVariables.php
@@ -34,7 +34,11 @@ class GlobalVariables
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * @return Pixlr|bool
+     *
+     * @deprecated since sonata-project/media-bundle 3.x, to be removed in 4.0.
      */
     public function getPixlr()
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #2107 .
Closes #1092 .

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated Pixlr integration.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
