### PR TITLE
Fix with null media and add safe output for html

### DIFF
--- a/src/Twig/Extension/FormatterMediaExtension.php
+++ b/src/Twig/Extension/FormatterMediaExtension.php
@@ -151,8 +151,8 @@ class FormatterMediaExtension extends AbstractExtension implements ExtensionInte
     public function getFunctions()
     {
         return [
-            new TwigFunction('sonata_media', [MediaRuntime::class, 'media']),
-            new TwigFunction('sonata_thumbnail', [MediaRuntime::class, 'thumbnail']),
+            new TwigFunction('sonata_media', [MediaRuntime::class, 'media'], ['is_safe' => ['html']]),
+            new TwigFunction('sonata_thumbnail', [MediaRuntime::class, 'thumbnail'], ['is_safe' => ['html']]),
             new TwigFunction('sonata_path', [MediaRuntime::class, 'path']),
         ];
     }

--- a/src/Twig/Extension/MediaExtension.php
+++ b/src/Twig/Extension/MediaExtension.php
@@ -62,8 +62,8 @@ class MediaExtension extends AbstractExtension implements InitRuntimeInterface
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('sonata_media', [MediaRuntime::class, 'media']),
-            new TwigFunction('sonata_thumbnail', [MediaRuntime::class, 'thumbnail']),
+            new TwigFunction('sonata_media', [MediaRuntime::class, 'media'], ['is_safe' => ['html']]),
+            new TwigFunction('sonata_thumbnail', [MediaRuntime::class, 'thumbnail'], ['is_safe' => ['html']]),
             new TwigFunction('sonata_path', [MediaRuntime::class, 'path']),
         ];
     }

--- a/src/Twig/MediaRuntime.php
+++ b/src/Twig/MediaRuntime.php
@@ -47,8 +47,8 @@ final class MediaRuntime implements RuntimeExtensionInterface
     }
 
     /**
-     * @param int|string|MediaInterface $media
-     * @param array<string, mixed>      $options
+     * @param int|string|MediaInterface|null $media
+     * @param array<string, mixed>           $options
      */
     public function media($media, string $format, array $options = []): string
     {
@@ -78,8 +78,8 @@ final class MediaRuntime implements RuntimeExtensionInterface
     /**
      * Returns the thumbnail for the provided media.
      *
-     * @param MediaInterface|int|string $media
-     * @param array<string, mixed>      $options
+     * @param int|stringMediaInterface|null $media
+     * @param array<string, mixed>          $options
      */
     public function thumbnail($media, string $format, array $options = []): string
     {
@@ -122,7 +122,7 @@ final class MediaRuntime implements RuntimeExtensionInterface
     }
 
     /**
-     * @param MediaInterface|int|string $media
+     * @param int|string|MediaInterface|null $media
      */
     public function path($media, string $format): string
     {
@@ -140,11 +140,11 @@ final class MediaRuntime implements RuntimeExtensionInterface
     }
 
     /**
-     * @param MediaInterface|int|string $media
+     * @param int|string|MediaInterface|null $media
      */
     private function getMedia($media): ?MediaInterface
     {
-        if (!$media instanceof MediaInterface) {
+        if (!$media instanceof MediaInterface && null !== $media) {
             $media = $this->mediaManager->find($media);
         }
 

--- a/src/Twig/MediaRuntime.php
+++ b/src/Twig/MediaRuntime.php
@@ -78,7 +78,7 @@ final class MediaRuntime implements RuntimeExtensionInterface
     /**
      * Returns the thumbnail for the provided media.
      *
-     * @param int|stringMediaInterface|null $media
+     * @param int|string|MediaInterface|null $media
      * @param array<string, mixed>          $options
      */
     public function thumbnail($media, string $format, array $options = []): string

--- a/src/Twig/MediaRuntime.php
+++ b/src/Twig/MediaRuntime.php
@@ -79,7 +79,7 @@ final class MediaRuntime implements RuntimeExtensionInterface
      * Returns the thumbnail for the provided media.
      *
      * @param int|string|MediaInterface|null $media
-     * @param array<string, mixed>          $options
+     * @param array<string, mixed>           $options
      */
     public function thumbnail($media, string $format, array $options = []): string
     {

--- a/tests/Twig/Extension/MediaExtensionTest.php
+++ b/tests/Twig/Extension/MediaExtensionTest.php
@@ -23,6 +23,7 @@ use Sonata\MediaBundle\Tests\App\Entity\Media;
 use Sonata\MediaBundle\Twig\Extension\MediaExtension;
 use Sonata\MediaBundle\Twig\MediaRuntime;
 use Twig\Environment;
+use Twig\Node\Node;
 use Twig\TwigFunction;
 
 /**
@@ -74,6 +75,9 @@ class MediaExtensionTest extends TestCase
         static::assertSame([MediaRuntime::class, 'media'], $functions[0]->getCallable());
         static::assertSame([MediaRuntime::class, 'thumbnail'], $functions[1]->getCallable());
         static::assertSame([MediaRuntime::class, 'path'], $functions[2]->getCallable());
+
+        static::assertSame(['html'], $functions[0]->getSafe(new Node()));
+        static::assertSame(['html'], $functions[1]->getSafe(new Node()));
     }
 
     /**

--- a/tests/Twig/MediaRuntimeTest.php
+++ b/tests/Twig/MediaRuntimeTest.php
@@ -62,6 +62,13 @@ class MediaRuntimeTest extends TestCase
         $this->mediaRuntime = new MediaRuntime($this->pool, $this->mediaManager, $this->twig);
     }
 
+    public function testWithNullInput(): void
+    {
+        static::assertSame('', $this->mediaRuntime->media(null, 'big'));
+        static::assertSame('', $this->mediaRuntime->thumbnail(null, 'big'));
+        static::assertSame('', $this->mediaRuntime->path(null, 'big'));
+    }
+
     public function testWithNonMediaInput(): void
     {
         $media = new Media();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is bug fixing.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed safe output of `sonata_media` and `sonata_thumbnail` functions
- Fixed calling `sonata_media` and `sonata_thumbnail` functions with null media
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
