### PR TITLE
AmazonMetadataBuilder - Pass content-length header

### DIFF
--- a/src/Metadata/AmazonMetadataBuilder.php
+++ b/src/Metadata/AmazonMetadataBuilder.php
@@ -77,7 +77,8 @@ final class AmazonMetadataBuilder implements MetadataBuilderInterface
     {
         return array_replace_recursive(
             $this->getDefaultMetadata(),
-            $this->getContentType($filename)
+            $this->getContentType($filename),
+            $this->getContentLength($media)
         );
     }
 
@@ -123,5 +124,18 @@ final class AmazonMetadataBuilder implements MetadataBuilderInterface
         }
 
         return ['contentType' => $mimeType];
+    }
+
+    /**
+     * Gets content-length of Media.
+     */
+    private function getContentLength(MediaInterface $media): array
+    {
+        $size = $media->getSize();
+        if ($size > 0) {
+            return ['contentLength' => $size];
+        }
+
+        return [];
     }
 }

--- a/src/Metadata/AmazonMetadataBuilder.php
+++ b/src/Metadata/AmazonMetadataBuilder.php
@@ -127,7 +127,9 @@ final class AmazonMetadataBuilder implements MetadataBuilderInterface
     }
 
     /**
-     * @return array<string, string|int>
+     * @return array<string, int>
+     *
+     * @phpstan-return array{contentLength?: int}
      */
     private function getContentLength(MediaInterface $media): array
     {

--- a/src/Metadata/AmazonMetadataBuilder.php
+++ b/src/Metadata/AmazonMetadataBuilder.php
@@ -126,6 +126,9 @@ final class AmazonMetadataBuilder implements MetadataBuilderInterface
         return ['contentType' => $mimeType];
     }
 
+    /**
+     * @return array<string, string|int>
+     */
     private function getContentLength(MediaInterface $media): array
     {
         $size = $media->getSize();

--- a/src/Metadata/AmazonMetadataBuilder.php
+++ b/src/Metadata/AmazonMetadataBuilder.php
@@ -126,9 +126,6 @@ final class AmazonMetadataBuilder implements MetadataBuilderInterface
         return ['contentType' => $mimeType];
     }
 
-    /**
-     * Gets content-length of Media.
-     */
     private function getContentLength(MediaInterface $media): array
     {
         $size = $media->getSize();

--- a/tests/Metadata/AmazonMetadataBuilderTest.php
+++ b/tests/Metadata/AmazonMetadataBuilderTest.php
@@ -27,7 +27,7 @@ final class AmazonMetadataBuilderTest extends TestCase
      * @dataProvider provider
      *
      * @param array<string, string|int> $mediaAttributes
-     * @param array<string, mixed> $expected
+     * @param array<string, mixed>      $expected
      *
      * @phpstan-param AmazonSettings $settings
      */

--- a/tests/Metadata/AmazonMetadataBuilderTest.php
+++ b/tests/Metadata/AmazonMetadataBuilderTest.php
@@ -30,7 +30,7 @@ final class AmazonMetadataBuilderTest extends TestCase
      *
      * @phpstan-param AmazonSettings $settings
      */
-    public function testAmazon(array $settings, array $expected): void
+    public function testAmazon(array $settings, array $mediaAttributes, array $expected): void
     {
         $mimeTypes = $this->createStub(MimeTypesInterface::class);
         $mimeTypes->method('getMimeTypes')->willReturnCallback(
@@ -38,6 +38,9 @@ final class AmazonMetadataBuilderTest extends TestCase
         );
 
         $media = $this->createStub(MediaInterface::class);
+        foreach ($mediaAttributes as $attribute => $value) {
+            $media->method('get'.ucfirst($attribute))->willReturn($value);
+        }
         $filename = '/test/folder/testfile.png';
 
         $amazonmetadatabuilder = new AmazonMetadataBuilder($settings, $mimeTypes);
@@ -58,12 +61,16 @@ final class AmazonMetadataBuilderTest extends TestCase
                 'meta' => [],
             ],
             [
+                'size' => 3000,
+            ],
+            [
                 'ACL' => AmazonMetadataBuilder::PRIVATE_ACCESS,
                 'storage' => AmazonMetadataBuilder::STORAGE_STANDARD,
                 'meta' => [],
                 'CacheControl' => '',
                 'encryption' => 'AES256',
                 'contentType' => 'image/png',
+                'contentLength' => 3000,
             ],
         ];
 
@@ -75,6 +82,7 @@ final class AmazonMetadataBuilderTest extends TestCase
                 'encryption' => 'aes256',
                 'meta' => ['key' => 'value'],
             ],
+            [],
             [
                 'ACL' => AmazonMetadataBuilder::PUBLIC_READ_WRITE,
                 'storage' => AmazonMetadataBuilder::STORAGE_STANDARD,
@@ -93,6 +101,7 @@ final class AmazonMetadataBuilderTest extends TestCase
                 'encryption' => 'aes256',
                 'meta' => ['key' => 'value'],
             ],
+            [],
             [
                 'ACL' => AmazonMetadataBuilder::AUTHENTICATED_READ,
                 'storage' => AmazonMetadataBuilder::STORAGE_STANDARD,
@@ -111,6 +120,7 @@ final class AmazonMetadataBuilderTest extends TestCase
                 'encryption' => 'aes256',
                 'meta' => ['key' => 'value'],
             ],
+            [],
             [
                 'ACL' => AmazonMetadataBuilder::BUCKET_OWNER_READ,
                 'storage' => AmazonMetadataBuilder::STORAGE_STANDARD,
@@ -129,6 +139,7 @@ final class AmazonMetadataBuilderTest extends TestCase
                 'encryption' => 'aes256',
                 'meta' => ['key' => 'value'],
             ],
+            [],
             [
                 'ACL' => AmazonMetadataBuilder::BUCKET_OWNER_FULL_CONTROL,
                 'storage' => AmazonMetadataBuilder::STORAGE_STANDARD,
@@ -147,6 +158,7 @@ final class AmazonMetadataBuilderTest extends TestCase
                 'encryption' => 'aes256',
                 'meta' => ['key' => 'value'],
             ],
+            [],
             [
                 'ACL' => AmazonMetadataBuilder::PUBLIC_READ,
                 'storage' => AmazonMetadataBuilder::STORAGE_REDUCED,
@@ -165,6 +177,7 @@ final class AmazonMetadataBuilderTest extends TestCase
                 'encryption' => 'aes256',
                 'meta' => ['key' => 'value'],
             ],
+            [],
             [
                 'ACL' => AmazonMetadataBuilder::PUBLIC_READ,
                 'storage' => AmazonMetadataBuilder::STORAGE_STANDARD,
@@ -183,6 +196,7 @@ final class AmazonMetadataBuilderTest extends TestCase
                 'encryption' => 'aes256',
                 'meta' => ['key' => 'value'],
             ],
+            [],
             [
                 'ACL' => AmazonMetadataBuilder::PUBLIC_READ,
                 'storage' => AmazonMetadataBuilder::STORAGE_STANDARD,
@@ -201,6 +215,7 @@ final class AmazonMetadataBuilderTest extends TestCase
                 'encryption' => 'aes256',
                 'meta' => ['key' => 'value'],
             ],
+            [],
             [
                 'ACL' => AmazonMetadataBuilder::PUBLIC_READ,
                 'storage' => AmazonMetadataBuilder::STORAGE_STANDARD,
@@ -219,6 +234,7 @@ final class AmazonMetadataBuilderTest extends TestCase
                 'encryption' => 'aes256',
                 'meta' => ['key' => 'value'],
             ],
+            [],
             [
                 'ACL' => AmazonMetadataBuilder::PUBLIC_READ,
                 'storage' => AmazonMetadataBuilder::STORAGE_STANDARD,
@@ -237,6 +253,7 @@ final class AmazonMetadataBuilderTest extends TestCase
                 'encryption' => 'aes256',
                 'meta' => ['key' => 'value'],
             ],
+            [],
             [
                 'ACL' => AmazonMetadataBuilder::PUBLIC_READ,
                 'storage' => AmazonMetadataBuilder::STORAGE_STANDARD,

--- a/tests/Metadata/AmazonMetadataBuilderTest.php
+++ b/tests/Metadata/AmazonMetadataBuilderTest.php
@@ -26,6 +26,7 @@ final class AmazonMetadataBuilderTest extends TestCase
     /**
      * @dataProvider provider
      *
+     * @param array<string, string|int> $mediaAttributes
      * @param array<string, mixed> $expected
      *
      * @phpstan-param AmazonSettings $settings


### PR DESCRIPTION
## Pass ContentLength header from AmazonMetadataBuilder

Our case - content-length is used to properly compress data on CDN:
```
Content-Length header
The origin must include a Content-Length header in the response so CloudFront can determine whether the size of the file is in the range that CloudFront compresses. If the Content-Length header is missing, CloudFront won't compress the file.
```
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it backwards compatible.


## Changelog
```markdown
### Fixed
- Allow CloudFront to compress files passing ContentLength in the headers.
```