### PR TITLE
Deprecate passing null to twig media functions

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,11 +4,17 @@ UPGRADE 3.x
 UPGRADE FROM 3.x to 3.x
 =======================
 
-# Deprecated `MigrateToJsonTypeCommand`
+### Deprecate `null` media value on Twig functions
+
+Our custom twig functions (`sonata_media`, `sonata_thumbnail` and `sonata_path`) used to accept a null value and produce an empty result.
+
+This is deprecated and you should make sure you check for null before calling those functions.
+
+### Deprecated `MigrateToJsonTypeCommand`
 
 This command was introduced a long time ago to migrate from array to json. Make sure you migrate it before upgrading to SonataMediaBundle 4.0.
 
-# Deprecated `ServiceProviderDataTransformer`
+### Deprecated `ServiceProviderDataTransformer`
 
 This class is deprecated because it is dead code. If you use it, please use `ProviderDataTransformer` instead.
 

--- a/src/Twig/MediaRuntime.php
+++ b/src/Twig/MediaRuntime.php
@@ -144,6 +144,20 @@ final class MediaRuntime implements RuntimeExtensionInterface
      */
     private function getMedia($media): ?MediaInterface
     {
+        // NEXT_MAJOR: Throw exception instead and remove references to null media being accepted.
+        if (!\is_int($media) && !\is_string($media) && !$media instanceof MediaInterface) {
+            @trigger_error(
+                'Using SonataMediaBundle custom Twig functions with a media that is not'
+                .' the identifier of the media or the media itself is deprecated since'
+                .' sonata-project/media-bundle 3.x and will be removed in version 4.0.',
+                \E_USER_DEPRECATED
+            );
+            // throw new \TypeError(sprintf(
+            //     'Media parameter must be either an identifier or the media itself for Twig functions, %s given.',
+            //     $media
+            // ));
+        }
+
         if (!$media instanceof MediaInterface && null !== $media) {
             $media = $this->mediaManager->find($media);
         }

--- a/tests/Twig/MediaRuntimeTest.php
+++ b/tests/Twig/MediaRuntimeTest.php
@@ -62,6 +62,9 @@ class MediaRuntimeTest extends TestCase
         $this->mediaRuntime = new MediaRuntime($this->pool, $this->mediaManager, $this->twig);
     }
 
+    /**
+     * @group legacy
+     */
     public function testWithNullInput(): void
     {
         static::assertSame('', $this->mediaRuntime->media(null, 'big'));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated passing null value for the media parameter to twig functions.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
