### PR TITLE
Make methods protected

### DIFF
--- a/src/Admin/BaseMediaAdmin.php
+++ b/src/Admin/BaseMediaAdmin.php
@@ -57,13 +57,25 @@ abstract class BaseMediaAdmin extends AbstractAdmin
         $this->contextManager = $contextManager;
     }
 
-    public function prePersist(object $object): void
+    final public function getObjectMetadata(object $object): MetadataInterface
+    {
+        $provider = $this->pool->getProvider($object->getProviderName());
+
+        $url = $provider->generatePublicUrl(
+            $object,
+            $provider->getFormatName($object, MediaProviderInterface::FORMAT_ADMIN)
+        );
+
+        return new Metadata($this->toString($object), $object->getDescription(), $url);
+    }
+
+    protected function prePersist(object $object): void
     {
         $parameters = $this->getPersistentParameters();
         $object->setContext($parameters['context']);
     }
 
-    public function configurePersistentParameters(): array
+    protected function configurePersistentParameters(): array
     {
         $parameters = [];
 
@@ -112,7 +124,7 @@ abstract class BaseMediaAdmin extends AbstractAdmin
         ]);
     }
 
-    public function alterNewInstance(object $object): void
+    protected function alterNewInstance(object $object): void
     {
         if ($this->hasRequest()) {
             if ($this->getRequest()->isMethod('POST')) {
@@ -139,18 +151,6 @@ abstract class BaseMediaAdmin extends AbstractAdmin
                 }
             }
         }
-    }
-
-    final public function getObjectMetadata(object $object): MetadataInterface
-    {
-        $provider = $this->pool->getProvider($object->getProviderName());
-
-        $url = $provider->generatePublicUrl(
-            $object,
-            $provider->getFormatName($object, MediaProviderInterface::FORMAT_ADMIN)
-        );
-
-        return new Metadata($this->toString($object), $object->getDescription(), $url);
     }
 
     protected function configureListFields(ListMapper $list): void

--- a/src/Admin/GalleryAdmin.php
+++ b/src/Admin/GalleryAdmin.php
@@ -40,19 +40,19 @@ final class GalleryAdmin extends AbstractAdmin
         $this->pool = $pool;
     }
 
-    public function prePersist(object $object): void
+    protected function prePersist(object $object): void
     {
         $parameters = $this->getPersistentParameters();
 
         $object->setContext($parameters['context']);
     }
 
-    public function postUpdate(object $object): void
+    protected function postUpdate(object $object): void
     {
         $object->reorderGalleryItems();
     }
 
-    public function configurePersistentParameters(): array
+    protected function configurePersistentParameters(): array
     {
         if (!$this->hasRequest()) {
             return [];
@@ -63,7 +63,7 @@ final class GalleryAdmin extends AbstractAdmin
         ];
     }
 
-    public function alterNewInstance(object $object): void
+    protected function alterNewInstance(object $object): void
     {
         if ($this->hasRequest()) {
             $object->setContext($this->getRequest()->get('context'));

--- a/tests/Admin/BaseMediaAdminTest.php
+++ b/tests/Admin/BaseMediaAdminTest.php
@@ -19,7 +19,6 @@ use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
-use Sonata\MediaBundle\Entity\BaseMedia;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\MediaBundle\Provider\Pool;
@@ -61,7 +60,7 @@ class BaseMediaAdminTest extends TestCase
 
         $this->mediaAdmin = new TestMediaAdmin(
             'media',
-            BaseMedia::class,
+            Media::class,
             'SonataMediaBundle:MediaAdmin',
             $this->pool,
             $this->categoryManager,
@@ -74,7 +73,6 @@ class BaseMediaAdminTest extends TestCase
 
     public function testAlterNewInstance(): void
     {
-        $media = new Media();
         $category = new Category();
         $context = new Context();
 
@@ -86,7 +84,7 @@ class BaseMediaAdminTest extends TestCase
         $this->categoryManager->method('find')->with(1)->willReturn($category);
         $this->request->setMethod('POST');
 
-        $this->mediaAdmin->alterNewInstance($media);
+        $media = $this->mediaAdmin->getNewInstance();
 
         static::assertSame('context', $media->getContext());
         static::assertSame($category, $media->getCategory());


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

On the admin-bundle 4.0 a lot of method were made protected, we missed this change on the migration to Sonata 4.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Changed visibility for public methods on Admin classes.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
