### PR TITLE
use event_listener instead of event_subscriber

### DIFF
--- a/src/Listener/BaseMediaEventSubscriber.php
+++ b/src/Listener/BaseMediaEventSubscriber.php
@@ -22,6 +22,7 @@ use Sonata\MediaBundle\Provider\Pool;
 
 /**
  * @phpstan-template T of ObjectManager
+ * NEXT_MAJOR: do not implement EventSubscriber interface anymore
  */
 abstract class BaseMediaEventSubscriber implements EventSubscriber
 {

--- a/src/Listener/ODM/MediaEventSubscriber.php
+++ b/src/Listener/ODM/MediaEventSubscriber.php
@@ -24,6 +24,9 @@ use Sonata\MediaBundle\Model\MediaInterface;
  */
 final class MediaEventSubscriber extends BaseMediaEventSubscriber
 {
+    /**
+     * NEXT_MAJOR: remove this method.
+     */
     public function getSubscribedEvents(): array
     {
         return [

--- a/src/Listener/ORM/MediaEventSubscriber.php
+++ b/src/Listener/ORM/MediaEventSubscriber.php
@@ -39,6 +39,9 @@ final class MediaEventSubscriber extends BaseMediaEventSubscriber
         parent::__construct($pool);
     }
 
+    /**
+     * NEXT_MAJOR: remove this method.
+     */
     public function getSubscribedEvents(): array
     {
         return [

--- a/src/Resources/config/doctrine_mongodb.php
+++ b/src/Resources/config/doctrine_mongodb.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Doctrine\ODM\MongoDB\Events;
 use Sonata\MediaBundle\Document\GalleryManager;
 use Sonata\MediaBundle\Document\MediaManager;
 use Sonata\MediaBundle\Generator\UuidGenerator;
@@ -38,7 +39,24 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->set('sonata.media.generator.default', UuidGenerator::class)
 
         ->set('sonata.media.doctrine.event_subscriber', MediaEventSubscriber::class)
-            ->tag('doctrine_mongodb.odm.event_subscriber')
+            ->tag('doctrine_mongodb.odm.event_listener', [
+                'event' => Events::prePersist,
+            ])
+            ->tag('doctrine_mongodb.odm.event_listener', [
+                'event' => Events::preUpdate,
+            ])
+            ->tag('doctrine_mongodb.odm.event_listener', [
+                'event' => Events::preRemove,
+            ])
+            ->tag('doctrine_mongodb.odm.event_listener', [
+                'event' => Events::postUpdate,
+            ])
+            ->tag('doctrine_mongodb.odm.event_listener', [
+                'event' => Events::postRemove,
+            ])
+            ->tag('doctrine_mongodb.odm.event_listener', [
+                'event' => Events::postPersist,
+            ])
             ->args([
                 service('sonata.media.pool'),
             ]);

--- a/src/Resources/config/doctrine_orm.php
+++ b/src/Resources/config/doctrine_orm.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Doctrine\ORM\Events;
 use Sonata\MediaBundle\Entity\GalleryManager;
 use Sonata\MediaBundle\Entity\MediaManager;
 use Sonata\MediaBundle\Generator\IdGenerator;
@@ -36,7 +37,27 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->set('sonata.media.generator.default', IdGenerator::class)
 
         ->set('sonata.media.doctrine.event_subscriber', MediaEventSubscriber::class)
-            ->tag('doctrine.event_subscriber')
+            ->tag('doctrine.event_listener', [
+                'event' => Events::prePersist,
+            ])
+            ->tag('doctrine.event_listener', [
+                'event' => Events::preUpdate,
+            ])
+            ->tag('doctrine.event_listener', [
+                'event' => Events::preRemove,
+            ])
+            ->tag('doctrine.event_listener', [
+                'event' => Events::postUpdate,
+            ])
+            ->tag('doctrine.event_listener', [
+                'event' => Events::postRemove,
+            ])
+            ->tag('doctrine.event_listener', [
+                'event' => Events::postPersist,
+            ])
+            ->tag('doctrine.event_listener', [
+                'event' => Events::onClear,
+            ])
             ->args([
                 service('sonata.media.pool'),
                 service('sonata.media.manager.category')->nullOnInvalid(),


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it should be BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #2410.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- Deprecation of Event Subscribers on Symfony 6.3. The MediaEventSubscriber now uses Event Listeners
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
