### PR TITLE
Add galley_item translation key for better SonatUserBundle roles display

### DIFF
--- a/src/Resources/translations/SonataMediaBundle.en.xliff
+++ b/src/Resources/translations/SonataMediaBundle.en.xliff
@@ -14,6 +14,10 @@
         <source>gallery</source>
         <target>Gallery</target>
       </trans-unit>
+      <trans-unit id="gallery_item">
+        <source>gallery_item</source>
+        <target>Gallery item</target>
+      </trans-unit>
       <trans-unit id="sonata_media">
         <source>sonata_media</source>
         <target>Media Library</target>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a smally fix.

SonataUserBundle translates admin names. Gallery and media are translated:

![Immagine 2023-03-10 130847](https://user-images.githubusercontent.com/1532616/224313830-d0b41810-f019-4f2a-9fcf-e96aca7792a8.png)

Gallery item is not, resulting in a row string:

![Immagine 2023-03-10 130904](https://user-images.githubusercontent.com/1532616/224313860-e8b19959-0200-49bd-9d10-fdc337728100.png)

![Immagine 2023-03-10 131008](https://user-images.githubusercontent.com/1532616/224313881-0f7b3b97-37eb-4ebe-adb1-48ce6e44c96b.png)


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added gallery_item translation key (english)
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
