### PR TITLE
Allow `iterable` as argument 1 for `MediaInterface::setGalleryItems()` and `GalleryInterface::setGalleryItems()`

### DIFF
--- a/src/Model/Gallery.php
+++ b/src/Model/Gallery.php
@@ -106,9 +106,9 @@ abstract class Gallery implements GalleryInterface
         return $this->defaultFormat;
     }
 
-    final public function setGalleryItems(Collection $galleryItems): void
+    final public function setGalleryItems(iterable $galleryItems): void
     {
-        $this->galleryItems = new ArrayCollection();
+        $this->galleryItems->clear();
 
         foreach ($galleryItems as $galleryItem) {
             $this->addGalleryItem($galleryItem);
@@ -150,6 +150,6 @@ abstract class Gallery implements GalleryInterface
             return $a->getPosition() <=> $b->getPosition();
         });
 
-        $this->setGalleryItems(new ArrayCollection(iterator_to_array($iterator)));
+        $this->setGalleryItems($iterator);
     }
 }

--- a/src/Model/GalleryInterface.php
+++ b/src/Model/GalleryInterface.php
@@ -49,9 +49,9 @@ interface GalleryInterface
     public function getDefaultFormat(): string;
 
     /**
-     * @param Collection<int, GalleryItemInterface> $galleryItems
+     * @param iterable<int, GalleryItemInterface> $galleryItems
      */
-    public function setGalleryItems(Collection $galleryItems): void;
+    public function setGalleryItems(iterable $galleryItems): void;
 
     /**
      * @return Collection<int, GalleryItemInterface>

--- a/src/Model/Media.php
+++ b/src/Model/Media.php
@@ -312,9 +312,13 @@ abstract class Media implements MediaInterface
         $this->category = $category;
     }
 
-    final public function setGalleryItems(Collection $galleryItems): void
+    final public function setGalleryItems(iterable $galleryItems): void
     {
-        $this->galleryItems = $galleryItems;
+        $this->galleryItems->clear();
+
+        foreach ($galleryItems as $galleryItem) {
+            $this->galleryItems->add($galleryItem);
+        }
     }
 
     final public function getGalleryItems(): Collection

--- a/src/Model/MediaInterface.php
+++ b/src/Model/MediaInterface.php
@@ -135,9 +135,9 @@ interface MediaInterface
     public function setCategory(?object $category = null): void;
 
     /**
-     * @param Collection<int, GalleryItemInterface> $galleryItems
+     * @param iterable<int, GalleryItemInterface> $galleryItems
      */
-    public function setGalleryItems(Collection $galleryItems): void;
+    public function setGalleryItems(iterable $galleryItems): void;
 
     /**
      * @return Collection<int, GalleryItemInterface>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Allow `iterable` as argument 1 for `MediaInterface::setGalleryItems()` and `GalleryInterface::setGalleryItems()`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because here is where the changed type declarations were added.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Argument 1 in order to allow any iterable type at `MediaInterface::setGalleryItems()` and `GalleryInterface::setGalleryItems()`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
