### PR TITLE
Fix wrong parentheses in template

### DIFF
--- a/src/Resources/views/MediaAdmin/inner_row_media.html.twig
+++ b/src/Resources/views/MediaAdmin/inner_row_media.html.twig
@@ -15,7 +15,7 @@ file that was distributed with this source code.
     <div class="col-sm-12">
         <div class="pull-left">
             {% if admin.isGranted('EDIT', object) and admin.hasRoute('edit') %}
-                <a href="{{ admin.generateObjectUrl('edit', object) }) }}" style="float: left; margin-right: 6px;">
+                <a href="{{ admin.generateObjectUrl('edit', object) }}" style="float: left; margin-right: 6px;">
                     {{ sonata_thumbnail(object, 'admin', {'width': 90}) }}
                 </a>
             {% else %}
@@ -24,7 +24,7 @@ file that was distributed with this source code.
         </div>
         <span class="badge pull-right">{{ object.providerName|trans({}, 'SonataMediaBundle') }}</span>
         {% if admin.isGranted('EDIT', object) and admin.hasRoute('edit') %}
-            <a href="{{ admin.generateObjectUrl('edit', object }) }}"><strong>{{ object.name }}</strong></a>
+            <a href="{{ admin.generateObjectUrl('edit', object) }}"><strong>{{ object.name }}</strong></a>
         {% else %}
             <strong>{{ object.name }}</strong>
         {% endif %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because there are syntax errors in one of the Twig templates.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #2243.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `src/Resources/views/MediaAdmin/inner_row_media.html.twig`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
