### PR TITLE
Remove dependency with doctrine/dbal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,6 @@
     },
     "conflict": {
         "aws/aws-sdk-php": "<3.0",
-        "doctrine/dbal": "<2.11",
         "doctrine/mongodb-odm": "<2.2",
         "doctrine/orm": "<2.9",
         "knplabs/knp-menu-bundle": "<3.0",
@@ -77,7 +76,6 @@
     },
     "require-dev": {
         "aws/aws-sdk-php": "^3.0",
-        "doctrine/dbal": "^2.11",
         "doctrine/mongodb-odm": "^2.2",
         "doctrine/orm": "^2.9",
         "jackalope/jackalope-doctrine-dbal": "^1.1",

--- a/src/Model/NoDriverGalleryManager.php
+++ b/src/Model/NoDriverGalleryManager.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Model;
 
-use Doctrine\DBAL\Connection;
 use Sonata\MediaBundle\Exception\NoDriverException;
 
 /**
@@ -68,7 +67,7 @@ final class NoDriverGalleryManager implements GalleryManagerInterface
         throw new NoDriverException();
     }
 
-    public function getConnection(): Connection
+    public function getConnection()
     {
         throw new NoDriverException();
     }

--- a/src/Model/NoDriverGalleryManager.php
+++ b/src/Model/NoDriverGalleryManager.php
@@ -67,6 +67,12 @@ final class NoDriverGalleryManager implements GalleryManagerInterface
         throw new NoDriverException();
     }
 
+    /**
+     * Do not add return typehint to this method, it forces a dependency with
+     * Doctrine DBAL that we do not want here. This method will probably be
+     * deprecated on sonata-project/doctrine-extensions because it is only for
+     * Doctrine ORM.
+     */
     public function getConnection()
     {
         throw new NoDriverException();

--- a/src/Model/NoDriverMediaManager.php
+++ b/src/Model/NoDriverMediaManager.php
@@ -67,6 +67,12 @@ final class NoDriverMediaManager implements MediaManagerInterface
         throw new NoDriverException();
     }
 
+    /**
+     * Do not add return typehint to this method, it forces a dependency with
+     * Doctrine DBAL that we do not want here. This method will probably be
+     * deprecated on sonata-project/doctrine-extensions because it is only for
+     * Doctrine ORM.
+     */
     public function getConnection()
     {
         throw new NoDriverException();

--- a/src/Model/NoDriverMediaManager.php
+++ b/src/Model/NoDriverMediaManager.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Model;
 
-use Doctrine\DBAL\Connection;
 use Sonata\MediaBundle\Exception\NoDriverException;
 
 /**
@@ -68,7 +67,7 @@ final class NoDriverMediaManager implements MediaManagerInterface
         throw new NoDriverException();
     }
 
-    public function getConnection(): Connection
+    public function getConnection()
     {
         throw new NoDriverException();
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->

The dependency is not really required, and that method should/will be deprecated on next major of doctrine extensions (because it is coupled with the orm, I couldn't find the getConnection on the document manager)

To me it is pedantic, because this only affects on the conflict section (for our users), for us it means not having to deal with one package here which is nice.