### PR TITLE
Make admin dependency optional for blocks

### DIFF
--- a/src/Block/FeatureMediaBlockService.php
+++ b/src/Block/FeatureMediaBlockService.php
@@ -43,19 +43,19 @@ final class FeatureMediaBlockService extends AbstractBlockService implements Edi
     private Pool $pool;
 
     /**
-     * @var AdminInterface<MediaInterface>
+     * @var AdminInterface<MediaInterface>|null
      */
-    private AdminInterface $mediaAdmin;
+    private ?AdminInterface $mediaAdmin;
 
     private MediaManagerInterface $mediaManager;
 
     /**
-     * @param AdminInterface<MediaInterface> $mediaAdmin
+     * @param AdminInterface<MediaInterface>|null $mediaAdmin
      */
     public function __construct(
         Environment $twig,
         Pool $pool,
-        AdminInterface $mediaAdmin,
+        ?AdminInterface $mediaAdmin,
         MediaManagerInterface $mediaManager
     ) {
         parent::__construct($twig);
@@ -220,6 +220,10 @@ final class FeatureMediaBlockService extends AbstractBlockService implements Edi
 
     private function getMediaBuilder(FormMapper $form): FormBuilderInterface
     {
+        if (null === $this->mediaAdmin) {
+            throw new \LogicException('The SonataAdminBundle is required to render the edit form.');
+        }
+
         $fieldDescription = $this->mediaAdmin->createFieldDescription('media', [
             'translation_domain' => 'SonataMediaBundle',
             'edit' => 'list',

--- a/src/Block/MediaBlockService.php
+++ b/src/Block/MediaBlockService.php
@@ -42,19 +42,19 @@ final class MediaBlockService extends AbstractBlockService implements EditableBl
     private Pool $pool;
 
     /**
-     * @var AdminInterface<MediaInterface>
+     * @var AdminInterface<MediaInterface>|null
      */
-    private AdminInterface $mediaAdmin;
+    private ?AdminInterface $mediaAdmin;
 
     private MediaManagerInterface $mediaManager;
 
     /**
-     * @param AdminInterface<MediaInterface> $mediaAdmin
+     * @param AdminInterface<MediaInterface>|null $mediaAdmin
      */
     public function __construct(
         Environment $twig,
         Pool $pool,
-        AdminInterface $mediaAdmin,
+        ?AdminInterface $mediaAdmin,
         MediaManagerInterface $mediaManager
     ) {
         parent::__construct($twig);
@@ -209,6 +209,10 @@ final class MediaBlockService extends AbstractBlockService implements EditableBl
 
     private function getMediaBuilder(FormMapper $form): FormBuilderInterface
     {
+        if (null === $this->mediaAdmin) {
+            throw new \LogicException('The SonataAdminBundle is required to render the edit form.');
+        }
+
         $fieldDescription = $this->mediaAdmin->createFieldDescription('media', [
             'translation_domain' => 'SonataMediaBundle',
             'edit' => 'list',

--- a/src/Resources/config/block.php
+++ b/src/Resources/config/block.php
@@ -27,7 +27,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->args([
                 new ReferenceConfigurator('twig'),
                 new ReferenceConfigurator('sonata.media.pool'),
-                new ReferenceConfigurator('sonata.media.admin.media'),
+                (new ReferenceConfigurator('sonata.media.admin.media'))->nullOnInvalid(),
                 new ReferenceConfigurator('sonata.media.manager.media'),
             ])
 
@@ -36,7 +36,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->args([
                 new ReferenceConfigurator('twig'),
                 new ReferenceConfigurator('sonata.media.pool'),
-                new ReferenceConfigurator('sonata.media.admin.media'),
+                (new ReferenceConfigurator('sonata.media.admin.media'))->nullOnInvalid(),
                 new ReferenceConfigurator('sonata.media.manager.media'),
             ])
 

--- a/tests/Block/FeatureMediaBlockServiceTest.php
+++ b/tests/Block/FeatureMediaBlockServiceTest.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Tests\Block;
 
+use PHPUnit\Framework\MockObject\Stub;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\BlockBundle\Test\BlockServiceTestCase;
 use Sonata\MediaBundle\Block\FeatureMediaBlockService;
+use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Sonata\MediaBundle\Provider\Pool;
 
@@ -27,10 +29,13 @@ class FeatureMediaBlockServiceTest extends BlockServiceTestCase
     {
         parent::setUp();
 
+        /** @var AdminInterface<MediaInterface>&Stub $mediaAdmin */
+        $mediaAdmin = $this->createStub(AdminInterface::class);
+
         $this->blockService = new FeatureMediaBlockService(
             $this->twig,
             new Pool('default'),
-            $this->createStub(AdminInterface::class),
+            $mediaAdmin,
             $this->createStub(MediaManagerInterface::class)
         );
     }

--- a/tests/Block/MediaBlockServiceTest.php
+++ b/tests/Block/MediaBlockServiceTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\MediaBundle\Tests\Block;
 
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\Block;
@@ -35,10 +36,13 @@ class MediaBlockServiceTest extends BlockServiceTestCase
 
         $this->pool = new Pool('default');
 
+        /** @var AdminInterface<MediaInterface>&Stub $mediaAdmin */
+        $mediaAdmin = $this->createStub(AdminInterface::class);
+
         $this->blockService = new MediaBlockService(
             $this->twig,
             $this->pool,
-            $this->createStub(AdminInterface::class),
+            $mediaAdmin,
             $this->createStub(MediaManagerInterface::class)
         );
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This is a patch for the upcoming stable release. As the admin bundle is an optional dependency, it should be possible to render the blocks without it.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Make "sonata-project/admin-bundle" dependency optional for blocks
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
