### PR TITLE
Fix deprecations from Symfony 5.4 typing system

### DIFF
--- a/src/Controller/GalleryAdminController.php
+++ b/src/Controller/GalleryAdminController.php
@@ -49,8 +49,8 @@ final class GalleryAdminController extends CRUDController
 
         $this->setFormTheme($formView, $this->admin->getFilterTheme());
 
-        if ($this->has('sonata.admin.admin_exporter')) {
-            $exporter = $this->get('sonata.admin.admin_exporter');
+        if ($this->container->has('sonata.admin.admin_exporter')) {
+            $exporter = $this->container->get('sonata.admin.admin_exporter');
             \assert($exporter instanceof AdminExporter);
             $exportFormats = $exporter->getAvailableFormats($this->admin);
         }

--- a/src/Controller/MediaAdminController.php
+++ b/src/Controller/MediaAdminController.php
@@ -40,7 +40,7 @@ final class MediaAdminController extends CRUDController
         $this->admin->checkAccess('create');
 
         if (null === $request->get('provider') && $request->isMethod('get')) {
-            $pool = $this->get('sonata.media.pool');
+            $pool = $this->container->get('sonata.media.pool');
             \assert($pool instanceof Pool);
 
             return $this->renderWithExtraParams('@SonataMedia/MediaAdmin/select_provider.html.twig', [
@@ -73,7 +73,7 @@ final class MediaAdminController extends CRUDController
 
         // set the default context
         if ([] === $filters || !\array_key_exists('context', $filters)) {
-            $pool = $this->get('sonata.media.pool');
+            $pool = $this->container->get('sonata.media.pool');
             \assert($pool instanceof Pool);
 
             $context = $this->admin->getPersistentParameter('context') ?? $pool->getDefaultContext();
@@ -84,10 +84,13 @@ final class MediaAdminController extends CRUDController
         $datagrid->setValue('context', null, $context);
 
         $rootCategory = null;
-        if ($this->has('sonata.media.manager.category') && $this->has('sonata.media.manager.context')) {
-            $categoryManager = $this->get('sonata.media.manager.category');
+        if (
+            $this->container->has('sonata.media.manager.category') &&
+            $this->container->has('sonata.media.manager.context')
+        ) {
+            $categoryManager = $this->container->get('sonata.media.manager.category');
             \assert($categoryManager instanceof CategoryManagerInterface);
-            $contextManager = $this->get('sonata.media.manager.context');
+            $contextManager = $this->container->get('sonata.media.manager.context');
             \assert($contextManager instanceof ContextManagerInterface);
 
             $rootCategories = $categoryManager->getRootCategoriesForContext($contextManager->find($context));
@@ -118,8 +121,8 @@ final class MediaAdminController extends CRUDController
 
         $this->setFormTheme($formView, $this->admin->getFilterTheme());
 
-        if ($this->has('sonata.admin.admin_exporter')) {
-            $exporter = $this->get('sonata.admin.admin_exporter');
+        if ($this->container->has('sonata.admin.admin_exporter')) {
+            $exporter = $this->container->get('sonata.admin.admin_exporter');
             \assert($exporter instanceof AdminExporter);
             $exportFormats = $exporter->getAvailableFormats($this->admin);
         }

--- a/src/Filesystem/Replicate.php
+++ b/src/Filesystem/Replicate.php
@@ -17,6 +17,7 @@ use Gaufrette\Adapter;
 use Gaufrette\Adapter\FileFactory;
 use Gaufrette\Adapter\MetadataSupporter;
 use Gaufrette\Adapter\StreamFactory;
+use Gaufrette\File;
 use Gaufrette\Filesystem;
 use Gaufrette\Stream;
 use Psr\Log\LoggerInterface;
@@ -46,7 +47,7 @@ final class Replicate implements Adapter, FileFactory, StreamFactory, MetadataSu
         $this->logger = $logger ?? new NullLogger();
     }
 
-    public function delete($key)
+    public function delete($key): bool
     {
         $ok = true;
 
@@ -69,6 +70,9 @@ final class Replicate implements Adapter, FileFactory, StreamFactory, MetadataSu
         return $ok;
     }
 
+    /**
+     * @return int|bool
+     */
     public function mtime($key)
     {
         return $this->primary->mtime($key);
@@ -77,16 +81,19 @@ final class Replicate implements Adapter, FileFactory, StreamFactory, MetadataSu
     /**
      * @return string[]
      */
-    public function keys()
+    public function keys(): array
     {
         return $this->primary->keys();
     }
 
-    public function exists($key)
+    public function exists($key): bool
     {
         return $this->primary->exists($key);
     }
 
+    /**
+     * @return int|bool
+     */
     public function write($key, $content)
     {
         $ok = true;
@@ -111,12 +118,15 @@ final class Replicate implements Adapter, FileFactory, StreamFactory, MetadataSu
         return $ok && false !== $return;
     }
 
+    /**
+     * @return string|bool
+     */
     public function read($key)
     {
         return $this->primary->read($key);
     }
 
-    public function rename($sourceKey, $targetKey)
+    public function rename($sourceKey, $targetKey): bool
     {
         $ok = true;
 
@@ -192,7 +202,7 @@ final class Replicate implements Adapter, FileFactory, StreamFactory, MetadataSu
         ];
     }
 
-    public function createFile($key, Filesystem $filesystem)
+    public function createFile($key, Filesystem $filesystem): File
     {
         if ($this->primary instanceof FileFactory) {
             return $this->primary->createFile($key, $filesystem);
@@ -207,10 +217,8 @@ final class Replicate implements Adapter, FileFactory, StreamFactory, MetadataSu
 
     /**
      * @param string $key
-     *
-     * @return Stream
      */
-    public function createStream($key)
+    public function createStream($key): Stream
     {
         if ($this->primary instanceof StreamFactory) {
             return $this->primary->createStream($key);
@@ -241,7 +249,7 @@ final class Replicate implements Adapter, FileFactory, StreamFactory, MetadataSu
         return $this->primary->listDirectory($directory);
     }
 
-    public function isDirectory($key)
+    public function isDirectory($key): bool
     {
         return $this->primary->isDirectory($key);
     }

--- a/src/Form/DataTransformer/ProviderDataTransformer.php
+++ b/src/Form/DataTransformer/ProviderDataTransformer.php
@@ -53,6 +53,9 @@ final class ProviderDataTransformer implements DataTransformerInterface, LoggerA
         $this->class = $class;
     }
 
+    /**
+     * @return mixed
+     */
     public function transform($value)
     {
         if (null === $value) {
@@ -62,6 +65,9 @@ final class ProviderDataTransformer implements DataTransformerInterface, LoggerA
         return $value;
     }
 
+    /**
+     * @return mixed
+     */
     public function reverseTransform($value)
     {
         if (!$value instanceof MediaInterface) {

--- a/src/Form/DataTransformer/ServiceProviderDataTransformer.php
+++ b/src/Form/DataTransformer/ServiceProviderDataTransformer.php
@@ -34,11 +34,17 @@ final class ServiceProviderDataTransformer implements DataTransformerInterface, 
         $this->provider = $provider;
     }
 
+    /**
+     * @return mixed
+     */
     public function transform($value)
     {
         return $value;
     }
 
+    /**
+     * @return mixed
+     */
     public function reverseTransform($value)
     {
         if (!$value instanceof MediaInterface) {

--- a/src/Form/Type/ApiMediaType.php
+++ b/src/Form/Type/ApiMediaType.php
@@ -71,12 +71,12 @@ final class ApiMediaType extends AbstractType implements LoggerAwareInterface
         ]);
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return ApiDoctrineMediaType::class;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sonata_media_api_form_media';
     }

--- a/src/Form/Type/MediaType.php
+++ b/src/Form/Type/MediaType.php
@@ -105,12 +105,12 @@ final class MediaType extends AbstractType implements LoggerAwareInterface
             ->setAllowedValues('context', array_keys($this->pool->getContexts()));
     }
 
-    public function getParent()
+    public function getParent(): ?string
     {
         return FormType::class;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sonata_media_type';
     }

--- a/src/Listener/ODM/MediaEventSubscriber.php
+++ b/src/Listener/ODM/MediaEventSubscriber.php
@@ -21,7 +21,7 @@ use Sonata\MediaBundle\Model\MediaInterface;
 
 final class MediaEventSubscriber extends BaseMediaEventSubscriber
 {
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         return [
             Events::prePersist,

--- a/src/Listener/ORM/MediaEventSubscriber.php
+++ b/src/Listener/ORM/MediaEventSubscriber.php
@@ -41,7 +41,7 @@ final class MediaEventSubscriber extends BaseMediaEventSubscriber
         $this->categoryManager = $categoryManager;
     }
 
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         return [
             Events::prePersist,

--- a/src/Twig/TokenParser/MediaTokenParser.php
+++ b/src/Twig/TokenParser/MediaTokenParser.php
@@ -15,6 +15,7 @@ namespace Sonata\MediaBundle\Twig\TokenParser;
 
 use Sonata\MediaBundle\Twig\Node\MediaNode;
 use Twig\Node\Expression\ArrayExpression;
+use Twig\Node\Node;
 use Twig\Token;
 use Twig\TokenParser\AbstractTokenParser;
 
@@ -38,7 +39,7 @@ final class MediaTokenParser extends AbstractTokenParser
      *
      * @see https://github.com/twigphp/Twig/issues/3443
      */
-    public function parse(Token $token)
+    public function parse(Token $token): Node
     {
         $media = $this->parser->getExpressionParser()->parseExpression();
 
@@ -60,7 +61,7 @@ final class MediaTokenParser extends AbstractTokenParser
         return new MediaNode($this->extensionName, $media, $format, $attributes, $token->getLine(), $this->getTag());
     }
 
-    public function getTag()
+    public function getTag(): string
     {
         return 'media';
     }

--- a/src/Twig/TokenParser/PathTokenParser.php
+++ b/src/Twig/TokenParser/PathTokenParser.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\MediaBundle\Twig\TokenParser;
 
 use Sonata\MediaBundle\Twig\Node\PathNode;
+use Twig\Node\Node;
 use Twig\Token;
 use Twig\TokenParser\AbstractTokenParser;
 
@@ -37,7 +38,7 @@ final class PathTokenParser extends AbstractTokenParser
      *
      * @see https://github.com/twigphp/Twig/issues/3443
      */
-    public function parse(Token $token)
+    public function parse(Token $token): Node
     {
         $media = $this->parser->getExpressionParser()->parseExpression();
 
@@ -50,7 +51,7 @@ final class PathTokenParser extends AbstractTokenParser
         return new PathNode($this->extensionName, $media, $format, $token->getLine(), $this->getTag());
     }
 
-    public function getTag()
+    public function getTag(): string
     {
         return 'path';
     }

--- a/src/Twig/TokenParser/ThumbnailTokenParser.php
+++ b/src/Twig/TokenParser/ThumbnailTokenParser.php
@@ -15,6 +15,7 @@ namespace Sonata\MediaBundle\Twig\TokenParser;
 
 use Sonata\MediaBundle\Twig\Node\ThumbnailNode;
 use Twig\Node\Expression\ArrayExpression;
+use Twig\Node\Node;
 use Twig\Token;
 use Twig\TokenParser\AbstractTokenParser;
 
@@ -38,7 +39,7 @@ final class ThumbnailTokenParser extends AbstractTokenParser
      *
      * @see https://github.com/twigphp/Twig/issues/3443
      */
-    public function parse(Token $token)
+    public function parse(Token $token): Node
     {
         $media = $this->parser->getExpressionParser()->parseExpression();
 
@@ -60,7 +61,7 @@ final class ThumbnailTokenParser extends AbstractTokenParser
         return new ThumbnailNode($this->extensionName, $media, $format, $attributes, $token->getLine(), $this->getTag());
     }
 
-    public function getTag()
+    public function getTag(): string
     {
         return 'thumbnail';
     }

--- a/src/Validator/Constraints/ValidMediaFormat.php
+++ b/src/Validator/Constraints/ValidMediaFormat.php
@@ -30,6 +30,9 @@ final class ValidMediaFormat extends Constraint
         return 'sonata.media.validator.format';
     }
 
+    /**
+     * @return string|string[]
+     */
     public function getTargets()
     {
         return self::CLASS_CONSTRAINT;

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -43,7 +43,7 @@ final class AppKernel extends Kernel
         parent::__construct('test', false);
     }
 
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
         return [
             new DoctrineBundle(),

--- a/tests/Filesystem/ReplicateTest.php
+++ b/tests/Filesystem/ReplicateTest.php
@@ -53,7 +53,7 @@ class ReplicateTest extends TestCase
         $slave->expects(static::once())->method('rename');
         $replicate->rename('foo', 'bar');
 
-        $master->expects(static::once())->method('isDirectory');
+        $master->expects(static::once())->method('isDirectory')->willReturn(true);
         $slave->expects(static::never())->method('isDirectory');
         $replicate->isDirectory('foo');
     }

--- a/tests/Provider/DailyMotionProviderTest.php
+++ b/tests/Provider/DailyMotionProviderTest.php
@@ -258,7 +258,7 @@ class DailyMotionProviderTest extends AbstractProviderTest
     {
         $this->formBuilder->expects(static::exactly(8))
             ->method('add')
-            ->willReturn(null);
+            ->willReturnSelf();
 
         $this->provider->buildCreateForm($this->form);
         $this->provider->buildEditForm($this->form);

--- a/tests/Provider/VimeoProviderTest.php
+++ b/tests/Provider/VimeoProviderTest.php
@@ -262,7 +262,7 @@ class VimeoProviderTest extends AbstractProviderTest
     {
         $this->formBuilder->expects(static::exactly(8))
             ->method('add')
-            ->willReturn(null);
+            ->willReturnSelf();
 
         $this->provider->buildCreateForm($this->form);
         $this->provider->buildEditForm($this->form);

--- a/tests/Provider/YouTubeProviderTest.php
+++ b/tests/Provider/YouTubeProviderTest.php
@@ -267,7 +267,7 @@ class YouTubeProviderTest extends AbstractProviderTest
     {
         $this->formBuilder->expects(static::exactly(8))
             ->method('add')
-            ->willReturn(null);
+            ->willReturnSelf();
 
         $this->provider->buildCreateForm($this->form);
         $this->provider->buildEditForm($this->form);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC break on 3.x.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Deprecations shown on Symfony 5.4
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
