### PR TITLE
Update `FixMediaContextCommand::__construct()` to avoid requiring a useless argument

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,11 @@ UPGRADE 3.x
 UPGRADE FROM 3.x to 3.x
 =======================
 
+### Sonata\MediaBundle\Command\FixMediaContextCommand::__construct()
+
+Argument 3 in `FixMediaContextCommand::__construct()` is deprecated, it is moved to the argument 2.
+Passing other type than `null` or `Sonata\ClassificationBundle\Model\ContextManagerInterface` as argument 2 is deprecated.
+
 ### Deprecate `null` media value on Twig functions
 
 Our custom twig functions (`sonata_media`, `sonata_thumbnail` and `sonata_path`) used to accept a null value and produce an empty result.

--- a/src/Resources/config/command.xml
+++ b/src/Resources/config/command.xml
@@ -21,7 +21,6 @@
         <service id="Sonata\MediaBundle\Command\FixMediaContextCommand" class="Sonata\MediaBundle\Command\FixMediaContextCommand" public="true">
             <tag name="console.command"/>
             <argument type="service" id="sonata.media.pool"/>
-            <argument type="service" id="sonata.media.manager.category" on-invalid="null"/>
             <argument type="service" id="sonata.classification.manager.context" on-invalid="null"/>
         </service>
         <service id="Sonata\MediaBundle\Command\MigrateToJsonTypeCommand" class="Sonata\MediaBundle\Command\MigrateToJsonTypeCommand" public="true">

--- a/tests/Command/FixMediaContextCommandTest.php
+++ b/tests/Command/FixMediaContextCommandTest.php
@@ -107,33 +107,6 @@ class FixMediaContextCommandTest extends TestCase
         static::assertSame(0, $output);
     }
 
-    public function testExecuteWithEmptyRoot(): void
-    {
-        $context = [
-            'providers' => [],
-            'formats' => [],
-            'download' => [],
-        ];
-
-        $this->pool->method('getContexts')->willReturn(['foo' => $context]);
-
-        $contextModel = new Context();
-
-        $this->contextManager->expects(static::once())->method('findOneBy')->with(static::equalTo(['id' => 'foo']))->willReturn($contextModel);
-
-        $category = new Category();
-
-        $this->categoryManager->expects(static::once())->method('getRootCategory')->with(static::equalTo($contextModel))->willReturn(null);
-        $this->categoryManager->expects(static::once())->method('create')->willReturn($category);
-        $this->categoryManager->expects(static::once())->method('save')->with(static::equalTo($category));
-
-        $output = $this->tester->execute(['command' => $this->command->getName()]);
-
-        static::assertMatchesRegularExpression('@ > default category for \'foo\' is missing, creating one\s+Done!@', $this->tester->getDisplay());
-
-        static::assertSame(0, $output);
-    }
-
     public function testExecuteWithNew(): void
     {
         $context = [
@@ -150,15 +123,11 @@ class FixMediaContextCommandTest extends TestCase
         $this->contextManager->expects(static::once())->method('create')->willReturn($contextModel);
         $this->contextManager->expects(static::once())->method('save')->with(static::equalTo($contextModel));
 
-        $category = new Category();
-
-        $this->categoryManager->expects(static::once())->method('getRootCategory')->with(static::equalTo($contextModel))->willReturn(null);
-        $this->categoryManager->expects(static::once())->method('create')->willReturn($category);
-        $this->categoryManager->expects(static::once())->method('save')->with(static::equalTo($category));
+        $this->categoryManager->expects(static::once())->method('getRootCategory')->with(static::equalTo($contextModel))->willReturn(new Category());
 
         $output = $this->tester->execute(['command' => $this->command->getName()]);
 
-        static::assertMatchesRegularExpression('@ > default category for \'foo\' is missing, creating one\s+Done!@', $this->tester->getDisplay());
+        static::assertMatchesRegularExpression('@ > default context for \'foo\' is missing, creating one\s+Done!@', $this->tester->getDisplay());
 
         static::assertSame(0, $output);
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Update `FixMediaContextCommand::__construct()` to avoid requiring a useless argument.
<!-- Describe your Pull Request content here -->

`CategoryManagerInterface::getRootCategory()` will always return an instance of `CategoryInterface`:
https://github.com/sonata-project/SonataMediaBundle/blob/af6dc96b377164cdfee8664bc9056ae882d58c25/src/Model/CategoryManagerInterface.php#L24-L29
So, the check for an empty root category and the attempt to create a new one are useless:
https://github.com/sonata-project/SonataMediaBundle/blob/af6dc96b377164cdfee8664bc9056ae882d58c25/src/Command/FixMediaContextCommand.php#L84-L95

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- `FixMediaContextCommand::__construct()` signature in order to accept an instance of `ContextManagerInterface` as argument 2.

### Deprecated
- Passing other type than `null` or `ContextManagerInterface` as argument 2 for `FixMediaContextCommand::__construct()`;
- Calling `FixMediaContextCommand::__construct()` with more than 2 arguments.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

## To do
- [x] Add an upgrade note.

