### PR TITLE
Avoid using final for getters/setters

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="v4.15.0@a1b5e489e6fcebe40cb804793d964e99fc347820">
+    <file src="src/Provider/BaseVideoProvider.php">
+        <InvalidScalarArgument occurrences="1">
+            <code>$exception-&gt;getCode()</code>
+        </InvalidScalarArgument>
+    </file>
+</files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<psalm xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://getpsalm.org/schema/config" errorLevel="2" findUnusedPsalmSuppress="true" resolveFromConfigFile="true" xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd">
+<psalm xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://getpsalm.org/schema/config" errorLevel="2" findUnusedPsalmSuppress="true" resolveFromConfigFile="true" xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd" errorBaseline="psalm-baseline.xml">
     <projectFiles>
         <directory name="src"/>
         <directory name="tests"/>

--- a/src/Model/Gallery.php
+++ b/src/Model/Gallery.php
@@ -52,67 +52,67 @@ abstract class Gallery implements GalleryInterface
         return $this->getName() ?? '-';
     }
 
-    final public function setName(?string $name): void
+    public function setName(?string $name): void
     {
         $this->name = $name;
     }
 
-    final public function getName(): ?string
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    final public function setContext(?string $context): void
+    public function setContext(?string $context): void
     {
         $this->context = $context;
     }
 
-    final public function getContext(): ?string
+    public function getContext(): ?string
     {
         return $this->context;
     }
 
-    final public function setEnabled(bool $enabled): void
+    public function setEnabled(bool $enabled): void
     {
         $this->enabled = $enabled;
     }
 
-    final public function getEnabled(): bool
+    public function getEnabled(): bool
     {
         return $this->enabled;
     }
 
-    final public function setUpdatedAt(?\DateTimeInterface $updatedAt): void
+    public function setUpdatedAt(?\DateTimeInterface $updatedAt): void
     {
         $this->updatedAt = $updatedAt;
     }
 
-    final public function getUpdatedAt(): ?\DateTimeInterface
+    public function getUpdatedAt(): ?\DateTimeInterface
     {
         return $this->updatedAt;
     }
 
-    final public function setCreatedAt(?\DateTimeInterface $createdAt): void
+    public function setCreatedAt(?\DateTimeInterface $createdAt): void
     {
         $this->createdAt = $createdAt;
     }
 
-    final public function getCreatedAt(): ?\DateTimeInterface
+    public function getCreatedAt(): ?\DateTimeInterface
     {
         return $this->createdAt;
     }
 
-    final public function setDefaultFormat(string $defaultFormat): void
+    public function setDefaultFormat(string $defaultFormat): void
     {
         $this->defaultFormat = $defaultFormat;
     }
 
-    final public function getDefaultFormat(): string
+    public function getDefaultFormat(): string
     {
         return $this->defaultFormat;
     }
 
-    final public function setGalleryItems(iterable $galleryItems): void
+    public function setGalleryItems(iterable $galleryItems): void
     {
         $this->galleryItems->clear();
 
@@ -121,26 +121,26 @@ abstract class Gallery implements GalleryInterface
         }
     }
 
-    final public function getGalleryItems(): Collection
+    public function getGalleryItems(): Collection
     {
         return $this->galleryItems;
     }
 
-    final public function addGalleryItem(GalleryItemInterface $galleryItem): void
+    public function addGalleryItem(GalleryItemInterface $galleryItem): void
     {
         $galleryItem->setGallery($this);
 
         $this->galleryItems[] = $galleryItem;
     }
 
-    final public function removeGalleryItem(GalleryItemInterface $galleryItem): void
+    public function removeGalleryItem(GalleryItemInterface $galleryItem): void
     {
         if ($this->galleryItems->contains($galleryItem)) {
             $this->galleryItems->removeElement($galleryItem);
         }
     }
 
-    final public function reorderGalleryItems(): void
+    public function reorderGalleryItems(): void
     {
         $iterator = $this->getGalleryItems()->getIterator();
 

--- a/src/Model/GalleryItem.php
+++ b/src/Model/GalleryItem.php
@@ -35,62 +35,62 @@ abstract class GalleryItem implements GalleryItemInterface
         return $this->getGallery().' | '.$this->getMedia();
     }
 
-    final public function setEnabled(bool $enabled): void
+    public function setEnabled(bool $enabled): void
     {
         $this->enabled = $enabled;
     }
 
-    final public function getEnabled(): bool
+    public function getEnabled(): bool
     {
         return $this->enabled;
     }
 
-    final public function setGallery(?GalleryInterface $gallery = null): void
+    public function setGallery(?GalleryInterface $gallery = null): void
     {
         $this->gallery = $gallery;
     }
 
-    final public function getGallery(): ?GalleryInterface
+    public function getGallery(): ?GalleryInterface
     {
         return $this->gallery;
     }
 
-    final public function setMedia(?MediaInterface $media = null): void
+    public function setMedia(?MediaInterface $media = null): void
     {
         $this->media = $media;
     }
 
-    final public function getMedia(): ?MediaInterface
+    public function getMedia(): ?MediaInterface
     {
         return $this->media;
     }
 
-    final public function setPosition(int $position): void
+    public function setPosition(int $position): void
     {
         $this->position = $position;
     }
 
-    final public function getPosition(): int
+    public function getPosition(): int
     {
         return $this->position;
     }
 
-    final public function setUpdatedAt(?\DateTimeInterface $updatedAt): void
+    public function setUpdatedAt(?\DateTimeInterface $updatedAt): void
     {
         $this->updatedAt = $updatedAt;
     }
 
-    final public function getUpdatedAt(): ?\DateTimeInterface
+    public function getUpdatedAt(): ?\DateTimeInterface
     {
         return $this->updatedAt;
     }
 
-    final public function setCreatedAt(?\DateTimeInterface $createdAt): void
+    public function setCreatedAt(?\DateTimeInterface $createdAt): void
     {
         $this->createdAt = $createdAt;
     }
 
-    final public function getCreatedAt(): ?\DateTimeInterface
+    public function getCreatedAt(): ?\DateTimeInterface
     {
         return $this->createdAt;
     }

--- a/src/Model/Media.php
+++ b/src/Model/Media.php
@@ -92,227 +92,227 @@ abstract class Media implements MediaInterface
         return $this->getName() ?? 'n/a';
     }
 
-    final public function setName(?string $name): void
+    public function setName(?string $name): void
     {
         $this->name = $name;
     }
 
-    final public function getName(): ?string
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    final public function setDescription(?string $description): void
+    public function setDescription(?string $description): void
     {
         $this->description = $description;
     }
 
-    final public function getDescription(): ?string
+    public function getDescription(): ?string
     {
         return $this->description;
     }
 
-    final public function setEnabled(bool $enabled): void
+    public function setEnabled(bool $enabled): void
     {
         $this->enabled = $enabled;
     }
 
-    final public function getEnabled(): bool
+    public function getEnabled(): bool
     {
         return $this->enabled;
     }
 
-    final public function setProviderName(?string $providerName): void
+    public function setProviderName(?string $providerName): void
     {
         $this->providerName = $providerName;
     }
 
-    final public function getProviderName(): ?string
+    public function getProviderName(): ?string
     {
         return $this->providerName;
     }
 
-    final public function setProviderStatus(?int $providerStatus): void
+    public function setProviderStatus(?int $providerStatus): void
     {
         $this->providerStatus = $providerStatus;
     }
 
-    final public function getProviderStatus(): ?int
+    public function getProviderStatus(): ?int
     {
         return $this->providerStatus;
     }
 
-    final public function setProviderReference(?string $providerReference): void
+    public function setProviderReference(?string $providerReference): void
     {
         $this->providerReference = $providerReference;
     }
 
-    final public function getProviderReference(): ?string
+    public function getProviderReference(): ?string
     {
         return $this->providerReference;
     }
 
-    final public function setProviderMetadata(array $providerMetadata = []): void
+    public function setProviderMetadata(array $providerMetadata = []): void
     {
         $this->providerMetadata = $providerMetadata;
     }
 
-    final public function getProviderMetadata(): array
+    public function getProviderMetadata(): array
     {
         return $this->providerMetadata;
     }
 
-    final public function setWidth(?int $width): void
+    public function setWidth(?int $width): void
     {
         $this->width = $width;
     }
 
-    final public function getWidth(): ?int
+    public function getWidth(): ?int
     {
         return $this->width;
     }
 
-    final public function setHeight(?int $height): void
+    public function setHeight(?int $height): void
     {
         $this->height = $height;
     }
 
-    final public function getHeight(): ?int
+    public function getHeight(): ?int
     {
         return $this->height;
     }
 
-    final public function setLength(?float $length): void
+    public function setLength(?float $length): void
     {
         $this->length = $length;
     }
 
-    final public function getLength(): ?float
+    public function getLength(): ?float
     {
         return $this->length;
     }
 
-    final public function setCopyright(?string $copyright): void
+    public function setCopyright(?string $copyright): void
     {
         $this->copyright = $copyright;
     }
 
-    final public function getCopyright(): ?string
+    public function getCopyright(): ?string
     {
         return $this->copyright;
     }
 
-    final public function setAuthorName(?string $authorName): void
+    public function setAuthorName(?string $authorName): void
     {
         $this->authorName = $authorName;
     }
 
-    final public function getAuthorName(): ?string
+    public function getAuthorName(): ?string
     {
         return $this->authorName;
     }
 
-    final public function setContext(?string $context): void
+    public function setContext(?string $context): void
     {
         $this->context = $context;
     }
 
-    final public function getContext(): ?string
+    public function getContext(): ?string
     {
         return $this->context;
     }
 
-    final public function setCdnStatus(?int $cdnStatus): void
+    public function setCdnStatus(?int $cdnStatus): void
     {
         $this->cdnStatus = $cdnStatus;
     }
 
-    final public function getCdnStatus(): ?int
+    public function getCdnStatus(): ?int
     {
         return $this->cdnStatus;
     }
 
-    final public function setCdnIsFlushable(bool $cdnIsFlushable): void
+    public function setCdnIsFlushable(bool $cdnIsFlushable): void
     {
         $this->cdnIsFlushable = $cdnIsFlushable;
     }
 
-    final public function getCdnIsFlushable(): bool
+    public function getCdnIsFlushable(): bool
     {
         return $this->cdnIsFlushable;
     }
 
-    final public function setCdnFlushIdentifier(?string $cdnFlushIdentifier): void
+    public function setCdnFlushIdentifier(?string $cdnFlushIdentifier): void
     {
         $this->cdnFlushIdentifier = $cdnFlushIdentifier;
     }
 
-    final public function getCdnFlushIdentifier(): ?string
+    public function getCdnFlushIdentifier(): ?string
     {
         return $this->cdnFlushIdentifier;
     }
 
-    final public function setCdnFlushAt(?\DateTimeInterface $cdnFlushAt): void
+    public function setCdnFlushAt(?\DateTimeInterface $cdnFlushAt): void
     {
         $this->cdnFlushAt = $cdnFlushAt;
     }
 
-    final public function getCdnFlushAt(): ?\DateTimeInterface
+    public function getCdnFlushAt(): ?\DateTimeInterface
     {
         return $this->cdnFlushAt;
     }
 
-    final public function setUpdatedAt(?\DateTimeInterface $updatedAt): void
+    public function setUpdatedAt(?\DateTimeInterface $updatedAt): void
     {
         $this->updatedAt = $updatedAt;
     }
 
-    final public function getUpdatedAt(): ?\DateTimeInterface
+    public function getUpdatedAt(): ?\DateTimeInterface
     {
         return $this->updatedAt;
     }
 
-    final public function setCreatedAt(?\DateTimeInterface $createdAt): void
+    public function setCreatedAt(?\DateTimeInterface $createdAt): void
     {
         $this->createdAt = $createdAt;
     }
 
-    final public function getCreatedAt(): ?\DateTimeInterface
+    public function getCreatedAt(): ?\DateTimeInterface
     {
         return $this->createdAt;
     }
 
-    final public function setContentType(?string $contentType): void
+    public function setContentType(?string $contentType): void
     {
         $this->contentType = $contentType;
     }
 
-    final public function getContentType(): ?string
+    public function getContentType(): ?string
     {
         return $this->contentType;
     }
 
-    final public function setSize(?int $size): void
+    public function setSize(?int $size): void
     {
         $this->size = $size;
     }
 
-    final public function getSize(): ?int
+    public function getSize(): ?int
     {
         return $this->size;
     }
 
-    final public function getCategory(): ?object
+    public function getCategory(): ?object
     {
         return $this->category;
     }
 
-    final public function setCategory(?object $category = null): void
+    public function setCategory(?object $category = null): void
     {
         $this->category = $category;
     }
 
-    final public function setGalleryItems(iterable $galleryItems): void
+    public function setGalleryItems(iterable $galleryItems): void
     {
         $this->galleryItems->clear();
 
@@ -321,17 +321,17 @@ abstract class Media implements MediaInterface
         }
     }
 
-    final public function getGalleryItems(): Collection
+    public function getGalleryItems(): Collection
     {
         return $this->galleryItems;
     }
 
-    final public function getBox(): Box
+    public function getBox(): Box
     {
         return new Box($this->width ?? 0, $this->height ?? 0);
     }
 
-    final public function getExtension(): ?string
+    public function getExtension(): ?string
     {
         $providerReference = $this->getProviderReference();
 
@@ -343,43 +343,43 @@ abstract class Media implements MediaInterface
         return preg_replace('{(\?|#).*}', '', pathinfo($providerReference, \PATHINFO_EXTENSION));
     }
 
-    final public function getPreviousProviderReference(): ?string
+    public function getPreviousProviderReference(): ?string
     {
         return $this->previousProviderReference;
     }
 
-    final public function setBinaryContent($binaryContent): void
+    public function setBinaryContent($binaryContent): void
     {
         $this->previousProviderReference = $this->providerReference;
         $this->providerReference = null;
         $this->binaryContent = $binaryContent;
     }
 
-    final public function resetBinaryContent(): void
+    public function resetBinaryContent(): void
     {
         $this->binaryContent = null;
     }
 
-    final public function getBinaryContent()
+    public function getBinaryContent()
     {
         return $this->binaryContent;
     }
 
-    final public function getMetadataValue(string $name, $default = null)
+    public function getMetadataValue(string $name, $default = null)
     {
         $metadata = $this->getProviderMetadata();
 
         return $metadata[$name] ?? $default;
     }
 
-    final public function setMetadataValue(string $name, $value): void
+    public function setMetadataValue(string $name, $value): void
     {
         $metadata = $this->getProviderMetadata();
         $metadata[$name] = $value;
         $this->setProviderMetadata($metadata);
     }
 
-    final public function unsetMetadataValue(string $name): void
+    public function unsetMetadataValue(string $name): void
     {
         $metadata = $this->getProviderMetadata();
         unset($metadata[$name]);

--- a/src/Provider/BaseVideoProvider.php
+++ b/src/Provider/BaseVideoProvider.php
@@ -179,11 +179,11 @@ abstract class BaseVideoProvider extends BaseProvider
     {
         try {
             $response = $this->sendRequest('GET', $url);
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException $exception) {
             throw new \RuntimeException(
                 sprintf('Unable to retrieve the video information for: %s', $url),
-                \is_int($e->getCode()) ? $e->getCode() : 0,
-                $e
+                $exception->getCode(),
+                $exception
             );
         }
 


### PR DESCRIPTION
For some reason it messes up with doctrine proxy loading

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a bug fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #2232 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Final modifier on all the getters / setters of the entities.

### Fixed
- Loading Media / Gallery object from the database.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
