### PR TITLE
Use `Connection::fetchAllAssociative()` instead of `fetchAll()`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
     },
     "conflict": {
         "aws/aws-sdk-php": "<3.0 || >= 4.0",
-        "doctrine/dbal": "<2.6",
+        "doctrine/dbal": "<2.11",
         "doctrine/mongodb-odm": "<2.0",
         "doctrine/orm": "<2.5",
         "doctrine/persistence": "<1.3",

--- a/src/Command/MigrateToJsonTypeCommand.php
+++ b/src/Command/MigrateToJsonTypeCommand.php
@@ -67,7 +67,7 @@ class MigrateToJsonTypeCommand extends BaseCommand
         $table = $input->getOption('table');
         $column = $input->getOption('column');
         $columnId = $input->getOption('column_id');
-        $medias = $this->entityManager->getConnection()->fetchAll("SELECT * FROM $table");
+        $medias = $this->entityManager->getConnection()->fetchAllAssociative("SELECT * FROM $table");
 
         foreach ($medias as $media) {
             // if the row need to migrate


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Use `Connection::fetchAllAssociative()` instead of `fetchAll()`, since this method does not exist in doctrine/dbal 3.x.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Part of #2035.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Support for `doctrine/dbal` < 2.11.

### Fixed
- Call to an undefined method `Connection::fetchAll()` when using `doctrine/dbal:3.x`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
