### PR TITLE
Make admin dependency optional for blocks

### DIFF
--- a/src/Resources/config/block.php
+++ b/src/Resources/config/block.php
@@ -45,7 +45,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->args([
                 new ReferenceConfigurator('twig'),
                 new ReferenceConfigurator('sonata.media.pool'),
-                new ReferenceConfigurator('sonata.media.admin.gallery'),
+                (new ReferenceConfigurator('sonata.media.admin.gallery'))->nullOnInvalid(),
                 new ReferenceConfigurator('sonata.media.manager.gallery'),
             ])
 

--- a/tests/Block/GalleryBlockServiceTest.php
+++ b/tests/Block/GalleryBlockServiceTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\MediaBundle\Tests\Block;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\MockObject\Stub;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\Block;
@@ -31,10 +32,13 @@ class GalleryBlockServiceTest extends BlockServiceTestCase
     {
         parent::setUp();
 
+        /** @var AdminInterface<GalleryInterface>&Stub $galleryAdmin */
+        $galleryAdmin = $this->createStub(AdminInterface::class);
+
         $this->blockService = new GalleryBlockService(
             $this->twig,
             new Pool('default'),
-            $this->createStub(AdminInterface::class),
+            $galleryAdmin,
             $this->createStub(GalleryManagerInterface::class)
         );
     }


### PR DESCRIPTION
#2214 fixed most of the problems, but one block service was missing

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix block service registration
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
