### PR TITLE
Add finals to abstract classes

### DIFF
--- a/src/Admin/BaseMediaAdmin.php
+++ b/src/Admin/BaseMediaAdmin.php
@@ -75,7 +75,7 @@ abstract class BaseMediaAdmin extends AbstractAdmin
         $object->setContext($parameters['context']);
     }
 
-    protected function configurePersistentParameters(): array
+    final protected function configurePersistentParameters(): array
     {
         $parameters = [];
 
@@ -124,7 +124,7 @@ abstract class BaseMediaAdmin extends AbstractAdmin
         ]);
     }
 
-    protected function alterNewInstance(object $object): void
+    final protected function alterNewInstance(object $object): void
     {
         if ($this->hasRequest()) {
             if ($this->getRequest()->isMethod('POST')) {

--- a/src/Admin/BaseMediaAdmin.php
+++ b/src/Admin/BaseMediaAdmin.php
@@ -75,7 +75,7 @@ abstract class BaseMediaAdmin extends AbstractAdmin
         $object->setContext($parameters['context']);
     }
 
-    final protected function configurePersistentParameters(): array
+    protected function configurePersistentParameters(): array
     {
         $parameters = [];
 
@@ -124,7 +124,7 @@ abstract class BaseMediaAdmin extends AbstractAdmin
         ]);
     }
 
-    final protected function alterNewInstance(object $object): void
+    protected function alterNewInstance(object $object): void
     {
         if ($this->hasRequest()) {
             if ($this->getRequest()->isMethod('POST')) {

--- a/src/Model/Gallery.php
+++ b/src/Model/Gallery.php
@@ -106,7 +106,7 @@ abstract class Gallery implements GalleryInterface
         return $this->defaultFormat;
     }
 
-    public function setGalleryItems(Collection $galleryItems): void
+    final public function setGalleryItems(Collection $galleryItems): void
     {
         $this->galleryItems = new ArrayCollection();
 
@@ -115,26 +115,26 @@ abstract class Gallery implements GalleryInterface
         }
     }
 
-    public function getGalleryItems(): Collection
+    final public function getGalleryItems(): Collection
     {
         return $this->galleryItems;
     }
 
-    public function addGalleryItem(GalleryItemInterface $galleryItem): void
+    final public function addGalleryItem(GalleryItemInterface $galleryItem): void
     {
         $galleryItem->setGallery($this);
 
         $this->galleryItems[] = $galleryItem;
     }
 
-    public function removeGalleryItem(GalleryItemInterface $galleryItem): void
+    final public function removeGalleryItem(GalleryItemInterface $galleryItem): void
     {
         if ($this->galleryItems->contains($galleryItem)) {
             $this->galleryItems->removeElement($galleryItem);
         }
     }
 
-    public function reorderGalleryItems(): void
+    final public function reorderGalleryItems(): void
     {
         $iterator = $this->getGalleryItems()->getIterator();
 

--- a/src/Model/GalleryItem.php
+++ b/src/Model/GalleryItem.php
@@ -32,62 +32,62 @@ abstract class GalleryItem implements GalleryItemInterface
         return $this->getGallery().' | '.$this->getMedia();
     }
 
-    public function setEnabled(bool $enabled): void
+    final public function setEnabled(bool $enabled): void
     {
         $this->enabled = $enabled;
     }
 
-    public function getEnabled(): bool
+    final public function getEnabled(): bool
     {
         return $this->enabled;
     }
 
-    public function setGallery(?GalleryInterface $gallery = null): void
+    final public function setGallery(?GalleryInterface $gallery = null): void
     {
         $this->gallery = $gallery;
     }
 
-    public function getGallery(): ?GalleryInterface
+    final public function getGallery(): ?GalleryInterface
     {
         return $this->gallery;
     }
 
-    public function setMedia(?MediaInterface $media = null): void
+    final public function setMedia(?MediaInterface $media = null): void
     {
         $this->media = $media;
     }
 
-    public function getMedia(): ?MediaInterface
+    final public function getMedia(): ?MediaInterface
     {
         return $this->media;
     }
 
-    public function setPosition(int $position): void
+    final public function setPosition(int $position): void
     {
         $this->position = $position;
     }
 
-    public function getPosition(): int
+    final public function getPosition(): int
     {
         return $this->position;
     }
 
-    public function setUpdatedAt(?\DateTimeInterface $updatedAt): void
+    final public function setUpdatedAt(?\DateTimeInterface $updatedAt): void
     {
         $this->updatedAt = $updatedAt;
     }
 
-    public function getUpdatedAt(): ?\DateTimeInterface
+    final public function getUpdatedAt(): ?\DateTimeInterface
     {
         return $this->updatedAt;
     }
 
-    public function setCreatedAt(?\DateTimeInterface $createdAt): void
+    final public function setCreatedAt(?\DateTimeInterface $createdAt): void
     {
         $this->createdAt = $createdAt;
     }
 
-    public function getCreatedAt(): ?\DateTimeInterface
+    final public function getCreatedAt(): ?\DateTimeInterface
     {
         return $this->createdAt;
     }

--- a/src/Model/Media.php
+++ b/src/Model/Media.php
@@ -312,12 +312,12 @@ abstract class Media implements MediaInterface
         $this->category = $category;
     }
 
-    public function setGalleryItems(Collection $galleryItems): void
+    final public function setGalleryItems(Collection $galleryItems): void
     {
         $this->galleryItems = $galleryItems;
     }
 
-    public function getGalleryItems(): Collection
+    final public function getGalleryItems(): Collection
     {
         return $this->galleryItems;
     }


### PR DESCRIPTION
This is to show how it will end. The PR will be done on 3.x first to mark them as final with annotations, then on the up merge we will change to php code.

Things not marked as final:

BaseMediaAdmin
* __construct
* prePersist
* configureListFields
* configureFormFields
* alterNewInstance
* configurePersistentParameters

BaseGallery (Document and Entity)
* __construct
* prePersist
* preUpdate

BaseGalleryItem (Document and Entity)
* prePersist
* preUpdate

BaseMedia (Document and Entity)
* __construct
* prePersist
* preUpdate

Gallery (Model)
* __toString

GalleryItem (Model)
* __toString

Media (Model)
* __toString
* getStatusList

GalleryManager
* create

BaseProvider
* __construct
* getProviderMetadata
* preRemove
* postRemove
* prePersist
* preUpdate
* validate

BaseVideoProvider
* __construct
* getProviderMetadata
* buildEditForm
* buildCreateForm
* buildMediaType
* postUpdate
* postPersist
* postRemove
* getMetadata
* getBoxHelperProperties

BaseMediaEventSubscriber
* __construct

@VincentLanglet wdyt?