### PR TITLE
Deprecate SonataNotificationBundle integration

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,12 @@ UPGRADE 3.x
 UPGRADE FROM 3.x to 3.x
 =======================
 
+### Deprecate Async processing with SonataNotificationBundle
+
+Integration with SonataNotificationBundle is deprecated. It was used for async processing of thumbnail generation.
+
+You can use the new integration with [Symfony Messenger](https://symfony.com/doc/current/messenger.html) instead.
+
 ### Deprecate API
 
 Integration with FOSRest, JMS Serializer and Nelmio Api Docs is deprecated, the ReST API provided with this bundle will be removed on 4.0.

--- a/src/Consumer/CreateThumbnailConsumer.php
+++ b/src/Consumer/CreateThumbnailConsumer.php
@@ -22,7 +22,9 @@ use Sonata\NotificationBundle\Exception\HandlingException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * @final since sonata-project/media-bundle 3.21.0
+ * NEXT_MAJOR: remove this file.
+ *
+ * @deprecated since sonata-project/media-bundle 3.x, to be removed in 4.0.
  */
 class CreateThumbnailConsumer implements ConsumerInterface
 {

--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -76,6 +76,7 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
             }
         }
 
+        // NEXT_MAJOR: Remove this condition and remove all configuration files related to this.
         if (isset($bundles['SonataNotificationBundle'])) {
             $loader->load('consumer.xml');
         }

--- a/src/Thumbnail/ConsumerThumbnail.php
+++ b/src/Thumbnail/ConsumerThumbnail.php
@@ -19,7 +19,9 @@ use Sonata\NotificationBundle\Backend\BackendInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
- * @final since sonata-project/media-bundle 3.21.0
+ * NEXT_MAJOR: remove this file.
+ *
+ * @deprecated since sonata-project/media-bundle 3.x, to be removed in 4.0.
  */
 class ConsumerThumbnail implements ThumbnailInterface
 {

--- a/tests/Thumbnail/ConsumerThumbnailTest.php
+++ b/tests/Thumbnail/ConsumerThumbnailTest.php
@@ -21,6 +21,11 @@ use Sonata\MediaBundle\Thumbnail\ThumbnailInterface;
 use Sonata\NotificationBundle\Backend\BackendInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+/**
+ * NEXT_MAJOR: Remove this class.
+ *
+ * @group legacy
+ */
 class ConsumerThumbnailTest extends TestCase
 {
     public function testGenerateDispatchesEvents(): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataMediaBundle/issues/2109

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated SonataNotificationBundle integration. Use Symfony Messenger integration instead.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
