### PR TITLE
Fix: bad annotation ValidMediaFormat constraint

### DIFF
--- a/src/Validator/Constraints/ValidMediaFormat.php
+++ b/src/Validator/Constraints/ValidMediaFormat.php
@@ -17,8 +17,6 @@ use Symfony\Component\Validator\Constraint;
 
 /**
  * @Annotation
- */
-/**
  * @final since sonata-project/media-bundle 3.21.0
  */
 class ValidMediaFormat extends Constraint


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Since v3.21.0, theez is a bug in annotation see  [this issue](https://github.com/sonata-project/SonataMediaBundle/issues/2206) for more details.

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->


<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix creation of galleries, an annotation was incorrectly configured.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
