### PR TITLE
Mark method from abstract classes as final

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,17 @@ UPGRADE 3.x
 UPGRADE FROM 3.x to 3.x
 =======================
 
+### Mark final methods on abstract classes
+
+The following abstract classes have some of their methods marked as final with annotations, on 4.0 they will be final, make sure to not reimplement them:
+
+- `Sonata\MediaBundle\Admin\BaseMediaAdmin`
+- `Sonata\MediaBundle\Listener\BaseMediaEventSubscriber`
+- `Sonata\MediaBundle\Model\Gallery`
+- `Sonata\MediaBundle\Model\Media`
+- `Sonata\MediaBundle\Provider\BaseProvider`
+- `Sonata\MediaBundle\Provider\BaseVideoProvider`
+
 ### Deprecate PantherPortal CDN
 
 PantherPortal CDN no longer exists.

--- a/src/Admin/BaseMediaAdmin.php
+++ b/src/Admin/BaseMediaAdmin.php
@@ -138,6 +138,9 @@ abstract class BaseMediaAdmin extends AbstractAdmin
         return $this->pool;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getObjectMetadata($object)
     {
         $provider = $this->pool->getProvider($object->getProviderName());

--- a/src/Listener/BaseMediaEventSubscriber.php
+++ b/src/Listener/BaseMediaEventSubscriber.php
@@ -40,6 +40,9 @@ abstract class BaseMediaEventSubscriber implements EventSubscriber
         return $this->container->get('sonata.media.pool');
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function postUpdate(EventArgs $args)
     {
         $media = $this->getMedia($args);
@@ -51,6 +54,9 @@ abstract class BaseMediaEventSubscriber implements EventSubscriber
         $this->getProvider($args)->postUpdate($media);
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function postRemove(EventArgs $args)
     {
         $media = $this->getMedia($args);
@@ -62,6 +68,9 @@ abstract class BaseMediaEventSubscriber implements EventSubscriber
         $this->getProvider($args)->postRemove($media);
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function postPersist(EventArgs $args)
     {
         $media = $this->getMedia($args);
@@ -73,6 +82,9 @@ abstract class BaseMediaEventSubscriber implements EventSubscriber
         $this->getProvider($args)->postPersist($media);
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function preUpdate(EventArgs $args)
     {
         $media = $this->getMedia($args);
@@ -89,6 +101,9 @@ abstract class BaseMediaEventSubscriber implements EventSubscriber
         $this->recomputeSingleEntityChangeSet($args);
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function preRemove(EventArgs $args)
     {
         $media = $this->getMedia($args);
@@ -100,6 +115,9 @@ abstract class BaseMediaEventSubscriber implements EventSubscriber
         $this->getProvider($args)->preRemove($this->getMedia($args));
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function prePersist(EventArgs $args)
     {
         $media = $this->getMedia($args);
@@ -122,6 +140,8 @@ abstract class BaseMediaEventSubscriber implements EventSubscriber
     abstract protected function getMedia(EventArgs $args);
 
     /**
+     * @final since sonata-project/media-bundle 3.x
+     *
      * @return MediaProviderInterface
      */
     protected function getProvider(EventArgs $args)

--- a/src/Model/Gallery.php
+++ b/src/Model/Gallery.php
@@ -62,51 +62,81 @@ abstract class Gallery implements GalleryInterface, GalleryMediaCollectionInterf
         return $this->getName() ?? '-';
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setName($name)
     {
         $this->name = $name;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getName()
     {
         return $this->name;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setEnabled($enabled)
     {
         $this->enabled = $enabled;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getEnabled()
     {
         return $this->enabled;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setUpdatedAt(?\DateTime $updatedAt = null)
     {
         $this->updatedAt = $updatedAt;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getUpdatedAt()
     {
         return $this->updatedAt;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setCreatedAt(?\DateTime $createdAt = null)
     {
         $this->createdAt = $createdAt;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getCreatedAt()
     {
         return $this->createdAt;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setDefaultFormat($defaultFormat)
     {
         $this->defaultFormat = $defaultFormat;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getDefaultFormat()
     {
         return $this->defaultFormat;
@@ -154,11 +184,17 @@ abstract class Gallery implements GalleryInterface, GalleryMediaCollectionInterf
         $this->addGalleryHasMedia($galleryHasMedia);
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setContext($context)
     {
         $this->context = $context;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getContext()
     {
         return $this->context;

--- a/src/Model/Media.php
+++ b/src/Model/Media.php
@@ -200,6 +200,9 @@ abstract class Media implements MediaInterface
         ];
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setBinaryContent($binaryContent)
     {
         $this->previousProviderReference = $this->providerReference;
@@ -207,16 +210,25 @@ abstract class Media implements MediaInterface
         $this->binaryContent = $binaryContent;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function resetBinaryContent()
     {
         $this->binaryContent = null;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getBinaryContent()
     {
         return $this->binaryContent;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getMetadataValue($name, $default = null)
     {
         $metadata = $this->getProviderMetadata();
@@ -224,6 +236,9 @@ abstract class Media implements MediaInterface
         return $metadata[$name] ?? $default;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setMetadataValue($name, $value)
     {
         $metadata = $this->getProviderMetadata();
@@ -231,6 +246,9 @@ abstract class Media implements MediaInterface
         $this->setProviderMetadata($metadata);
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function unsetMetadataValue($name)
     {
         $metadata = $this->getProviderMetadata();
@@ -238,196 +256,313 @@ abstract class Media implements MediaInterface
         $this->setProviderMetadata($metadata);
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setName($name)
     {
         $this->name = $name;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getName()
     {
         return $this->name;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setDescription($description)
     {
         $this->description = $description;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getDescription()
     {
         return $this->description;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setEnabled($enabled)
     {
         $this->enabled = $enabled;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getEnabled()
     {
         return $this->enabled;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setProviderName($providerName)
     {
         $this->providerName = $providerName;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getProviderName()
     {
         return $this->providerName;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setProviderStatus($providerStatus)
     {
         $this->providerStatus = $providerStatus;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getProviderStatus()
     {
         return $this->providerStatus;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setProviderReference($providerReference)
     {
         $this->providerReference = $providerReference;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getProviderReference()
     {
         return $this->providerReference;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setProviderMetadata(array $providerMetadata = [])
     {
         $this->providerMetadata = $providerMetadata;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getProviderMetadata()
     {
         return $this->providerMetadata;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setWidth($width)
     {
         $this->width = $width;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getWidth()
     {
         return $this->width;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setHeight($height)
     {
         $this->height = $height;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getHeight()
     {
         return $this->height;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setLength($length)
     {
         $this->length = $length;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getLength()
     {
         return $this->length;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setCopyright($copyright)
     {
         $this->copyright = $copyright;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getCopyright()
     {
         return $this->copyright;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setAuthorName($authorName)
     {
         $this->authorName = $authorName;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getAuthorName()
     {
         return $this->authorName;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setContext($context)
     {
         $this->context = $context;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getContext()
     {
         return $this->context;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setCdnIsFlushable($cdnIsFlushable)
     {
         $this->cdnIsFlushable = $cdnIsFlushable;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getCdnIsFlushable()
     {
         return $this->cdnIsFlushable;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setCdnFlushIdentifier($cdnFlushIdentifier)
     {
         $this->cdnFlushIdentifier = $cdnFlushIdentifier;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getCdnFlushIdentifier()
     {
         return $this->cdnFlushIdentifier;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setCdnFlushAt(?\DateTime $cdnFlushAt = null)
     {
         $this->cdnFlushAt = $cdnFlushAt;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getCdnFlushAt()
     {
         return $this->cdnFlushAt;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setUpdatedAt(?\DateTime $updatedAt = null)
     {
         $this->updatedAt = $updatedAt;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getUpdatedAt()
     {
         return $this->updatedAt;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setCreatedAt(?\DateTime $createdAt = null)
     {
         $this->createdAt = $createdAt;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getCreatedAt()
     {
         return $this->createdAt;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setContentType($contentType)
     {
         $this->contentType = $contentType;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getContentType()
     {
         return $this->contentType;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getExtension()
     {
         $providerReference = $this->getProviderReference();
@@ -439,26 +574,41 @@ abstract class Media implements MediaInterface
         return preg_replace('{(\?|#).*}', '', pathinfo($providerReference, \PATHINFO_EXTENSION));
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setSize($size)
     {
         $this->size = $size;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getSize()
     {
         return $this->size;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setCdnStatus($cdnStatus)
     {
         $this->cdnStatus = $cdnStatus;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getCdnStatus()
     {
         return $this->cdnStatus;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getBox()
     {
         return new Box($this->width, $this->height);
@@ -474,6 +624,9 @@ abstract class Media implements MediaInterface
         return $this->galleryHasMedias;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getPreviousProviderReference()
     {
         return $this->previousProviderReference;
@@ -503,6 +656,8 @@ abstract class Media implements MediaInterface
     }
 
     /**
+     * @final since sonata-project/media-bundle 3.x
+     *
      * @return CategoryInterface
      */
     public function getCategory()
@@ -511,10 +666,7 @@ abstract class Media implements MediaInterface
     }
 
     // NEXT_MAJOR: Uncomment this method and remove __call and __set
-    // /**
-    //  * @param CategoryInterface|null $category
-    //  */
-    // public function setCategory($category = null)
+    // final public function setCategory(?object $category = null): void
     // {
     //     $this->category = $category;
     // }

--- a/src/Provider/BaseProvider.php
+++ b/src/Provider/BaseProvider.php
@@ -90,6 +90,9 @@ abstract class BaseProvider implements MediaProviderInterface
         $this->flushCdn($media);
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function flushCdn(MediaInterface $media)
     {
         if (null === $media->getId() || !$media->getCdnIsFlushable()) {
@@ -132,31 +135,49 @@ abstract class BaseProvider implements MediaProviderInterface
         }
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function addFormat($name, $format)
     {
         $this->formats[$name] = $format;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getFormat($name)
     {
         return $this->formats[$name] ?? false;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function requireThumbnails()
     {
         return null !== $this->getResizer();
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function generateThumbnails(MediaInterface $media)
     {
         $this->thumbnail->generate($this, $media);
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function removeThumbnails(MediaInterface $media, $formats = null)
     {
         $this->thumbnail->delete($this, $media, $formats);
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getFormatName(MediaInterface $media, $format)
     {
         if (MediaProviderInterface::FORMAT_ADMIN === $format) {
@@ -206,61 +227,97 @@ abstract class BaseProvider implements MediaProviderInterface
         }
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function generatePath(MediaInterface $media)
     {
         return $this->pathGenerator->generatePath($media);
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getFormats()
     {
         return $this->formats;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setName($name)
     {
         $this->name = $name;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getName()
     {
         return $this->name;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setTemplates(array $templates)
     {
         $this->templates = $templates;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getTemplates()
     {
         return $this->templates;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getTemplate($name)
     {
         return $this->templates[$name] ?? null;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getResizer()
     {
         return $this->resizer;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getFilesystem()
     {
         return $this->filesystem;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getCdn()
     {
         return $this->cdn;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getCdnPath($relativePath, $isFlushable)
     {
         return $this->getCdn()->getPath($relativePath, $isFlushable);
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function setResizer(ResizerInterface $resizer)
     {
         $this->resizer = $resizer;

--- a/src/Provider/BaseVideoProvider.php
+++ b/src/Provider/BaseVideoProvider.php
@@ -100,11 +100,17 @@ abstract class BaseVideoProvider extends BaseProvider
         return new Metadata($this->getName(), $this->getName().'.description', null, 'SonataMediaBundle', ['class' => 'fa fa-video-camera']);
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getReferenceImage(MediaInterface $media)
     {
         return $media->getMetadataValue('thumbnail_url');
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function getReferenceFile(MediaInterface $media)
     {
         $key = $this->generatePrivateUrl($media, MediaProviderInterface::FORMAT_REFERENCE);
@@ -124,6 +130,9 @@ abstract class BaseVideoProvider extends BaseProvider
         return $referenceFile;
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function generatePublicUrl(MediaInterface $media, $format)
     {
         return $this->getCdn()->getPath(sprintf(
@@ -134,6 +143,9 @@ abstract class BaseVideoProvider extends BaseProvider
         ), $media->getCdnIsFlushable());
     }
 
+    /**
+     * @final since sonata-project/media-bundle 3.x
+     */
     public function generatePrivateUrl(MediaInterface $media, $format)
     {
         return sprintf(


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

This change will help with #2191 . There are methods on that PR that are not present on this one, so this PR only focuses on the finals that will be useful for the 4.x version (there is no need to mark something final that in 4.x is removed).

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Added final annotation to methods that will be final on 4.x.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
