### PR TITLE
Fix issue when generating public URL for reference with FileProvider

### DIFF
--- a/src/Provider/FileProvider.php
+++ b/src/Provider/FileProvider.php
@@ -194,7 +194,7 @@ class FileProvider extends BaseProvider implements FileProviderInterface
     public function generatePublicUrl(MediaInterface $media, string $format): string
     {
         if (MediaProviderInterface::FORMAT_REFERENCE === $format) {
-            $this->getCdn()->getPath($this->getReferenceImage($media), $media->getCdnIsFlushable());
+            return $this->getCdn()->getPath($this->getReferenceImage($media), $media->getCdnIsFlushable());
         }
 
         return $this->thumbnail->generatePublicUrl($this, $media, $format);

--- a/tests/Provider/FileProviderTest.php
+++ b/tests/Provider/FileProviderTest.php
@@ -78,6 +78,7 @@ class FileProviderTest extends AbstractProviderTest
         static::assertSame('default/0011/24/ASDASD.txt', $this->provider->getReferenceImage($media));
         static::assertSame('default/0011/24', $this->provider->generatePath($media));
         static::assertSame('/bundles/sonatamedia/file.png', $this->provider->generatePublicUrl($media, 'admin'));
+        static::assertSame('/uploads/media/default/0011/24/ASDASD.txt', $this->provider->generatePublicUrl($media, 'reference'));
     }
 
     public function testHelperProperties(): void


### PR DESCRIPTION
## Subject

I am targeting this branch, because this can only be fixed on 4.x.

Closes issue https://github.com/sonata-project/SonataMediaBundle/issues/2155


## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Missing CDN part when generating public URL for FileProvider with reference format
```