### PR TITLE
Make phpstan more strict

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,6 +10,8 @@ parameters:
         - tests
     treatPhpDocTypesAsCertain: false
     checkGenericClassInNonGenericObjectType: true
+    checkInternalClassCaseSensitivity: true
     checkMissingIterableValueType: true
     checkMissingVarTagTypehint: true
     checkMissingTypehints: true
+    checkUninitializedProperties: true

--- a/src/Document/BaseGallery.php
+++ b/src/Document/BaseGallery.php
@@ -13,16 +13,10 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Document;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Sonata\MediaBundle\Model\Gallery;
 
 abstract class BaseGallery extends Gallery
 {
-    public function __construct()
-    {
-        $this->galleryItems = new ArrayCollection();
-    }
-
     public function prePersist(): void
     {
         $this->createdAt = new \DateTime();

--- a/src/Document/BaseMedia.php
+++ b/src/Document/BaseMedia.php
@@ -13,16 +13,10 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Document;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Sonata\MediaBundle\Model\Media;
 
 abstract class BaseMedia extends Media
 {
-    public function __construct()
-    {
-        $this->galleryItems = new ArrayCollection();
-    }
-
     public function prePersist(): void
     {
         $this->createdAt = new \DateTime();

--- a/src/Entity/BaseGallery.php
+++ b/src/Entity/BaseGallery.php
@@ -13,16 +13,10 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Entity;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Sonata\MediaBundle\Model\Gallery;
 
 abstract class BaseGallery extends Gallery
 {
-    public function __construct()
-    {
-        $this->galleryItems = new ArrayCollection();
-    }
-
     public function prePersist(): void
     {
         $this->createdAt = new \DateTime();

--- a/src/Entity/BaseMedia.php
+++ b/src/Entity/BaseMedia.php
@@ -13,16 +13,10 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Entity;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Sonata\MediaBundle\Model\Media;
 
 abstract class BaseMedia extends Media
 {
-    public function __construct()
-    {
-        $this->galleryItems = new ArrayCollection();
-    }
-
     public function prePersist(): void
     {
         $this->createdAt = new \DateTime();

--- a/src/Model/Gallery.php
+++ b/src/Model/Gallery.php
@@ -36,6 +36,11 @@ abstract class Gallery implements GalleryInterface
      */
     protected Collection $galleryItems;
 
+    public function __construct()
+    {
+        $this->galleryItems = new ArrayCollection();
+    }
+
     public function __toString(): string
     {
         return $this->getName() ?? '-';

--- a/src/Model/Media.php
+++ b/src/Model/Media.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Model;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Imagine\Image\Box;
 use Sonata\ClassificationBundle\Model\CategoryInterface;
@@ -80,6 +81,11 @@ abstract class Media implements MediaInterface
      * @var CategoryInterface|null
      */
     protected ?object $category = null;
+
+    public function __construct()
+    {
+        $this->galleryItems = new ArrayCollection();
+    }
 
     public function __toString(): string
     {

--- a/tests/Form/Type/AbstractTypeTest.php
+++ b/tests/Form/Type/AbstractTypeTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\MediaBundle\Tests\Form\Type;
 
 use Sonata\MediaBundle\Provider\Pool;
-use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\Test\TypeTestCase;
 
@@ -23,8 +22,6 @@ use Symfony\Component\Form\Test\TypeTestCase;
  */
 abstract class AbstractTypeTest extends TypeTestCase
 {
-    protected FormBuilder $formBuilder;
-
     protected FormTypeInterface $formType;
 
     protected Pool $mediaPool;

--- a/tests/Provider/AbstractProviderTest.php
+++ b/tests/Provider/AbstractProviderTest.php
@@ -27,7 +27,6 @@ use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Sonata\MediaBundle\Tests\App\Entity\Media;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormTypeInterface;
 
 /**
  * @author Virgile Vivier <virgilevivier@gmail.com>
@@ -45,11 +44,6 @@ abstract class AbstractProviderTest extends TestCase
      * @var FormMapper<MediaInterface>
      */
     protected FormMapper $form;
-
-    /**
-     * @var MockObject&FormTypeInterface
-     */
-    protected MockObject $formType;
 
     /**
      * @phpstan-var T


### PR DESCRIPTION
We should use those defaults on all projects

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Moved `__construct()` method from Entity/Document to Model.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
