### PR TITLE
Fix deprecations for commands while maintian lazyness

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
         "psalm/plugin-phpunit": "^0.16",
         "psalm/plugin-symfony": "^3.0",
         "sonata-project/admin-bundle": "^4.9",
-        "sonata-project/block-bundle": "^4.0",
+        "sonata-project/block-bundle": "^4.11",
         "sonata-project/classification-bundle": "^4.0",
         "sonata-project/doctrine-orm-admin-bundle": "^4.0",
         "symfony/browser-kit": "^4.4 || ^5.4 || ^6.0",
@@ -100,7 +100,7 @@
         "knplabs/knp-menu-bundle": "<3.0",
         "liip/imagine-bundle": "<2.0",
         "sonata-project/admin-bundle": "<4.9",
-        "sonata-project/block-bundle": "<4.0",
+        "sonata-project/block-bundle": "<4.11",
         "sonata-project/classification-bundle": "<4.0",
         "sonata-project/doctrine-orm-admin-bundle": "<4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "homepage": "https://docs.sonata-project.org/projects/SonataMediaBundle",
     "require": {
         "php": "^7.4 || ^8.0",
-        "doctrine/persistence": "^2.0",
+        "doctrine/persistence": "^2.0 || ^3.0",
         "imagine/imagine": "^1.3",
         "knplabs/gaufrette": "^0.10",
         "nyholm/psr7": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "homepage": "https://docs.sonata-project.org/projects/SonataMediaBundle",
     "require": {
         "php": "^7.4 || ^8.0",
-        "doctrine/persistence": "^2.0 || ^3.0",
+        "doctrine/persistence": "^2.0",
         "imagine/imagine": "^1.3",
         "knplabs/gaufrette": "^0.10",
         "nyholm/psr7": "^1.4",

--- a/src/Command/AddMassMediaCommand.php
+++ b/src/Command/AddMassMediaCommand.php
@@ -15,13 +15,16 @@ namespace Sonata\MediaBundle\Command;
 
 use Sonata\Doctrine\Model\ClearableManagerInterface;
 use Sonata\MediaBundle\Model\MediaManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'sonata:media:add-multiple', description: 'Add medias in mass into the database')]
 final class AddMassMediaCommand extends Command
 {
+    // TODO: Remove static properties when support for Symfony < 6.0 is dropped.
     protected static $defaultName = 'sonata:media:add-multiple';
     protected static $defaultDescription = 'Add medias in mass into the database';
 
@@ -47,6 +50,7 @@ final class AddMassMediaCommand extends Command
         \assert(null !== static::$defaultDescription);
 
         $this
+            // TODO: Remove setDescription when support for Symfony < 5.4 is dropped.
             ->setDescription(static::$defaultDescription)
             ->addOption('file', null, InputOption::VALUE_REQUIRED, 'The file to parse')
             ->addOption('delimiter', null, InputOption::VALUE_REQUIRED, 'Set the field delimiter (one character only)', ',')

--- a/src/Command/AddMediaCommand.php
+++ b/src/Command/AddMediaCommand.php
@@ -14,14 +14,17 @@ declare(strict_types=1);
 namespace Sonata\MediaBundle\Command;
 
 use Sonata\MediaBundle\Model\MediaManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'sonata:media:add', description: 'Add a media into the database')]
 final class AddMediaCommand extends Command
 {
+    // TODO: Remove static properties when support for Symfony < 6.0 is dropped.
     protected static $defaultName = 'sonata:media:add';
     protected static $defaultDescription = 'Add a media into the database';
 
@@ -42,6 +45,7 @@ final class AddMediaCommand extends Command
         \assert(null !== static::$defaultDescription);
 
         $this
+            // TODO: Remove setDescription when support for Symfony < 5.4 is dropped.
             ->setDescription(static::$defaultDescription)
             ->addArgument('providerName', InputArgument::REQUIRED, 'The provider')
             ->addArgument('context', InputArgument::REQUIRED, 'The context')

--- a/src/Command/CleanMediaCommand.php
+++ b/src/Command/CleanMediaCommand.php
@@ -17,6 +17,7 @@ use Sonata\MediaBundle\Filesystem\Local;
 use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Sonata\MediaBundle\Provider\FileProvider;
 use Sonata\MediaBundle\Provider\Pool;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -25,8 +26,10 @@ use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 
+#[AsCommand(name: 'sonata:media:clean-uploads', description: 'Find orphaned files in media upload directory')]
 final class CleanMediaCommand extends Command
 {
+    // TODO: Remove static properties when support for Symfony < 6.0 is dropped.
     protected static $defaultName = 'sonata:media:clean-uploads';
     protected static $defaultDescription = 'Find orphaned files in media upload directory';
 
@@ -58,6 +61,7 @@ final class CleanMediaCommand extends Command
         \assert(null !== static::$defaultDescription);
 
         $this
+            // TODO: Remove setDescription when support for Symfony < 5.4 is dropped.
             ->setDescription(static::$defaultDescription)
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Execute the cleanup as a dry run. This doesn\'t remove any files');
     }

--- a/src/Command/FixMediaContextCommand.php
+++ b/src/Command/FixMediaContextCommand.php
@@ -16,12 +16,15 @@ namespace Sonata\MediaBundle\Command;
 use Sonata\ClassificationBundle\Model\CategoryManagerInterface;
 use Sonata\ClassificationBundle\Model\ContextManagerInterface;
 use Sonata\MediaBundle\Provider\Pool;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(name: 'sonata:media:fix-media-context', description: 'Generate the default category for each media context')]
 final class FixMediaContextCommand extends Command
 {
+    // TODO: Remove static properties when support for Symfony < 6.0 is dropped.
     protected static $defaultName = 'sonata:media:fix-media-context';
     protected static $defaultDescription = 'Generate the default category for each media context';
 
@@ -47,6 +50,7 @@ final class FixMediaContextCommand extends Command
     {
         \assert(null !== static::$defaultDescription);
 
+        // TODO: Remove setDescription when support for Symfony < 5.4 is dropped.
         $this->setDescription(static::$defaultDescription);
     }
 

--- a/src/Command/RefreshMetadataCommand.php
+++ b/src/Command/RefreshMetadataCommand.php
@@ -16,6 +16,7 @@ namespace Sonata\MediaBundle\Command;
 use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\MediaBundle\Provider\Pool;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
@@ -28,8 +29,10 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
  *
  * Useful if you have existing media content and added new formats.
  */
+#[AsCommand(name: 'sonata:media:refresh-metadata', description: 'Refresh meta information')]
 final class RefreshMetadataCommand extends Command
 {
+    // TODO: Remove static properties when support for Symfony < 6.0 is dropped.
     protected static $defaultName = 'sonata:media:refresh-metadata';
     protected static $defaultDescription = 'Refresh meta information';
 
@@ -55,6 +58,7 @@ final class RefreshMetadataCommand extends Command
         \assert(null !== static::$defaultDescription);
 
         $this
+            // TODO: Remove setDescription when support for Symfony < 5.4 is dropped.
             ->setDescription(static::$defaultDescription)
             ->addArgument('providerName', InputArgument::OPTIONAL, 'The provider')
             ->addArgument('context', InputArgument::OPTIONAL, 'The context');

--- a/src/Command/RemoveThumbsCommand.php
+++ b/src/Command/RemoveThumbsCommand.php
@@ -17,6 +17,7 @@ use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\MediaBundle\Provider\Pool;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
@@ -30,8 +31,10 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
  *
  * Useful if you have existing media content and added new formats.
  */
+#[AsCommand(name: 'sonata:media:remove-thumbnails', description: 'Remove uploaded image thumbs')]
 final class RemoveThumbsCommand extends Command
 {
+    // TODO: Remove static properties when support for Symfony < 6.0 is dropped.
     protected static $defaultName = 'sonata:media:remove-thumbnails';
     protected static $defaultDescription = 'Remove uploaded image thumbs';
 
@@ -57,6 +60,7 @@ final class RemoveThumbsCommand extends Command
         \assert(null !== static::$defaultDescription);
 
         $this
+            // TODO: Remove setDescription when support for Symfony < 5.4 is dropped.
             ->setDescription(static::$defaultDescription)
             ->addArgument('providerName', InputArgument::OPTIONAL, 'The provider')
             ->addArgument('context', InputArgument::OPTIONAL, 'The context')

--- a/src/Command/SyncThumbsCommand.php
+++ b/src/Command/SyncThumbsCommand.php
@@ -18,6 +18,7 @@ use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\MediaBundle\Provider\Pool;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -30,8 +31,10 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
  *
  * Useful if you have existing media content and added new formats.
  */
+#[AsCommand(name: 'sonata:media:sync-thumbnails', description: 'Sync uploaded image thumbs with new media formats')]
 final class SyncThumbsCommand extends Command
 {
+    // TODO: Remove static properties when support for Symfony < 6.0 is dropped.
     protected static $defaultName = 'sonata:media:sync-thumbnails';
     protected static $defaultDescription = 'Sync uploaded image thumbs with new media formats';
 
@@ -57,6 +60,7 @@ final class SyncThumbsCommand extends Command
         \assert(null !== static::$defaultDescription);
 
         $this
+            // TODO: Remove setDescription when support for Symfony < 5.4 is dropped.
             ->setDescription(static::$defaultDescription)
             ->addArgument('providerName', InputArgument::OPTIONAL, 'The provider')
             ->addArgument('context', InputArgument::OPTIONAL, 'The context')

--- a/src/Command/UpdateCdnStatusCommand.php
+++ b/src/Command/UpdateCdnStatusCommand.php
@@ -17,6 +17,7 @@ use Sonata\MediaBundle\CDN\CDNInterface;
 use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Sonata\MediaBundle\Provider\MediaProviderInterface;
 use Sonata\MediaBundle\Provider\Pool;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -29,8 +30,10 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
  *
  * @author Javier Spagnoletti <phansys@gmail.com>
  */
+#[AsCommand(name: 'sonata:media:update-cdn-status', description: 'Updates model media with the current CDN status')]
 final class UpdateCdnStatusCommand extends Command
 {
+    // TODO: Remove static properties when support for Symfony < 6.0 is dropped.
     protected static $defaultName = 'sonata:media:update-cdn-status';
     protected static $defaultDescription = 'Updates model media with the current CDN status';
 
@@ -56,6 +59,7 @@ final class UpdateCdnStatusCommand extends Command
         \assert(null !== static::$defaultDescription);
 
         $this
+            // TODO: Remove setDescription when support for Symfony < 5.4 is dropped.
             ->setDescription(static::$defaultDescription)
             ->addArgument('providerName', InputArgument::OPTIONAL, 'The provider')
             ->addArgument('context', InputArgument::OPTIONAL, 'The context')

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -17,6 +17,7 @@ use DAMA\DoctrineTestBundle\DAMADoctrineTestBundle;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Knp\Bundle\MenuBundle\KnpMenuBundle;
 use Sonata\AdminBundle\SonataAdminBundle;
+use Sonata\BlockBundle\Cache\HttpCacheHandler;
 use Sonata\BlockBundle\SonataBlockBundle;
 use Sonata\Doctrine\Bridge\Symfony\SonataDoctrineBundle;
 use Sonata\DoctrineORMAdminBundle\SonataDoctrineORMAdminBundle;
@@ -99,6 +100,10 @@ final class AppKernel extends Kernel
             $loader->load(__DIR__.'/Resources/config/config_symfony_v5.yaml');
         } else {
             $loader->load(__DIR__.'/Resources/config/config_symfony_v4.yaml');
+        }
+
+        if (class_exists(HttpCacheHandler::class)) {
+            $loader->load(__DIR__.'/Resources/config/config_sonata_block_v4.yaml');
         }
 
         $loader->load(__DIR__.'/Resources/config/services.php');

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -92,6 +92,9 @@ final class AppKernel extends Kernel
         $routes->import(__DIR__.'/Resources/config/routing/routes.yaml');
     }
 
+    /**
+     * @psalm-suppress DeprecatedClass
+     */
     protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
     {
         $loader->load(__DIR__.'/Resources/config/config.yaml');

--- a/tests/App/Resources/config/config.yaml
+++ b/tests/App/Resources/config/config.yaml
@@ -9,6 +9,7 @@ framework:
         enable_annotations: false
     router:
         utf8: true
+    http_method_override: false
 
 security:
     role_hierarchy: null

--- a/tests/App/Resources/config/config_sonata_block_v4.yaml
+++ b/tests/App/Resources/config/config_sonata_block_v4.yaml
@@ -1,0 +1,2 @@
+sonata_block:
+    http_cache: false


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Avoid deprecations for console commands on Symfony 6.1.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
