### PR TITLE
Set Cloudfront class on service definition

### DIFF
--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -15,7 +15,6 @@ namespace Sonata\MediaBundle\DependencyInjection;
 
 use Sonata\Doctrine\Mapper\Builder\OptionsBuilder;
 use Sonata\Doctrine\Mapper\DoctrineCollector;
-use Sonata\MediaBundle\CDN\CloudFrontVersion3;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -217,13 +216,10 @@ final class SonataMediaExtension extends Extension implements PrependExtensionIn
                 'secret' => $config['cdn']['cloudfront']['secret'],
             ];
 
-            $cloudFrontClass = CloudFrontVersion3::class;
-
             $container->getDefinition('sonata.media.cdn.cloudfront.client')
                 ->replaceArgument(0, $cloudFrontConfig);
 
             $container->getDefinition('sonata.media.cdn.cloudfront')
-                ->setClass($cloudFrontClass)
                 ->replaceArgument(0, new Reference('sonata.media.cdn.cloudfront.client'))
                 ->replaceArgument(1, $config['cdn']['cloudfront']['distribution_id'])
                 ->replaceArgument(2, $config['cdn']['cloudfront']['path']);

--- a/src/Resources/config/media.php
+++ b/src/Resources/config/media.php
@@ -15,6 +15,7 @@ use Aws\CloudFront\CloudFrontClient;
 use Imagine\Gd\Imagine as GdImagine;
 use Imagine\Gmagick\Imagine as GmagickImagine;
 use Imagine\Imagick\Imagine as ImagickImagine;
+use Sonata\MediaBundle\CDN\CloudFrontVersion3;
 use Sonata\MediaBundle\CDN\Fallback;
 use Sonata\MediaBundle\CDN\PantherPortal;
 use Sonata\MediaBundle\CDN\Server;
@@ -67,8 +68,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->set('sonata.media.cdn.cloudfront.client', CloudFrontClient::class)
             ->args([[]])
 
-        // The class for "sonata.media.cdn.cloudfront" service is set dynamically at `SonataMediaExtension`
-        ->set('sonata.media.cdn.cloudfront')
+        ->set('sonata.media.cdn.cloudfront', CloudFrontVersion3::class)
             ->args(['', '', ''])
 
         ->set('sonata.media.cdn.fallback', Fallback::class)


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is where only one class for cloudfront is present.
