### PR TITLE
Make FeatureMediaBlockService not extend from MediaBlockService

### DIFF
--- a/src/Block/FeatureMediaBlockService.php
+++ b/src/Block/FeatureMediaBlockService.php
@@ -22,10 +22,10 @@ use Sonata\BlockBundle\Form\Mapper\FormMapper;
 use Sonata\BlockBundle\Meta\Metadata;
 use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
-use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\Form\Type\ImmutableArrayType;
 use Sonata\Form\Validator\ErrorElement;
 use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
@@ -51,19 +51,18 @@ final class FeatureMediaBlockService extends AbstractBlockService implements Edi
     private $mediaAdmin;
 
     /**
-     * @var ManagerInterface<MediaInterface>
+     * @var MediaManagerInterface
      */
     private $mediaManager;
 
     /**
-     * @param AdminInterface<MediaInterface>   $mediaAdmin
-     * @param ManagerInterface<MediaInterface> $mediaManager
+     * @param AdminInterface<MediaInterface> $mediaAdmin
      */
     public function __construct(
         Environment $twig,
         Pool $pool,
         AdminInterface $mediaAdmin,
-        ManagerInterface $mediaManager
+        MediaManagerInterface $mediaManager
     ) {
         parent::__construct($twig);
 

--- a/src/Block/FeatureMediaBlockService.php
+++ b/src/Block/FeatureMediaBlockService.php
@@ -13,22 +13,65 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Block;
 
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Form\Type\ModelListType;
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
+use Sonata\BlockBundle\Block\Service\EditableBlockService;
 use Sonata\BlockBundle\Form\Mapper\FormMapper;
 use Sonata\BlockBundle\Meta\Metadata;
 use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\Form\Type\ImmutableArrayType;
 use Sonata\Form\Validator\ErrorElement;
+use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Twig\Environment;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-final class FeatureMediaBlockService extends MediaBlockService
+final class FeatureMediaBlockService extends AbstractBlockService implements EditableBlockService
 {
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    /**
+     * @var AdminInterface<MediaInterface>
+     */
+    private $mediaAdmin;
+
+    /**
+     * @var ManagerInterface<MediaInterface>
+     */
+    private $mediaManager;
+
+    /**
+     * @param AdminInterface<MediaInterface>   $mediaAdmin
+     * @param ManagerInterface<MediaInterface> $mediaManager
+     */
+    public function __construct(
+        Environment $twig,
+        Pool $pool,
+        AdminInterface $mediaAdmin,
+        ManagerInterface $mediaManager
+    ) {
+        parent::__construct($twig);
+
+        $this->pool = $pool;
+        $this->mediaAdmin = $mediaAdmin;
+        $this->mediaManager = $mediaManager;
+    }
+
     public function configureSettings(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
@@ -91,14 +134,59 @@ final class FeatureMediaBlockService extends MediaBlockService
         ]);
     }
 
-    /**
-     * @return string[]
-     */
-    public function getStylesheets(string $media): array
+    public function configureCreateForm(FormMapper $form, BlockInterface $block): void
     {
-        return [
-            '/bundles/sonatamedia/blocks/feature_media/theme.css',
-        ];
+        $this->configureEditForm($form, $block);
+    }
+
+    public function execute(BlockContextInterface $blockContext, ?Response $response = null): Response
+    {
+        // make sure we have a valid format
+        $media = $blockContext->getBlock()->getSetting('mediaId');
+
+        if ($media instanceof MediaInterface) {
+            $choices = $this->getFormatChoices($media);
+
+            if (!\array_key_exists($blockContext->getSetting('format'), $choices)) {
+                $blockContext->setSetting('format', key($choices));
+            }
+        }
+
+        $template = $blockContext->getTemplate();
+        \assert(\is_string($template));
+
+        return $this->renderResponse($template, [
+            'media' => $blockContext->getSetting('mediaId'),
+            'block' => $blockContext->getBlock(),
+            'settings' => $blockContext->getSettings(),
+        ], $response);
+    }
+
+    public function load(BlockInterface $block): void
+    {
+        $mediaId = $block->getSetting('mediaId');
+
+        if (null === $mediaId || $mediaId instanceof MediaInterface) {
+            return;
+        }
+
+        $media = $this->mediaManager->findOneBy(['id' => $mediaId]);
+
+        if (null === $media) {
+            return;
+        }
+
+        $block->setSetting('mediaId', $media);
+    }
+
+    public function prePersist(BlockInterface $block): void
+    {
+        $block->setSetting('mediaId', $block->getSetting('mediaId') instanceof MediaInterface ? $block->getSetting('mediaId')->getId() : null);
+    }
+
+    public function preUpdate(BlockInterface $block): void
+    {
+        $block->setSetting('mediaId', $block->getSetting('mediaId') instanceof MediaInterface ? $block->getSetting('mediaId')->getId() : null);
     }
 
     public function getMetadata(): MetadataInterface
@@ -110,5 +198,45 @@ final class FeatureMediaBlockService extends MediaBlockService
 
     public function validate(ErrorElement $errorElement, BlockInterface $block): void
     {
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getFormatChoices(?MediaInterface $media = null): array
+    {
+        if (!$media instanceof MediaInterface) {
+            return [];
+        }
+
+        $context = $media->getContext();
+
+        if (null === $context || !$this->pool->hasContext($context)) {
+            return [];
+        }
+
+        $formatChoices = [];
+        $formats = $this->pool->getFormatNamesByContext($context);
+
+        foreach ($formats as $code => $format) {
+            $formatChoices[$code] = $code;
+        }
+
+        return $formatChoices;
+    }
+
+    private function getMediaBuilder(FormMapper $form): FormBuilderInterface
+    {
+        $fieldDescription = $this->mediaAdmin->createFieldDescription('media', [
+            'translation_domain' => 'SonataMediaBundle',
+            'edit' => 'list',
+        ]);
+
+        return $form->create('mediaId', ModelListType::class, [
+            'sonata_field_description' => $fieldDescription,
+            'class' => $this->mediaAdmin->getClass(),
+            'model_manager' => $this->mediaAdmin->getModelManager(),
+            'label' => 'form.label_media',
+        ]);
     }
 }

--- a/src/Block/GalleryBlockService.php
+++ b/src/Block/GalleryBlockService.php
@@ -183,10 +183,16 @@ final class GalleryBlockService extends AbstractBlockService implements Editable
 
     public function load(BlockInterface $block): void
     {
-        $gallery = $block->getSetting('galleryId');
+        $galleryId = $block->getSetting('galleryId');
 
-        if (null !== $gallery) {
-            $gallery = $this->galleryManager->findOneBy(['id' => $gallery]);
+        if (null === $galleryId || $galleryId instanceof GalleryInterface) {
+            return;
+        }
+
+        $gallery = $this->galleryManager->findOneBy(['id' => $galleryId]);
+
+        if (null === $gallery) {
+            return;
         }
 
         $block->setSetting('galleryId', $gallery);

--- a/src/Block/GalleryBlockService.php
+++ b/src/Block/GalleryBlockService.php
@@ -22,10 +22,10 @@ use Sonata\BlockBundle\Form\Mapper\FormMapper;
 use Sonata\BlockBundle\Meta\Metadata;
 use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
-use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\Form\Type\ImmutableArrayType;
 use Sonata\Form\Validator\ErrorElement;
 use Sonata\MediaBundle\Model\GalleryInterface;
+use Sonata\MediaBundle\Model\GalleryManagerInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
@@ -52,19 +52,18 @@ final class GalleryBlockService extends AbstractBlockService implements Editable
     private $galleryAdmin;
 
     /**
-     * @var ManagerInterface<GalleryInterface>
+     * @var GalleryManagerInterface
      */
     private $galleryManager;
 
     /**
-     * @param AdminInterface<GalleryInterface>   $galleryAdmin
-     * @param ManagerInterface<GalleryInterface> $galleryManager
+     * @param AdminInterface<GalleryInterface> $galleryAdmin
      */
     public function __construct(
         Environment $twig,
         Pool $pool,
         AdminInterface $galleryAdmin,
-        ManagerInterface $galleryManager
+        GalleryManagerInterface $galleryManager
     ) {
         parent::__construct($twig);
 

--- a/src/Block/MediaBlockService.php
+++ b/src/Block/MediaBlockService.php
@@ -22,10 +22,10 @@ use Sonata\BlockBundle\Form\Mapper\FormMapper;
 use Sonata\BlockBundle\Meta\Metadata;
 use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
-use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\Form\Type\ImmutableArrayType;
 use Sonata\Form\Validator\ErrorElement;
 use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -50,19 +50,18 @@ final class MediaBlockService extends AbstractBlockService implements EditableBl
     private $mediaAdmin;
 
     /**
-     * @var ManagerInterface<MediaInterface>
+     * @var MediaManagerInterface
      */
     private $mediaManager;
 
     /**
-     * @param AdminInterface<MediaInterface>   $mediaAdmin
-     * @param ManagerInterface<MediaInterface> $mediaManager
+     * @param AdminInterface<MediaInterface> $mediaAdmin
      */
     public function __construct(
         Environment $twig,
         Pool $pool,
         AdminInterface $mediaAdmin,
-        ManagerInterface $mediaManager
+        MediaManagerInterface $mediaManager
     ) {
         parent::__construct($twig);
 

--- a/src/Block/MediaBlockService.php
+++ b/src/Block/MediaBlockService.php
@@ -37,22 +37,22 @@ use Twig\Environment;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class MediaBlockService extends AbstractBlockService implements EditableBlockService
+final class MediaBlockService extends AbstractBlockService implements EditableBlockService
 {
     /**
      * @var Pool
      */
-    protected $pool;
+    private $pool;
 
     /**
      * @var AdminInterface<MediaInterface>
      */
-    protected $mediaAdmin;
+    private $mediaAdmin;
 
     /**
      * @var ManagerInterface<MediaInterface>
      */
-    protected $mediaManager;
+    private $mediaManager;
 
     /**
      * @param AdminInterface<MediaInterface>   $mediaAdmin
@@ -148,10 +148,16 @@ class MediaBlockService extends AbstractBlockService implements EditableBlockSer
 
     public function load(BlockInterface $block): void
     {
-        $media = $block->getSetting('mediaId', null);
+        $mediaId = $block->getSetting('mediaId');
 
-        if (\is_int($media)) {
-            $media = $this->mediaManager->findOneBy(['id' => $media]);
+        if (null === $mediaId || $mediaId instanceof MediaInterface) {
+            return;
+        }
+
+        $media = $this->mediaManager->findOneBy(['id' => $mediaId]);
+
+        if (null === $media) {
+            return;
         }
 
         $block->setSetting('mediaId', $media);
@@ -186,7 +192,7 @@ class MediaBlockService extends AbstractBlockService implements EditableBlockSer
     /**
      * @return array<string, string>
      */
-    protected function getFormatChoices(?MediaInterface $media = null): array
+    private function getFormatChoices(?MediaInterface $media = null): array
     {
         if (!$media instanceof MediaInterface) {
             return [];
@@ -208,7 +214,7 @@ class MediaBlockService extends AbstractBlockService implements EditableBlockSer
         return $formatChoices;
     }
 
-    protected function getMediaBuilder(FormMapper $form): FormBuilderInterface
+    private function getMediaBuilder(FormMapper $form): FormBuilderInterface
     {
         $fieldDescription = $this->mediaAdmin->createFieldDescription('media', [
             'translation_domain' => 'SonataMediaBundle',

--- a/src/Command/AddMassMediaCommand.php
+++ b/src/Command/AddMassMediaCommand.php
@@ -14,8 +14,7 @@ declare(strict_types=1);
 namespace Sonata\MediaBundle\Command;
 
 use Sonata\Doctrine\Model\ClearableManagerInterface;
-use Sonata\Doctrine\Model\ManagerInterface;
-use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -27,7 +26,7 @@ final class AddMassMediaCommand extends Command
     protected static $defaultDescription = 'Add medias in mass into the database';
 
     /**
-     * @var ManagerInterface<MediaInterface>
+     * @var MediaManagerInterface
      */
     private $mediaManager;
 
@@ -37,11 +36,9 @@ final class AddMassMediaCommand extends Command
     private $setters = [];
 
     /**
-     * @param ManagerInterface<MediaInterface> $mediaManager
-     *
      * @internal This class should only be used through the console
      */
-    public function __construct(ManagerInterface $mediaManager)
+    public function __construct(MediaManagerInterface $mediaManager)
     {
         parent::__construct();
 

--- a/src/Command/AddMediaCommand.php
+++ b/src/Command/AddMediaCommand.php
@@ -13,8 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Command;
 
-use Sonata\Doctrine\Model\ManagerInterface;
-use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -27,16 +26,14 @@ final class AddMediaCommand extends Command
     protected static $defaultDescription = 'Add a media into the database';
 
     /**
-     * @var ManagerInterface<MediaInterface>
+     * @var MediaManagerInterface
      */
     private $mediaManager;
 
     /**
-     * @param ManagerInterface<MediaInterface> $mediaManager
-     *
      * @internal This class should only be used through the console
      */
-    public function __construct(ManagerInterface $mediaManager)
+    public function __construct(MediaManagerInterface $mediaManager)
     {
         parent::__construct();
 

--- a/src/Command/RefreshMetadataCommand.php
+++ b/src/Command/RefreshMetadataCommand.php
@@ -13,8 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Command;
 
-use Sonata\Doctrine\Model\ManagerInterface;
-use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Component\Console\Command\Command;
@@ -40,7 +39,7 @@ final class RefreshMetadataCommand extends Command
     private $mediaPool;
 
     /**
-     * @var ManagerInterface<MediaInterface>
+     * @var MediaManagerInterface
      */
     private $mediaManager;
 
@@ -60,11 +59,9 @@ final class RefreshMetadataCommand extends Command
     private $input;
 
     /**
-     * @param ManagerInterface<MediaInterface> $mediaManager
-     *
      * @internal This class should only be used through the console
      */
-    public function __construct(Pool $mediaPool, ManagerInterface $mediaManager)
+    public function __construct(Pool $mediaPool, MediaManagerInterface $mediaManager)
     {
         parent::__construct();
 

--- a/src/Command/RemoveThumbsCommand.php
+++ b/src/Command/RemoveThumbsCommand.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Command;
 
-use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Component\Console\Command\Command;
@@ -41,7 +41,7 @@ final class RemoveThumbsCommand extends Command
     private $mediaPool;
 
     /**
-     * @var ManagerInterface<MediaInterface>
+     * @var MediaManagerInterface
      */
     private $mediaManager;
 
@@ -61,11 +61,9 @@ final class RemoveThumbsCommand extends Command
     private $output;
 
     /**
-     * @param ManagerInterface<MediaInterface> $mediaManager
-     *
      * @internal This class should only be used through the console
      */
-    public function __construct(Pool $mediaPool, ManagerInterface $mediaManager)
+    public function __construct(Pool $mediaPool, MediaManagerInterface $mediaManager)
     {
         parent::__construct();
 

--- a/src/Command/SyncThumbsCommand.php
+++ b/src/Command/SyncThumbsCommand.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Sonata\MediaBundle\Command;
 
 use Sonata\Doctrine\Model\ClearableManagerInterface;
-use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Component\Console\Command\Command;
@@ -41,7 +41,7 @@ final class SyncThumbsCommand extends Command
     private $mediaPool;
 
     /**
-     * @var ManagerInterface<MediaInterface>
+     * @var MediaManagerInterface
      */
     private $mediaManager;
 
@@ -56,11 +56,9 @@ final class SyncThumbsCommand extends Command
     private $output;
 
     /**
-     * @param ManagerInterface<MediaInterface> $mediaManager
-     *
      * @internal This class should only be used through the console
      */
-    public function __construct(Pool $mediaPool, ManagerInterface $mediaManager)
+    public function __construct(Pool $mediaPool, MediaManagerInterface $mediaManager)
     {
         parent::__construct();
 

--- a/src/Command/UpdateCdnStatusCommand.php
+++ b/src/Command/UpdateCdnStatusCommand.php
@@ -13,9 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Command;
 
-use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\MediaBundle\CDN\CDNInterface;
-use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Component\Console\Command\Command;
@@ -41,7 +40,7 @@ final class UpdateCdnStatusCommand extends Command
     private $mediaPool;
 
     /**
-     * @var ManagerInterface<MediaInterface>
+     * @var MediaManagerInterface
      */
     private $mediaManager;
 
@@ -61,11 +60,9 @@ final class UpdateCdnStatusCommand extends Command
     private $input;
 
     /**
-     * @param ManagerInterface<MediaInterface> $mediaManager
-     *
      * @internal This class should only be used through the console
      */
-    public function __construct(Pool $mediaPool, ManagerInterface $mediaManager)
+    public function __construct(Pool $mediaPool, MediaManagerInterface $mediaManager)
     {
         parent::__construct();
 

--- a/src/Consumer/CreateThumbnailConsumer.php
+++ b/src/Consumer/CreateThumbnailConsumer.php
@@ -13,8 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Consumer;
 
-use Sonata\Doctrine\Model\ManagerInterface;
-use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Sonata\MediaBundle\Thumbnail\GenerableThumbnailInterface;
 use Sonata\NotificationBundle\Consumer\ConsumerEvent;
@@ -25,7 +24,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 final class CreateThumbnailConsumer implements ConsumerInterface
 {
     /**
-     * @var ManagerInterface<MediaInterface>
+     * @var MediaManagerInterface
      */
     private $mediaManager;
 
@@ -39,10 +38,7 @@ final class CreateThumbnailConsumer implements ConsumerInterface
      */
     private $container;
 
-    /**
-     * @param ManagerInterface<MediaInterface> $mediaManager
-     */
-    public function __construct(ManagerInterface $mediaManager, Pool $pool, ContainerInterface $container)
+    public function __construct(MediaManagerInterface $mediaManager, Pool $pool, ContainerInterface $container)
     {
         $this->mediaManager = $mediaManager;
         $this->pool = $pool;

--- a/src/Twig/Extension/MediaExtension.php
+++ b/src/Twig/Extension/MediaExtension.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Twig\Extension;
 
-use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Sonata\MediaBundle\Twig\TokenParser\MediaTokenParser;
 use Sonata\MediaBundle\Twig\TokenParser\PathTokenParser;
@@ -36,7 +36,7 @@ final class MediaExtension extends AbstractExtension
     private $resources = [];
 
     /**
-     * @var ManagerInterface<MediaInterface>
+     * @var MediaManagerInterface
      */
     private $mediaManager;
 
@@ -46,11 +46,9 @@ final class MediaExtension extends AbstractExtension
     private $twig;
 
     /**
-     * @param ManagerInterface<MediaInterface> $mediaManager
-     *
      * @internal This class should only be used through Twig
      */
-    public function __construct(Pool $mediaPool, ManagerInterface $mediaManager, Environment $twig)
+    public function __construct(Pool $mediaPool, MediaManagerInterface $mediaManager, Environment $twig)
     {
         $this->mediaPool = $mediaPool;
         $this->mediaManager = $mediaManager;

--- a/tests/Block/FeatureMediaBlockServiceTest.php
+++ b/tests/Block/FeatureMediaBlockServiceTest.php
@@ -15,8 +15,8 @@ namespace Sonata\MediaBundle\Tests\Block;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\BlockBundle\Test\BlockServiceTestCase;
-use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\MediaBundle\Block\FeatureMediaBlockService;
+use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Sonata\MediaBundle\Provider\Pool;
 
 class FeatureMediaBlockServiceTest extends BlockServiceTestCase
@@ -34,7 +34,7 @@ class FeatureMediaBlockServiceTest extends BlockServiceTestCase
             $this->twig,
             new Pool('default'),
             $this->createStub(AdminInterface::class),
-            $this->createStub(ManagerInterface::class)
+            $this->createStub(MediaManagerInterface::class)
         );
     }
 

--- a/tests/Block/GalleryBlockServiceTest.php
+++ b/tests/Block/GalleryBlockServiceTest.php
@@ -18,9 +18,9 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\Block;
 use Sonata\BlockBundle\Test\BlockServiceTestCase;
-use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\MediaBundle\Block\GalleryBlockService;
 use Sonata\MediaBundle\Model\GalleryInterface;
+use Sonata\MediaBundle\Model\GalleryManagerInterface;
 use Sonata\MediaBundle\Provider\Pool;
 
 class GalleryBlockServiceTest extends BlockServiceTestCase
@@ -38,7 +38,7 @@ class GalleryBlockServiceTest extends BlockServiceTestCase
             $this->twig,
             new Pool('default'),
             $this->createStub(AdminInterface::class),
-            $this->createStub(ManagerInterface::class)
+            $this->createStub(GalleryManagerInterface::class)
         );
     }
 

--- a/tests/Block/MediaBlockServiceTest.php
+++ b/tests/Block/MediaBlockServiceTest.php
@@ -18,9 +18,9 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\Block;
 use Sonata\BlockBundle\Test\BlockServiceTestCase;
-use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\MediaBundle\Block\MediaBlockService;
 use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Sonata\MediaBundle\Provider\Pool;
 
 class MediaBlockServiceTest extends BlockServiceTestCase
@@ -45,7 +45,7 @@ class MediaBlockServiceTest extends BlockServiceTestCase
             $this->twig,
             $this->pool,
             $this->createStub(AdminInterface::class),
-            $this->createStub(ManagerInterface::class)
+            $this->createStub(MediaManagerInterface::class)
         );
     }
 

--- a/tests/Twig/Extension/MediaExtensionTest.php
+++ b/tests/Twig/Extension/MediaExtensionTest.php
@@ -15,9 +15,9 @@ namespace Sonata\MediaBundle\Tests\Twig\Extension;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Sonata\Doctrine\Model\ManagerInterface;
 use Sonata\MediaBundle\Model\Media;
 use Sonata\MediaBundle\Model\MediaInterface;
+use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Sonata\MediaBundle\Twig\Extension\MediaExtension;
@@ -101,11 +101,11 @@ class MediaExtensionTest extends TestCase
     }
 
     /**
-     * @return MockObject&ManagerInterface<MediaInterface>
+     * @return MockObject&MediaManagerInterface
      */
     public function getMediaManager(): object
     {
-        return $this->createMock(ManagerInterface::class);
+        return $this->createMock(MediaManagerInterface::class);
     }
 
     /**


### PR DESCRIPTION
In the process, getStylesheet is removed since it is not used on
BlockBundle 4.0, and load is refactor to ensure we can load the
correct entity with its given id (not necessarily a integer).

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this breaks BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Changed `FeatureMediaBlockService` to not extend `MediaBlockService`.
- Changed `MediaBlockService` to be final.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
