### PR TITLE
Allow reusing of the MediaType for other correctly interfaced media objects

### DIFF
--- a/src/Form/Type/MediaType.php
+++ b/src/Form/Type/MediaType.php
@@ -50,7 +50,7 @@ final class MediaType extends AbstractType implements LoggerAwareInterface
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $dataTransformer = new ProviderDataTransformer($this->pool, $this->class, [
+        $dataTransformer = new ProviderDataTransformer($this->pool, $options['data_class'], [
             'provider' => $options['provider'],
             'context' => $options['context'],
             'empty_on_new' => $options['empty_on_new'],


### PR DESCRIPTION
## Subject

The default value for data_class is set to `$this->class` already and it is configurable, allowing override improves reusability without breaking anything.

I am targeting this branch, because it is BC

## Changelog

```markdown
### Changed
- `MediaType` form type will now allow you to pass your own `data_class` instead of relying on the provided `$this->class`.
```