### PR TITLE
Deprecate uneeded classes for 4.0

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,17 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.x to 3.x
+=======================
+
+# Deprecated `MigrateToJsonTypeCommand`
+
+This command was introduced a long time ago to migrate from array to json. Make sure you migrate it before upgrading to SonataMediaBundle 4.0.
+
+# Deprecated `ServiceProviderDataTransformer`
+
+This class is deprecated because it is dead code. If you use it, please use `ProviderDataTransformer` instead.
+
 UPGRADE FROM 3.33 to 3.34
 =========================
 

--- a/src/Command/MigrateToJsonTypeCommand.php
+++ b/src/Command/MigrateToJsonTypeCommand.php
@@ -21,7 +21,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * @final since sonata-project/media-bundle 3.21.0
+ * NEXT_MAJOR: remove this file.
+ *
+ * @deprecated since sonata-project/media-bundle 3.x, to be removed in 4.0.
  */
 class MigrateToJsonTypeCommand extends BaseCommand
 {
@@ -48,6 +50,12 @@ class MigrateToJsonTypeCommand extends BaseCommand
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
+        @trigger_error(sprintf(
+            '%s is deprecated since sonata-project/media-bundle 3.x and will be removed'
+            .' in version 4.0. Make sure you execute it to migrate to json type before upgrading to 4.0.',
+            __CLASS__
+        ), \E_USER_DEPRECATED);
+
         if (null === $this->entityManager) {
             throw new \LogicException(
                 'This command could not be executed since one of its dependencies is missing.'

--- a/src/Form/DataTransformer/ServiceProviderDataTransformer.php
+++ b/src/Form/DataTransformer/ServiceProviderDataTransformer.php
@@ -21,7 +21,9 @@ use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Symfony\Component\Form\DataTransformerInterface;
 
 /**
- * @final since sonata-project/media-bundle 3.21.0
+ * NEXT_MAJOR: remove this file.
+ *
+ * @deprecated since sonata-project/media-bundle 3.x, to be removed in 4.0.
  */
 class ServiceProviderDataTransformer implements DataTransformerInterface, LoggerAwareInterface
 {
@@ -46,6 +48,13 @@ class ServiceProviderDataTransformer implements DataTransformerInterface, Logger
 
     public function reverseTransform($value)
     {
+        @trigger_error(sprintf(
+            '%s is deprecated since sonata-project/media-bundle 3.x and will be removed'
+            .' in version 4.0. Use %s instead.',
+            __CLASS__,
+            ProviderDataTransformer::class
+        ), \E_USER_DEPRECATED);
+
         if (!$value instanceof MediaInterface) {
             return $value;
         }

--- a/tests/Form/DataTransformer/ServiceProviderDataTransformerTest.php
+++ b/tests/Form/DataTransformer/ServiceProviderDataTransformerTest.php
@@ -19,6 +19,11 @@ use Sonata\MediaBundle\Form\DataTransformer\ServiceProviderDataTransformer;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 
+/**
+ * NEXT_MAJOR: Remove this class.
+ *
+ * @group legacy
+ */
 class ServiceProviderDataTransformerTest extends TestCase
 {
     public function testTransformNoop(): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `MigrateToJsonTypeCommand`.
- Deprecated `ServiceProviderDataTransformer`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
