### PR TITLE
Backport ImageProviderInterface from 4.x

### DIFF
--- a/src/Provider/ImageProvider.php
+++ b/src/Provider/ImageProvider.php
@@ -27,7 +27,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 /**
  * @final since sonata-project/media-bundle 3.21.0
  */
-class ImageProvider extends FileProvider
+class ImageProvider extends FileProvider implements ImageProviderInterface
 {
     /**
      * @var ImagineInterface

--- a/src/Provider/ImageProviderInterface.php
+++ b/src/Provider/ImageProviderInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\MediaBundle\Provider;
+
+/**
+ * @author Jordi Sala <jordism91@gmail.com>
+ */
+interface ImageProviderInterface
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function getFormatsForContext(string $context): array;
+}

--- a/src/Validator/Constraints/ImageUploadDimensionValidator.php
+++ b/src/Validator/Constraints/ImageUploadDimensionValidator.php
@@ -15,7 +15,7 @@ namespace Sonata\MediaBundle\Validator\Constraints;
 
 use Imagine\Image\ImagineInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
-use Sonata\MediaBundle\Provider\ImageProvider;
+use Sonata\MediaBundle\Provider\ImageProviderInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -28,11 +28,11 @@ final class ImageUploadDimensionValidator extends ConstraintValidator
     private $imagineAdapter;
 
     /**
-     * @var ImageProvider
+     * @var ImageProviderInterface
      */
     private $imageProvider;
 
-    public function __construct(ImagineInterface $imagineAdapter, ImageProvider $imageProvider)
+    public function __construct(ImagineInterface $imagineAdapter, ImageProviderInterface $imageProvider)
     {
         $this->imagineAdapter = $imagineAdapter;
         $this->imageProvider = $imageProvider;

--- a/tests/Fixtures/SonataClassificationBundle/Validator/Constraints/ImageUploadDimensionValidatorTest.php
+++ b/tests/Fixtures/SonataClassificationBundle/Validator/Constraints/ImageUploadDimensionValidatorTest.php
@@ -19,7 +19,7 @@ use Imagine\Image\ImagineInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
 use Sonata\MediaBundle\Model\MediaInterface;
-use Sonata\MediaBundle\Provider\ImageProvider;
+use Sonata\MediaBundle\Provider\ImageProviderInterface;
 use Sonata\MediaBundle\Validator\Constraints\ImageUploadDimension;
 use Sonata\MediaBundle\Validator\Constraints\ImageUploadDimensionValidator;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -37,14 +37,14 @@ final class ImageUploadDimensionValidatorTest extends ConstraintValidatorTestCas
     private $imagineAdapter;
 
     /**
-     * @var ImageProvider&MockObject
+     * @var ImageProviderInterface&MockObject
      */
     private $imageProvider;
 
     protected function setUp(): void
     {
         $this->imagineAdapter = $this->createStub(ImagineInterface::class);
-        $this->imageProvider = $this->createStub(ImageProvider::class);
+        $this->imageProvider = $this->createStub(ImageProviderInterface::class);
 
         parent::setUp();
     }


### PR DESCRIPTION
## Subject

I am preparing to migrate to Symfony 5 and all new Sonata bundle, including Media Bundle 4. One issue is that I have a class that inherits from `ImageProvider`. This is no longer possible in 4.0, where a new interface `ImageProviderInterface` is introduced. It would be convenient if I could migrate my implementation to this new interface before migrating every Sonata/Symfony package.

I am targeting this branch, because it backports a feature from 4.0.

## Changelog

```markdown
### Added
- Added `ImageProviderInterface` so `ImageProvider` can be replaced without extending the class.
```