### PR TITLE
Deprecate using master and slave

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -18,6 +18,34 @@ This command was introduced a long time ago to migrate from array to json. Make 
 
 This class is deprecated because it is dead code. If you use it, please use `ProviderDataTransformer` instead.
 
+### Deprecated using `master` and `slave` words in configuration
+
+Before:
+
+```yaml
+sonata_media:
+    cdn:
+        fallback:
+            master: sonata.media.cdn.panther
+    filesystem:
+        replicate:
+            master: sonata.media.adapter.filesystem.s3
+            slave: sonata.media.adapter.filesystem.local
+```
+
+After:
+
+```yaml
+sonata_media:
+    cdn:
+        fallback:
+            primary: sonata.media.cdn.panther
+    filesystem:
+        replicate:
+            primary: sonata.media.adapter.filesystem.s3
+            secondary: sonata.media.adapter.filesystem.local
+```
+
 UPGRADE FROM 3.33 to 3.34
 =========================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,7 +56,7 @@ Available services
     - ``sonata.media.filesystem.local``       : The local filesystem (default)
     - ``sonata.media.filesystem.ftp``         : FTP
     - ``sonata.media.filesystem.s3``          : Amazon S3
-    - ``sonata.media.filesystem.replicate``   : Replicate file to a master and to a slave
+    - ``sonata.media.filesystem.replicate``   : Replicate file to a primary and a secondary
 
  - CDN
 

--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -81,7 +81,7 @@ Full configuration options:
                 version:
 
             fallback:
-                master:     sonata.media.cdn.panther
+                primary:     sonata.media.cdn.panther
                 fallback:   sonata.media.cdn.server
 
         filesystem:
@@ -118,8 +118,8 @@ Full configuration options:
                 domain:
 
             replicate:
-                master: sonata.media.adapter.filesystem.s3
-                slave: sonata.media.adapter.filesystem.local
+                primary: sonata.media.adapter.filesystem.s3
+                secondary: sonata.media.adapter.filesystem.local
 
         providers:
             file:

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -172,7 +172,14 @@ class Configuration implements ConfigurationInterface
 
                         ->arrayNode('fallback')
                             ->children()
-                                ->scalarNode('master')->isRequired()->end()
+                                // NEXT_MAJOR: Remove master and make primary required
+                                ->scalarNode('master')
+                                    ->setDeprecated(...$this->getBackwardCompatibleArgumentsForSetDeprecated(
+                                        'The "%node%" option is deprecated, use "primary" instead.',
+                                        '3.x'
+                                    ))
+                                ->end()
+                                ->scalarNode('primary')->end()
                                 ->scalarNode('fallback')->isRequired()->end()
                             ->end()
                         ->end()
@@ -295,10 +302,23 @@ class Configuration implements ConfigurationInterface
                             ->end()
                         ->end()
 
+                        // NEXT_MAJOR: Remove master and slave and make primary and secondary required
                         ->arrayNode('replicate')
                             ->children()
-                                ->scalarNode('master')->isRequired()->end()
-                                ->scalarNode('slave')->isRequired()->end()
+                                ->scalarNode('master')
+                                    ->setDeprecated(...$this->getBackwardCompatibleArgumentsForSetDeprecated(
+                                        'The "%node%" option is deprecated, use "primary" instead.',
+                                        '3.x'
+                                    ))
+                                ->end()
+                                ->scalarNode('primary')->end()
+                                ->scalarNode('slave')
+                                    ->setDeprecated(...$this->getBackwardCompatibleArgumentsForSetDeprecated(
+                                        'The "%node%" option is deprecated, use "secondary" instead.',
+                                        '3.x'
+                                    ))
+                                ->end()
+                                ->scalarNode('secondary')->end()
                             ->end()
                         ->end()
                         ->arrayNode('openstack')

--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -373,8 +373,9 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
         }
 
         if ($container->hasDefinition('sonata.media.cdn.fallback') && isset($config['cdn']['fallback'])) {
+            // NEXT_MAJOR: Do not fallback to master
             $container->getDefinition('sonata.media.cdn.fallback')
-                ->replaceArgument(0, new Reference($config['cdn']['fallback']['master']))
+                ->replaceArgument(0, new Reference($config['cdn']['fallback']['primary'] ?? $config['cdn']['fallback']['master']))
                 ->replaceArgument(1, new Reference($config['cdn']['fallback']['fallback']));
         } else {
             $container->removeDefinition('sonata.media.cdn.fallback');
@@ -453,9 +454,10 @@ class SonataMediaExtension extends Extension implements PrependExtensionInterfac
         }
 
         if ($container->hasDefinition('sonata.media.adapter.filesystem.replicate') && isset($config['filesystem']['replicate'])) {
+            // NEXT_MAJOR: Do not fallback to master and slave
             $container->getDefinition('sonata.media.adapter.filesystem.replicate')
-                ->replaceArgument(0, new Reference($config['filesystem']['replicate']['master']))
-                ->replaceArgument(1, new Reference($config['filesystem']['replicate']['slave']));
+                ->replaceArgument(0, new Reference($config['filesystem']['replicate']['primary'] ?? $config['filesystem']['replicate']['master']))
+                ->replaceArgument(1, new Reference($config['filesystem']['replicate']['secondary'] ?? $config['filesystem']['replicate']['slave']));
         } else {
             $container->removeDefinition('sonata.media.adapter.filesystem.replicate');
             $container->removeDefinition('sonata.media.filesystem.replicate');

--- a/tests/DependencyInjection/SonataMediaExtensionTest.php
+++ b/tests/DependencyInjection/SonataMediaExtensionTest.php
@@ -462,6 +462,74 @@ class SonataMediaExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasService('sonata.media.formatter.twig', FormatterMediaExtension::class);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
+    public function testFallbackCDNWithDeprecatedConfiguration(): void
+    {
+        $this->load([
+            'cdn' => [
+                'fallback' => [
+                    'master' => 'sonata.media.cdn.cloudfront',
+                    'fallback' => 'sonata.media.cdn.server',
+                ],
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('sonata.media.cdn.fallback', 0, 'sonata.media.cdn.cloudfront');
+    }
+
+    public function testFallbackCDN(): void
+    {
+        $this->load([
+            'cdn' => [
+                'fallback' => [
+                    'primary' => 'sonata.media.cdn.cloudfront',
+                    'fallback' => 'sonata.media.cdn.server',
+                ],
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('sonata.media.cdn.fallback', 0, 'sonata.media.cdn.cloudfront');
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
+    public function testReplicateFilesystemWithDeprecatedConfiguration(): void
+    {
+        $this->load([
+            'filesystem' => [
+                'replicate' => [
+                    'master' => 'sonata.media.adapter.filesystem.s3',
+                    'slave' => 'sonata.media.adapter.filesystem.local',
+                ],
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('sonata.media.adapter.filesystem.replicate', 0, 'sonata.media.adapter.filesystem.s3');
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('sonata.media.adapter.filesystem.replicate', 1, 'sonata.media.adapter.filesystem.local');
+    }
+
+    public function testReplicateFilesystem(): void
+    {
+        $this->load([
+            'filesystem' => [
+                'replicate' => [
+                    'primary' => 'sonata.media.adapter.filesystem.s3',
+                    'secondary' => 'sonata.media.adapter.filesystem.local',
+                ],
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('sonata.media.adapter.filesystem.replicate', 0, 'sonata.media.adapter.filesystem.s3');
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('sonata.media.adapter.filesystem.replicate', 1, 'sonata.media.adapter.filesystem.local');
+    }
+
     protected function getMinimalConfiguration(): array
     {
         return [

--- a/tests/Filesystem/ReplicateTest.php
+++ b/tests/Filesystem/ReplicateTest.php
@@ -21,40 +21,40 @@ class ReplicateTest extends TestCase
 {
     public function testReplicate(): void
     {
-        $master = $this->createMock(Adapter::class);
-        $slave = $this->createMock(Adapter::class);
-        $replicate = new Replicate($master, $slave);
+        $primary = $this->createMock(Adapter::class);
+        $secondary = $this->createMock(Adapter::class);
+        $replicate = new Replicate($primary, $secondary);
 
-        $master->expects(static::once())->method('mtime')->willReturn('master');
-        $slave->expects(static::never())->method('mtime');
-        static::assertSame('master', $replicate->mtime('foo'));
+        $primary->expects(static::once())->method('mtime')->willReturn('primary');
+        $secondary->expects(static::never())->method('mtime');
+        static::assertSame('primary', $replicate->mtime('foo'));
 
-        $master->expects(static::once())->method('delete')->willReturn('master');
-        $slave->expects(static::once())->method('delete')->willReturn('master');
+        $primary->expects(static::once())->method('delete')->willReturn('primary');
+        $secondary->expects(static::once())->method('delete')->willReturn('primary');
         $replicate->delete('foo');
 
-        $master->expects(static::once())->method('keys')->willReturn([]);
-        $slave->expects(static::never())->method('keys')->willReturn([]);
+        $primary->expects(static::once())->method('keys')->willReturn([]);
+        $secondary->expects(static::never())->method('keys')->willReturn([]);
         static::assertIsArray($replicate->keys());
 
-        $master->expects(static::once())->method('exists')->willReturn(true);
-        $slave->expects(static::never())->method('exists');
+        $primary->expects(static::once())->method('exists')->willReturn(true);
+        $secondary->expects(static::never())->method('exists');
         static::assertTrue($replicate->exists('foo'));
 
-        $master->expects(static::once())->method('write')->willReturn(123);
-        $slave->expects(static::once())->method('write')->willReturn(123);
+        $primary->expects(static::once())->method('write')->willReturn(123);
+        $secondary->expects(static::once())->method('write')->willReturn(123);
         static::assertTrue($replicate->write('foo', 'contents'));
 
-        $master->expects(static::once())->method('read')->willReturn('master content');
-        $slave->expects(static::never())->method('read');
-        static::assertSame('master content', $replicate->read('foo'));
+        $primary->expects(static::once())->method('read')->willReturn('primary content');
+        $secondary->expects(static::never())->method('read');
+        static::assertSame('primary content', $replicate->read('foo'));
 
-        $master->expects(static::once())->method('rename');
-        $slave->expects(static::once())->method('rename');
+        $primary->expects(static::once())->method('rename');
+        $secondary->expects(static::once())->method('rename');
         $replicate->rename('foo', 'bar');
 
-        $master->expects(static::once())->method('isDirectory');
-        $slave->expects(static::never())->method('isDirectory');
+        $primary->expects(static::once())->method('isDirectory');
+        $secondary->expects(static::never())->method('isDirectory');
         $replicate->isDirectory('foo');
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecate using `master` and `slave` for filesystem and cdn configuration, use `primary` and `secondary` instead.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
