### PR TITLE
Make cdnIsFlushable non nullable

### DIFF
--- a/src/Resources/config/doctrine/BaseMedia.orm.xml
+++ b/src/Resources/config/doctrine/BaseMedia.orm.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping                           http://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
     <mapped-superclass name="Sonata\MediaBundle\Entity\BaseMedia">
-        <field name="name" column="name" type="string" nullable="false" length="255"/>
+        <field name="name" column="name" type="string" length="255"/>
         <field name="description" column="description" type="text" nullable="true" length="1024"/>
-        <field name="enabled" column="enabled" type="boolean" nullable="false"/>
-        <field name="providerName" column="provider_name" type="string" nullable="false" length="255"/>
-        <field name="providerStatus" column="provider_status" type="integer" nullable="false"/>
-        <field name="providerReference" column="provider_reference" type="string" nullable="false" length="255"/>
+        <field name="enabled" column="enabled" type="boolean"/>
+        <field name="providerName" column="provider_name" type="string" length="255"/>
+        <field name="providerStatus" column="provider_status" type="integer"/>
+        <field name="providerReference" column="provider_reference" type="string" length="255"/>
         <field name="providerMetadata" column="provider_metadata" type="json" nullable="true"/>
         <field name="width" column="width" type="integer" nullable="true"/>
         <field name="height" column="height" type="integer" nullable="true"/>
@@ -16,7 +16,7 @@
         <field name="copyright" column="copyright" type="string" nullable="true"/>
         <field name="authorName" column="author_name" type="string" nullable="true"/>
         <field name="context" column="context" type="string" nullable="true" length="64"/>
-        <field name="cdnIsFlushable" column="cdn_is_flushable" type="boolean" nullable="true"/>
+        <field name="cdnIsFlushable" column="cdn_is_flushable" type="boolean"/>
         <field name="cdnFlushIdentifier" column="cdn_flush_identifier" type="string" nullable="true" length="64"/>
         <field name="cdnFlushAt" column="cdn_flush_at" type="datetime" nullable="true"/>
         <field name="cdnStatus" column="cdn_status" type="integer" nullable="true"/>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this breaks BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #2153 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- `cdnIsFlushable` property on Media entity is non nullable now.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->

I have also removed the nullable="false". They should not change anything, by default it is a false attribute.
