### PR TITLE
Avoid adminBundle deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-phpunit": "^0.16",
         "psalm/plugin-symfony": "^3.0",
-        "sonata-project/admin-bundle": "^4.0",
+        "sonata-project/admin-bundle": "^4.9",
         "sonata-project/block-bundle": "^4.0",
         "sonata-project/classification-bundle": "^4.0",
         "sonata-project/doctrine-orm-admin-bundle": "^4.0",
@@ -98,7 +98,7 @@
         "doctrine/orm": "<2.9",
         "knplabs/knp-menu-bundle": "<3.0",
         "liip/imagine-bundle": "<2.0",
-        "sonata-project/admin-bundle": "<4.0",
+        "sonata-project/admin-bundle": "<4.9",
         "sonata-project/block-bundle": "<4.0",
         "sonata-project/classification-bundle": "<4.0",
         "sonata-project/doctrine-orm-admin-bundle": "<4.0"

--- a/src/Admin/BaseMediaAdmin.php
+++ b/src/Admin/BaseMediaAdmin.php
@@ -40,21 +40,43 @@ abstract class BaseMediaAdmin extends AbstractAdmin
     protected $classnameLabel = 'Media';
 
     /**
-     * @phpstan-param class-string<\Sonata\MediaBundle\Model\MediaInterface> $class
+     * NEXT_MAJOR: Change to (Pool, ?CategoryManagerInterface, ?ContextManagerInterface).
+     *
+     * @param Pool|string                          $pool
+     * @param CategoryManagerInterface|string|null $categoryManager
+     * @param ContextManagerInterface|string|null  $contextManager
+     *
+     * @phpstan-param CategoryManagerInterface|class-string<\Sonata\MediaBundle\Model\MediaInterface>|null $categoryManager
      */
     public function __construct(
-        string $code,
-        string $class,
-        string $baseControllerName,
-        Pool $pool,
-        ?CategoryManagerInterface $categoryManager = null,
-        ?ContextManagerInterface $contextManager = null
+        $pool,
+        $categoryManager = null,
+        $contextManager = null,
+        ?Pool $deprecatedPool = null,
+        ?CategoryManagerInterface $deprecatedCategoryManager = null,
+        ?ContextManagerInterface $deprecatedContextManager = null
     ) {
-        parent::__construct($code, $class, $baseControllerName);
+        // NEXT_MAJOR: Keep the if part.
+        if ($pool instanceof Pool) {
+            \assert(!\is_string($categoryManager));
+            \assert(!\is_string($contextManager));
 
-        $this->pool = $pool;
-        $this->categoryManager = $categoryManager;
-        $this->contextManager = $contextManager;
+            parent::__construct();
+
+            $this->pool = $pool;
+            $this->categoryManager = $categoryManager;
+            $this->contextManager = $contextManager;
+        } else {
+            \assert(\is_string($categoryManager));
+            \assert(\is_string($contextManager));
+            \assert(null !== $deprecatedPool);
+
+            parent::__construct($pool, $categoryManager, $contextManager);
+
+            $this->pool = $deprecatedPool;
+            $this->categoryManager = $deprecatedCategoryManager;
+            $this->contextManager = $deprecatedContextManager;
+        }
     }
 
     final public function getObjectMetadata(object $object): MetadataInterface

--- a/src/Admin/GalleryAdmin.php
+++ b/src/Admin/GalleryAdmin.php
@@ -30,12 +30,9 @@ final class GalleryAdmin extends AbstractAdmin
 
     private Pool $pool;
 
-    /**
-     * @phpstan-param class-string<\Sonata\MediaBundle\Model\GalleryInterface<\Sonata\MediaBundle\Model\GalleryItemInterface>> $class
-     */
-    public function __construct(string $code, string $class, string $baseControllerName, Pool $pool)
+    public function __construct(Pool $pool)
     {
-        parent::__construct($code, $class, $baseControllerName);
+        parent::__construct();
 
         $this->pool = $pool;
     }

--- a/src/Admin/GalleryAdmin.php
+++ b/src/Admin/GalleryAdmin.php
@@ -118,8 +118,8 @@ final class GalleryAdmin extends AbstractAdmin
         $list
             ->addIdentifier('name')
             ->add('enabled', 'boolean', ['editable' => true])
-            ->add('context', 'trans', ['catalogue' => 'SonataMediaBundle'])
-            ->add('defaultFormat', 'trans', ['catalogue' => 'SonataMediaBundle']);
+            ->add('context', 'trans', ['value_translation_domain' => 'SonataMediaBundle'])
+            ->add('defaultFormat', 'trans', ['value_translation_domain' => 'SonataMediaBundle']);
     }
 
     protected function configureDatagridFilters(DatagridMapper $filter): void

--- a/src/Resources/config/doctrine_mongodb_admin.php
+++ b/src/Resources/config/doctrine_mongodb_admin.php
@@ -26,6 +26,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         ->set('sonata.media.admin.media', MediaAdmin::class)
             ->tag('sonata.admin', [
+                'model_class' => '%sonata.media.media.class%',
+                'controller' => 'sonata.media.controller.media.admin',
                 'manager_type' => 'doctrine_mongodb',
                 'group' => 'sonata_media',
                 'translation_domain' => 'SonataMediaBundle',
@@ -34,9 +36,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'icon' => '<i class=\'fa fa-image\'></i>',
             ])
             ->args([
-                '',
-                '%sonata.media.media.class%',
-                'sonata.media.controller.media.admin',
                 new ReferenceConfigurator('sonata.media.pool'),
                 (new ReferenceConfigurator('sonata.media.manager.category'))->nullOnInvalid(),
                 (new ReferenceConfigurator('sonata.media.manager.context'))->nullOnInvalid(),
@@ -51,6 +50,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         ->set('sonata.media.admin.gallery', GalleryAdmin::class)
             ->tag('sonata.admin', [
+                'model_class' => '%sonata.media.gallery.class%',
+                'controller' => 'sonata.media.controller.gallery.admin',
                 'manager_type' => 'doctrine_mongodb',
                 'group' => 'sonata_media',
                 'translation_domain' => 'SonataMediaBundle',
@@ -59,9 +60,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'icon' => '<i class=\'fa fa-image\'></i>',
             ])
             ->args([
-                '',
-                '%sonata.media.gallery.class%',
-                'sonata.media.controller.gallery.admin',
                 new ReferenceConfigurator('sonata.media.pool'),
             ])
             ->call('setTemplates', [[
@@ -70,6 +68,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         ->set('sonata.media.admin.gallery_item', GalleryItemAdmin::class)
             ->tag('sonata.admin', [
+                'model_class' => '%sonata.media.gallery_item.class%',
+                'controller' => '%sonata.admin.configuration.default_controller%',
                 'manager_type' => 'doctrine_mongodb',
                 'group' => 'sonata_media',
                 'translation_domain' => 'SonataMediaBundle',
@@ -77,10 +77,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'show_in_dashboard' => false,
                 'label_translator_strategy' => 'sonata.admin.label.strategy.underscore',
                 'icon' => '<i class=\'fa fa-image\'></i>',
-            ])
-            ->args([
-                '',
-                '%sonata.media.gallery_item.class%',
-                '%sonata.admin.configuration.default_controller%',
             ]);
 };

--- a/src/Resources/config/doctrine_mongodb_admin.php
+++ b/src/Resources/config/doctrine_mongodb_admin.php
@@ -28,7 +28,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->tag('sonata.admin', [
                 'manager_type' => 'doctrine_mongodb',
                 'group' => 'sonata_media',
-                'label_catalogue' => 'SonataMediaBundle',
+                'translation_domain' => 'SonataMediaBundle',
                 'label' => 'media',
                 'label_translator_strategy' => 'sonata.admin.label.strategy.underscore',
                 'icon' => '<i class=\'fa fa-image\'></i>',
@@ -42,7 +42,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 (new ReferenceConfigurator('sonata.media.manager.context'))->nullOnInvalid(),
             ])
             ->call('setModelManager', [new ReferenceConfigurator('sonata.media.admin.media.manager')])
-            ->call('setTranslationDomain', ['SonataMediaBundle'])
             ->call('setTemplates', [[
                 'inner_list_row' => '@SonataMedia/MediaAdmin/inner_row_media.html.twig',
                 'base_list_field' => '@SonataAdmin/CRUD/base_list_flat_field.html.twig',
@@ -54,7 +53,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->tag('sonata.admin', [
                 'manager_type' => 'doctrine_mongodb',
                 'group' => 'sonata_media',
-                'label_catalogue' => 'SonataMediaBundle',
+                'translation_domain' => 'SonataMediaBundle',
                 'label' => 'gallery',
                 'label_translator_strategy' => 'sonata.admin.label.strategy.underscore',
                 'icon' => '<i class=\'fa fa-image\'></i>',
@@ -65,7 +64,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'sonata.media.controller.gallery.admin',
                 new ReferenceConfigurator('sonata.media.pool'),
             ])
-            ->call('setTranslationDomain', ['SonataMediaBundle'])
             ->call('setTemplates', [[
                 'list' => '@SonataMedia/GalleryAdmin/list.html.twig',
             ]])
@@ -74,7 +72,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->tag('sonata.admin', [
                 'manager_type' => 'doctrine_mongodb',
                 'group' => 'sonata_media',
-                'label_catalogue' => 'SonataMediaBundle',
+                'translation_domain' => 'SonataMediaBundle',
                 'label' => 'gallery_item',
                 'show_in_dashboard' => false,
                 'label_translator_strategy' => 'sonata.admin.label.strategy.underscore',
@@ -84,6 +82,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 '',
                 '%sonata.media.gallery_item.class%',
                 '%sonata.admin.configuration.default_controller%',
-            ])
-            ->call('setTranslationDomain', ['SonataMediaBundle']);
+            ]);
 };

--- a/src/Resources/config/doctrine_orm_admin.php
+++ b/src/Resources/config/doctrine_orm_admin.php
@@ -28,7 +28,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->tag('sonata.admin', [
                 'manager_type' => 'orm',
                 'group' => 'sonata_media',
-                'label_catalogue' => 'SonataMediaBundle',
+                'translation_domain' => 'SonataMediaBundle',
                 'label' => 'media',
                 'label_translator_strategy' => 'sonata.admin.label.strategy.underscore',
                 'icon' => '<i class=\'fa fa-image\'></i>',
@@ -42,7 +42,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 (new ReferenceConfigurator('sonata.media.manager.context'))->nullOnInvalid(),
             ])
             ->call('setModelManager', [new ReferenceConfigurator('sonata.media.admin.media.manager')])
-            ->call('setTranslationDomain', ['SonataMediaBundle'])
             ->call('setTemplates', [[
                 'inner_list_row' => '@SonataMedia/MediaAdmin/inner_row_media.html.twig',
                 'outer_list_rows_mosaic' => '@SonataMedia/MediaAdmin/list_outer_rows_mosaic.html.twig',
@@ -56,7 +55,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'manager_type' => 'orm',
                 'group' => 'sonata_media',
                 'label' => 'gallery',
-                'label_catalogue' => 'SonataMediaBundle',
+                'translation_domain' => 'SonataMediaBundle',
                 'label_translator_strategy' => 'sonata.admin.label.strategy.underscore',
                 'icon' => '<i class=\'fa fa-image\'></i>',
             ])
@@ -66,7 +65,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'sonata.media.controller.gallery.admin',
                 new ReferenceConfigurator('sonata.media.pool'),
             ])
-            ->call('setTranslationDomain', ['SonataMediaBundle'])
             ->call('setTemplates', [[
                 'list' => '@SonataMedia/GalleryAdmin/list.html.twig',
             ]])
@@ -76,7 +74,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'manager_type' => 'orm',
                 'show_in_dashboard' => false,
                 'group' => 'sonata_media',
-                'label_catalogue' => 'SonataMediaBundle',
+                'translation_domain' => 'SonataMediaBundle',
                 'label' => 'gallery_item',
                 'label_translator_strategy' => 'sonata.admin.label.strategy.underscore',
                 'icon' => '<i class=\'fa fa-image\'></i>',
@@ -85,6 +83,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 '',
                 '%sonata.media.gallery_item.class%',
                 '%sonata.admin.configuration.default_controller%',
-            ])
-            ->call('setTranslationDomain', ['SonataMediaBundle']);
+            ]);
 };

--- a/src/Resources/config/doctrine_orm_admin.php
+++ b/src/Resources/config/doctrine_orm_admin.php
@@ -26,6 +26,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         ->set('sonata.media.admin.media', MediaAdmin::class)
             ->tag('sonata.admin', [
+                'model_class' => '%sonata.media.media.class%',
+                'controller' => 'sonata.media.controller.media.admin',
                 'manager_type' => 'orm',
                 'group' => 'sonata_media',
                 'translation_domain' => 'SonataMediaBundle',
@@ -34,9 +36,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'icon' => '<i class=\'fa fa-image\'></i>',
             ])
             ->args([
-                '',
-                '%sonata.media.media.class%',
-                'sonata.media.controller.media.admin',
                 new ReferenceConfigurator('sonata.media.pool'),
                 (new ReferenceConfigurator('sonata.media.manager.category'))->nullOnInvalid(),
                 (new ReferenceConfigurator('sonata.media.manager.context'))->nullOnInvalid(),
@@ -52,6 +51,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         ->set('sonata.media.admin.gallery', GalleryAdmin::class)
             ->tag('sonata.admin', [
+                'model_class' => '%sonata.media.gallery.class%',
+                'controller' => 'sonata.media.controller.gallery.admin',
                 'manager_type' => 'orm',
                 'group' => 'sonata_media',
                 'label' => 'gallery',
@@ -60,9 +61,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'icon' => '<i class=\'fa fa-image\'></i>',
             ])
             ->args([
-                '',
-                '%sonata.media.gallery.class%',
-                'sonata.media.controller.gallery.admin',
                 new ReferenceConfigurator('sonata.media.pool'),
             ])
             ->call('setTemplates', [[
@@ -71,6 +69,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         ->set('sonata.media.admin.gallery_item', GalleryItemAdmin::class)
             ->tag('sonata.admin', [
+                'model_class' => '%sonata.media.gallery_item.class%',
+                'controller' => '%sonata.admin.configuration.default_controller%',
                 'manager_type' => 'orm',
                 'show_in_dashboard' => false,
                 'group' => 'sonata_media',
@@ -78,10 +78,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 'label' => 'gallery_item',
                 'label_translator_strategy' => 'sonata.admin.label.strategy.underscore',
                 'icon' => '<i class=\'fa fa-image\'></i>',
-            ])
-            ->args([
-                '',
-                '%sonata.media.gallery_item.class%',
-                '%sonata.admin.configuration.default_controller%',
             ]);
 };

--- a/tests/Admin/BaseMediaAdminTest.php
+++ b/tests/Admin/BaseMediaAdminTest.php
@@ -59,13 +59,11 @@ class BaseMediaAdminTest extends TestCase
         $this->modelManager = $this->createStub(ModelManagerInterface::class);
 
         $this->mediaAdmin = new TestMediaAdmin(
-            'media',
-            Media::class,
-            'SonataMediaBundle:MediaAdmin',
             $this->pool,
             $this->categoryManager,
             $this->contextManager
         );
+        $this->mediaAdmin->setModelClass(Media::class);
         $this->mediaAdmin->setRequest($this->request);
         $this->mediaAdmin->setModelManager($this->modelManager);
         $this->mediaAdmin->setUniqId('uniqId');

--- a/tests/Admin/GalleryAdminTest.php
+++ b/tests/Admin/GalleryAdminTest.php
@@ -15,7 +15,6 @@ namespace Sonata\MediaBundle\Tests\Admin;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\MediaBundle\Admin\GalleryAdmin;
-use Sonata\MediaBundle\Entity\BaseGallery;
 use Sonata\MediaBundle\Provider\Pool;
 
 class GalleryAdminTest extends TestCase
@@ -25,9 +24,6 @@ class GalleryAdminTest extends TestCase
     protected function setUp(): void
     {
         $this->galleryAdmin = new GalleryAdmin(
-            'media',
-            BaseGallery::class,
-            'SonataMediaBundle:GalleryAdmin',
             new Pool('default')
         );
     }

--- a/tests/Admin/GalleryItemAdminTest.php
+++ b/tests/Admin/GalleryItemAdminTest.php
@@ -15,7 +15,6 @@ namespace Sonata\MediaBundle\Tests\Admin;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\MediaBundle\Admin\GalleryItemAdmin;
-use Sonata\MediaBundle\Entity\BaseGalleryItem;
 
 class GalleryItemAdminTest extends TestCase
 {
@@ -23,11 +22,7 @@ class GalleryItemAdminTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->galleryItemAdmin = new GalleryItemAdmin(
-            'gallery',
-            BaseGalleryItem::class,
-            'SonataMediaBundle:GalleryAdmin'
-        );
+        $this->galleryItemAdmin = new GalleryItemAdmin();
     }
 
     public function testItDoesNotHaveSubject(): void

--- a/tests/Admin/ORM/MediaAdminTest.php
+++ b/tests/Admin/ORM/MediaAdminTest.php
@@ -16,7 +16,6 @@ namespace Sonata\MediaBundle\Tests\Admin\ORM;
 use PHPUnit\Framework\TestCase;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
 use Sonata\MediaBundle\Admin\ORM\MediaAdmin;
-use Sonata\MediaBundle\Entity\BaseMedia;
 use Sonata\MediaBundle\Provider\Pool;
 
 class MediaAdminTest extends TestCase
@@ -26,9 +25,6 @@ class MediaAdminTest extends TestCase
     protected function setUp(): void
     {
         $this->mediaAdmin = new MediaAdmin(
-            'media',
-            BaseMedia::class,
-            'SonataMediaBundle:MediaAdmin',
             new Pool('default'),
             $this->createStub(CategoryManagerInterface::class)
         );

--- a/tests/Provider/AbstractProviderTest.php
+++ b/tests/Provider/AbstractProviderTest.php
@@ -55,7 +55,8 @@ abstract class AbstractProviderTest extends TestCase
         $this->formBuilder = $this->createMock(FormBuilderInterface::class);
         $this->formBuilder->method('getOption')->willReturn('api');
 
-        $admin = new MediaAdmin('media', Media::class, '', new Pool('default'));
+        $admin = new MediaAdmin(new Pool('default'));
+        $admin->setModelClass(Media::class);
         $admin->setLabelTranslatorStrategy($this->createStub(LabelTranslatorStrategyInterface::class));
         $admin->setFieldDescriptionFactory($this->createStub(FieldDescriptionFactoryInterface::class));
 


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Deprecations introduces by SonataAdminBundle 4.9.0
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
