### PR TITLE
[RFC] Deprecate ReST API

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,12 @@ UPGRADE 3.x
 UPGRADE FROM 3.x to 3.x
 =======================
 
+### Deprecate API
+
+Integration with FOSRest, JMS Serializer and Nelmio Api Docs is deprecated, the ReST API provided with this bundle will be removed on 4.0.
+
+If you are relying on this, consider moving to other solution like [API Platform](https://api-platform.com/) instead.
+
 ### Deprecate Pixlr integration
 
 Integration with Pixlr is deprecated now. There is no replacement since

--- a/src/Controller/Api/GalleryController.php
+++ b/src/Controller/Api/GalleryController.php
@@ -35,9 +35,11 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
- * @final since sonata-project/media-bundle 3.21.0
+ * NEXT_MAJOR: Remove this file.
  *
  * @author Hugo Briand <briand@ekino.com>
+ *
+ * @deprecated since sonata-project/media-bundle 3.x, to be removed in 4.0.
  */
 class GalleryController
 {

--- a/src/Controller/Api/MediaController.php
+++ b/src/Controller/Api/MediaController.php
@@ -36,11 +36,13 @@ use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 /**
+ * NEXT_MAJOR: Remove this file.
+ *
  * Note: Media is plural, medium is singular (at least according to FOSRestBundle route generator).
  *
- * @final since sonata-project/media-bundle 3.21.0
- *
  * @author Hugo Briand <briand@ekino.com>
+ *
+ * @deprecated since sonata-project/media-bundle 3.x, to be removed in 4.0.
  */
 class MediaController
 {

--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -55,11 +55,13 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
         $loader->load('form.xml');
         $loader->load('gaufrette.xml');
         $loader->load('validators.xml');
+        // NEXT_MAJOR: Remove next line and the file.
         $loader->load('serializer.xml');
         $loader->load('command.xml');
 
         $bundles = $container->getParameter('kernel.bundles');
 
+        // NEXT_MAJOR: Remove this condition and remove all configuration files related to this.
         if (isset($bundles['FOSRestBundle'], $bundles['NelmioApiDocBundle'])) {
             $loader->load(sprintf('api_form_%s.xml', $config['db_driver']));
 

--- a/src/Document/GalleryManager.php
+++ b/src/Document/GalleryManager.php
@@ -34,6 +34,11 @@ class GalleryManager extends BaseDocumentManager implements GalleryManagerInterf
         parent::save($gallery);
     }
 
+    /**
+     * NEXT_MAJOR: remove this method.
+     *
+     * @deprecated since sonata-project/media-bundle 3.x, to be removed in 4.0.
+     */
     public function getPager(array $criteria, $page, $limit = 10, array $sort = [])
     {
         throw new \RuntimeException('Not Implemented yet');

--- a/src/Document/MediaManager.php
+++ b/src/Document/MediaManager.php
@@ -41,6 +41,11 @@ class MediaManager extends BaseDocumentManager implements MediaManagerInterface
         }
     }
 
+    /**
+     * NEXT_MAJOR: remove this method.
+     *
+     * @deprecated since sonata-project/media-bundle 3.x, to be removed in 4.0.
+     */
     public function getPager(array $criteria, $page, $limit = 10, array $sort = [])
     {
         throw new \RuntimeException('Not Implemented yet');

--- a/src/Entity/GalleryManager.php
+++ b/src/Entity/GalleryManager.php
@@ -36,6 +36,11 @@ class GalleryManager extends BaseEntityManager implements GalleryManagerInterfac
         parent::save($gallery);
     }
 
+    /**
+     * NEXT_MAJOR: remove this method.
+     *
+     * @deprecated since sonata-project/media-bundle 3.x, to be removed in 4.0.
+     */
     public function getPager(array $criteria, $page, $limit = 10, array $sort = [])
     {
         $query = $this->getRepository()

--- a/src/Entity/MediaManager.php
+++ b/src/Entity/MediaManager.php
@@ -47,6 +47,11 @@ class MediaManager extends BaseEntityManager implements MediaManagerInterface
         }
     }
 
+    /**
+     * NEXT_MAJOR: remove this method.
+     *
+     * @deprecated since sonata-project/media-bundle 3.x, to be removed in 4.0.
+     */
     public function getPager(array $criteria, $page, $limit = 10, array $sort = [])
     {
         $query = $this->getRepository()

--- a/src/Extra/ApiMediaFile.php
+++ b/src/Extra/ApiMediaFile.php
@@ -16,7 +16,9 @@ namespace Sonata\MediaBundle\Extra;
 use Symfony\Component\HttpFoundation\File\File;
 
 /**
- * @final since sonata-project/media-bundle 3.21.0
+ * NEXT_MAJOR: Remove this file.
+ *
+ * @deprecated since sonata-project/media-bundle 3.x, to be removed in 4.0.
  */
 class ApiMediaFile extends File
 {

--- a/src/Form/Type/ApiDoctrineMediaType.php
+++ b/src/Form/Type/ApiDoctrineMediaType.php
@@ -16,7 +16,9 @@ namespace Sonata\MediaBundle\Form\Type;
 use Sonata\Form\Type\BaseDoctrineORMSerializationType;
 
 /**
- * @final since sonata-project/media-bundle 3.21.0
+ * NEXT_MAJOR: Remove this file.
+ *
+ * @deprecated since sonata-project/media-bundle 3.x, to be removed in 4.0.
  */
 class ApiDoctrineMediaType extends BaseDoctrineORMSerializationType
 {

--- a/src/Form/Type/ApiGalleryHasMediaType.php
+++ b/src/Form/Type/ApiGalleryHasMediaType.php
@@ -16,7 +16,9 @@ namespace Sonata\MediaBundle\Form\Type;
 use Sonata\Form\Type\BaseDoctrineORMSerializationType;
 
 /**
- * @final since sonata-project/media-bundle 3.21.0
+ * NEXT_MAJOR: Remove this file.
+ *
+ * @deprecated since sonata-project/media-bundle 3.x, to be removed in 4.0.
  */
 class ApiGalleryHasMediaType extends BaseDoctrineORMSerializationType
 {

--- a/src/Form/Type/ApiGalleryType.php
+++ b/src/Form/Type/ApiGalleryType.php
@@ -16,7 +16,9 @@ namespace Sonata\MediaBundle\Form\Type;
 use Sonata\Form\Type\BaseDoctrineORMSerializationType;
 
 /**
- * @final since sonata-project/media-bundle 3.21.0
+ * NEXT_MAJOR: Remove this file.
+ *
+ * @deprecated since sonata-project/media-bundle 3.x, to be removed in 4.0.
  */
 class ApiGalleryType extends BaseDoctrineORMSerializationType
 {

--- a/src/Form/Type/ApiMediaType.php
+++ b/src/Form/Type/ApiMediaType.php
@@ -24,9 +24,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
- * @final since sonata-project/media-bundle 3.21.0
+ * NEXT_MAJOR: Remove this file.
  *
  * @author Hugo Briand <briand@ekino.com>
+ *
+ * @deprecated since sonata-project/media-bundle 3.x, to be removed in 4.0.
  */
 class ApiMediaType extends AbstractType implements LoggerAwareInterface
 {

--- a/src/Model/GalleryManagerInterface.php
+++ b/src/Model/GalleryManagerInterface.php
@@ -16,6 +16,9 @@ namespace Sonata\MediaBundle\Model;
 use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\Doctrine\Model\PageableManagerInterface;
 
+/**
+ * NEXT_MAJOR: Remove PageableManagerInterface extension.
+ */
 interface GalleryManagerInterface extends ManagerInterface, PageableManagerInterface
 {
 }

--- a/src/Model/MediaManagerInterface.php
+++ b/src/Model/MediaManagerInterface.php
@@ -16,6 +16,9 @@ namespace Sonata\MediaBundle\Model;
 use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\Doctrine\Model\PageableManagerInterface;
 
+/**
+ * NEXT_MAJOR: Remove PageableManagerInterface extension.
+ */
 interface MediaManagerInterface extends ManagerInterface, PageableManagerInterface
 {
 }

--- a/src/Serializer/GallerySerializerHandler.php
+++ b/src/Serializer/GallerySerializerHandler.php
@@ -16,9 +16,13 @@ namespace Sonata\MediaBundle\Serializer;
 use Sonata\Form\Serializer\BaseSerializerHandler;
 
 /**
+ * NEXT_MAJOR: Remove this file and the serializer configuration for Gallery.
+ *
  * @final since sonata-project/media-bundle 3.21.0
  *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
+ *
+ * @deprecated since sonata-project/media-bundle 3.x, to be removed in 4.0.
  */
 class GallerySerializerHandler extends BaseSerializerHandler
 {

--- a/src/Serializer/MediaSerializerHandler.php
+++ b/src/Serializer/MediaSerializerHandler.php
@@ -16,9 +16,13 @@ namespace Sonata\MediaBundle\Serializer;
 use Sonata\Form\Serializer\BaseSerializerHandler;
 
 /**
+ * NEXT_MAJOR: Remove this file and the serializer configuration for Media.
+ *
  * @final since sonata-project/media-bundle 3.21.0
  *
  * @author Sylvain Deloux <sylvain.deloux@ekino.com>
+ *
+ * @deprecated since sonata-project/media-bundle 3.x, to be removed in 4.0.
  */
 class MediaSerializerHandler extends BaseSerializerHandler
 {

--- a/tests/Controller/Api/GalleryControllerTest.php
+++ b/tests/Controller/Api/GalleryControllerTest.php
@@ -30,7 +30,11 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
+ * NEXT_MAJOR: Remove this class.
+ *
  * @author Hugo Briand <briand@ekino.com>
+ *
+ * @group legacy
  */
 class GalleryControllerTest extends TestCase
 {

--- a/tests/Controller/Api/MediaControllerTest.php
+++ b/tests/Controller/Api/MediaControllerTest.php
@@ -28,7 +28,11 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
+ * NEXT_MAJOR: Remove this class.
+ *
  * @author Hugo Briand <briand@ekino.com>
+ *
+ * @group legacy
  */
 class MediaControllerTest extends TestCase
 {

--- a/tests/Entity/GalleryManagerTest.php
+++ b/tests/Entity/GalleryManagerTest.php
@@ -21,7 +21,11 @@ use Sonata\MediaBundle\Entity\BaseGallery;
 use Sonata\MediaBundle\Entity\GalleryManager;
 
 /**
+ * NEXT_MAJOR: Remove this class.
+ *
  * @author Benoit de Jacobet <benoit.de-jacobet@ekino.com>
+ *
+ * @group legacy
  */
 class GalleryManagerTest extends TestCase
 {

--- a/tests/Entity/MediaManagerTest.php
+++ b/tests/Entity/MediaManagerTest.php
@@ -21,7 +21,11 @@ use Sonata\MediaBundle\Entity\BaseMedia;
 use Sonata\MediaBundle\Entity\MediaManager;
 
 /**
+ * NEXT_MAJOR: Remove this class.
+ *
  * @author Benoit de Jacobet <benoit.de-jacobet@ekino.com>
+ *
+ * @group legacy
  */
 class MediaManagerTest extends TestCase
 {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated ReST API with FOSRest, Nelmio Api Docs and JMS Serializer.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
