### PR TITLE
SimpleResizer calculation in `round()` can get return invalid value for image resizing.

### DIFF
--- a/src/Resizer/SimpleResizer.php
+++ b/src/Resizer/SimpleResizer.php
@@ -77,11 +77,11 @@ class SimpleResizer implements ResizerInterface
         }
 
         if (null === $settings['height']) {
-            $settings['height'] = (int) round($settings['width'] * $size->getHeight() / $size->getWidth());
+            $settings['height'] = max((int) round($settings['width'] * $size->getHeight() / $size->getWidth()), 1);
         }
 
         if (null === $settings['width']) {
-            $settings['width'] = (int) round($settings['height'] * $size->getWidth() / $size->getHeight());
+            $settings['width'] = max((int) round($settings['height'] * $size->getWidth() / $size->getHeight()), 1);
         }
 
         return $this->computeBox($media, $settings);

--- a/tests/Resizer/SimpleResizerTest.php
+++ b/tests/Resizer/SimpleResizerTest.php
@@ -94,12 +94,16 @@ class SimpleResizerTest extends TestCase
             ['inset', ['width' => 90, 'height' => null], new Box(50, 50), new Box(90, 90)],
             ['inset', ['width' => 90, 'height' => null], new Box(567, 200), new Box(90, 32)],
             ['inset', ['width' => 100, 'height' => 100], new Box(567, 200), new Box(100, 35)],
+            ['inset', ['width' => 1060, 'height' => 1], new Box(567, 200), new Box(3, 1)],
+            ['inset', ['width' => 1, 'height' => 1060], new Box(567, 200), new Box(1, 1)],
 
             ['outbound', ['width' => 90, 'height' => 90], new Box(100, 120), new Box(90, 90)],
             ['outbound', ['width' => 90, 'height' => 90], new Box(120, 100), new Box(90, 90)],
             ['outbound', ['width' => 90, 'height' => 90], new Box(50, 50), new Box(90, 90)],
             ['outbound', ['width' => 90, 'height' => null], new Box(50, 50), new Box(90, 90)],
             ['outbound', ['width' => 90, 'height' => null], new Box(567, 50), new Box(90, 8)],
+            ['outbound', ['width' => 1060, 'height' => 1], new Box(567, 200), new Box(1060, 1)],
+            ['outbound', ['width' => 1, 'height' => 1060], new Box(567, 200), new Box(1, 1060)],
         ];
     }
 }


### PR DESCRIPTION
## Subject

I am targeting this branch, because this is a bugfix.

the `round` method in the `SimpleResizer` can return 0 and thats invalid for image resizing.

## Changelog
```markdown
### Fixed
* `round()` can return 0 which is invalid for image resizing.

```