### PR TITLE
Fix media route for download action

### DIFF
--- a/src/Resources/config/routing/media.xml
+++ b/src/Resources/config/routing/media.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
-    <route id="sonata_media_download" path="/download/{id}/{format}" controller="Sonata\MediaBundle\Controller\MediaController::downloadAction">
+    <route id="sonata_media_download" path="/download/{id}/{format}" controller="sonata.media.controller.media::downloadAction">
         <default key="format">reference</default>
         <requirement key="id">.*</requirement>
     </route>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is hotfix for master.

On 3.x this is not a problem because controller are not registered as a service.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
