### PR TITLE
Only load controllers if SonataAdminBundle is enabled

### DIFF
--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -52,7 +52,6 @@ final class SonataMediaExtension extends Extension implements PrependExtensionIn
         $loader->load('gaufrette.php');
         $loader->load('validators.php');
         $loader->load('commands.php');
-        $loader->load('controllers.php');
 
         $bundles = $container->getParameter('kernel.bundles');
         \assert(\is_array($bundles));
@@ -76,6 +75,7 @@ final class SonataMediaExtension extends Extension implements PrependExtensionIn
         $loader->load(sprintf('%s.php', $config['db_driver']));
 
         if (isset($bundles['SonataAdminBundle'])) {
+            $loader->load('controllers.php');
             $loader->load(sprintf('%s_admin.php', $config['db_driver']));
 
             $sonataRoles = [];

--- a/tests/DependencyInjection/SonataMediaExtensionTest.php
+++ b/tests/DependencyInjection/SonataMediaExtensionTest.php
@@ -19,7 +19,13 @@ use Imagine\Gd\Imagine as GdImagine;
 use Imagine\Gmagick\Imagine as GmagicImagine;
 use Imagine\Imagick\Imagine as ImagicImagine;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Sonata\MediaBundle\Admin\GalleryAdmin;
+use Sonata\MediaBundle\Admin\GalleryItemAdmin;
+use Sonata\MediaBundle\Admin\ODM\MediaAdmin as ODMMediaAdmin;
+use Sonata\MediaBundle\Admin\ORM\MediaAdmin as ORMMediaAdmin;
 use Sonata\MediaBundle\CDN\CloudFrontVersion3;
+use Sonata\MediaBundle\Controller\GalleryAdminController;
+use Sonata\MediaBundle\Controller\MediaAdminController;
 use Sonata\MediaBundle\DependencyInjection\SonataMediaExtension;
 use Sonata\MediaBundle\Messenger\GenerateThumbnailsHandler;
 use Sonata\MediaBundle\Resizer\SimpleResizer;
@@ -155,12 +161,36 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
 
     public function testLoadWithSonataAdminDefaults(): void
     {
-        $this->load();
+        $this->load(['db_driver' => 'no_driver']);
 
         static::assertSame(
             $this->container->getDefinition('sonata.media.security.superadmin_strategy')->getArgument(2),
             ['ROLE_ADMIN', 'ROLE_SUPER_ADMIN']
         );
+
+        $this->assertContainerBuilderHasService('sonata.media.controller.media.admin', MediaAdminController::class);
+        $this->assertContainerBuilderHasService('sonata.media.controller.gallery.admin', GalleryAdminController::class);
+        $this->assertContainerBuilderNotHasService('sonata.media.admin.media');
+        $this->assertContainerBuilderNotHasService('sonata.media.admin.gallery');
+        $this->assertContainerBuilderNotHasService('sonata.media.admin.gallery_item');
+    }
+
+    public function testLoadWithSonataAdminOrm(): void
+    {
+        $this->load(['db_driver' => 'doctrine_orm']);
+
+        $this->assertContainerBuilderHasService('sonata.media.admin.media', ORMMediaAdmin::class);
+        $this->assertContainerBuilderHasService('sonata.media.admin.gallery', GalleryAdmin::class);
+        $this->assertContainerBuilderHasService('sonata.media.admin.gallery_item', GalleryItemAdmin::class);
+    }
+
+    public function testLoadWithSonataAdminMongoDB(): void
+    {
+        $this->load(['db_driver' => 'doctrine_mongodb']);
+
+        $this->assertContainerBuilderHasService('sonata.media.admin.media', ODMMediaAdmin::class);
+        $this->assertContainerBuilderHasService('sonata.media.admin.gallery', GalleryAdmin::class);
+        $this->assertContainerBuilderHasService('sonata.media.admin.gallery_item', GalleryItemAdmin::class);
     }
 
     public function testLoadWithSonataAdminCustomConfiguration(): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this can only be fixed on 4.x.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #2143.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed load controllers only when SonataAdminBundle is enabled.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
