### PR TITLE
Fix root category check

### DIFF
--- a/src/Listener/ORM/MediaEventSubscriber.php
+++ b/src/Listener/ORM/MediaEventSubscriber.php
@@ -98,10 +98,16 @@ final class MediaEventSubscriber extends BaseMediaEventSubscriber
             throw new \RuntimeException(sprintf('There is no context on media %s', $media->getId() ?? ''));
         }
 
-        if (null === $this->rootCategories || !\array_key_exists($context, $this->rootCategories)) {
-            throw new \RuntimeException(sprintf('There is no main category related to context: %s', $context));
+        if (null !== $this->rootCategories) {
+            foreach ($this->rootCategories as $category) {
+                $categoryContext = $category->getContext();
+
+                if (null !== $categoryContext && $categoryContext->getId() === $context) {
+                    return $category;
+                }
+            }
         }
 
-        return $this->rootCategories[$context];
+        throw new \RuntimeException(sprintf('There is no main category related to context: %s', $context));
     }
 }

--- a/tests/Listener/ORM/MediaEventSubscriberTest.php
+++ b/tests/Listener/ORM/MediaEventSubscriberTest.php
@@ -18,6 +18,7 @@ use Doctrine\ORM\Events;
 use PHPUnit\Framework\TestCase;
 use Sonata\ClassificationBundle\Model\CategoryInterface;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
+use Sonata\ClassificationBundle\Model\ContextInterface;
 use Sonata\MediaBundle\Listener\ORM\MediaEventSubscriber;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\MediaBundle\Provider\Pool;
@@ -39,12 +40,17 @@ class MediaEventSubscriberTest extends TestCase
         $pool = new Pool('default');
         $pool->addProvider('provider', $provider);
 
+        $categoryContext = $this->createMock(ContextInterface::class);
+        $categoryContext->method('getId')->willReturn('context');
+
         $category = $this->createMock(CategoryInterface::class);
+        $category->method('getContext')->willReturn($categoryContext);
+
         $catManager = $this->createMock(CategoryManagerInterface::class);
 
         $catManager->expects(static::exactly(2))
             ->method('getAllRootCategories')
-            ->willReturn(['context' => $category]);
+            ->willReturn([$category]);
 
         $subscriber = new MediaEventSubscriber($pool, $catManager);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

There was an API change. The `CategoryManagerInterface::getAllRootCategories` method returns a list instead of a map.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a patch.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix root category check
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
