### PR TITLE
Fix: SimpleResizer calculation in round() can return invalid value for image resizing. (4.x)

### DIFF
--- a/src/Resizer/SimpleResizer.php
+++ b/src/Resizer/SimpleResizer.php
@@ -65,11 +65,11 @@ final class SimpleResizer implements ResizerInterface
         }
 
         if (null === $height) {
-            $height = (int) round($width * $size->getHeight() / $size->getWidth());
+            $height = max((int) round($width * $size->getHeight() / $size->getWidth()), 1);
         }
 
         if (null === $width) {
-            $width = (int) round($height * $size->getWidth() / $size->getHeight());
+            $width = max((int) round($height * $size->getWidth() / $size->getHeight()), 1);
         }
 
         return $this->computeBox($media, $width, $height);

--- a/tests/Resizer/SimpleResizerTest.php
+++ b/tests/Resizer/SimpleResizerTest.php
@@ -201,6 +201,26 @@ class SimpleResizerTest extends TestCase
             'resizer_options' => [],
         ], new Box(567, 200), new Box(100, 35)];
 
+        yield [ManipulatorInterface::THUMBNAIL_INSET, [
+            'width' => 1,
+            'height' => 1060,
+            'quality' => 80,
+            'format' => 'jpg',
+            'constraint' => true,
+            'resizer' => null,
+            'resizer_options' => [],
+        ], new Box(567, 200), new Box(1, 1)];
+
+        yield [ManipulatorInterface::THUMBNAIL_INSET, [
+            'width' => 1060,
+            'height' => 1,
+            'quality' => 80,
+            'format' => 'jpg',
+            'constraint' => true,
+            'resizer' => null,
+            'resizer_options' => [],
+        ], new Box(567, 200), new Box(3, 1)];
+
         yield [ManipulatorInterface::THUMBNAIL_OUTBOUND, [
             'width' => 90,
             'height' => 90,
@@ -300,5 +320,25 @@ class SimpleResizerTest extends TestCase
             'resizer' => null,
             'resizer_options' => [],
         ], new Box(567, 50), new Box(90, 8)];
+
+        yield [ManipulatorInterface::THUMBNAIL_OUTBOUND | ManipulatorInterface::THUMBNAIL_FLAG_UPSCALE, [
+            'width' => 1,
+            'height' => 1060,
+            'quality' => 80,
+            'format' => 'jpg',
+            'constraint' => true,
+            'resizer' => null,
+            'resizer_options' => [],
+        ], new Box(50, 50), new Box(1, 1060)];
+
+        yield [ManipulatorInterface::THUMBNAIL_OUTBOUND | ManipulatorInterface::THUMBNAIL_FLAG_UPSCALE, [
+            'width' => 1060,
+            'height' => 1,
+            'quality' => 80,
+            'format' => 'jpg',
+            'constraint' => true,
+            'resizer' => null,
+            'resizer_options' => [],
+        ], new Box(567, 50), new Box(1060, 1)];
     }
 }


### PR DESCRIPTION
## Subject

I am targeting this branch, because this is a bugfix.

the `round` method in the `SimpleResizer` can return 0 and thats invalid for image resizing.

## Changelog
```markdown
### Fixed
* `round()` can return 0 which is invalid for image resizing.

```

ref #2404 