### PR TITLE
Fix french translations for gallery

### DIFF
--- a/src/Resources/translations/SonataMediaBundle.fr.xliff
+++ b/src/Resources/translations/SonataMediaBundle.fr.xliff
@@ -548,7 +548,7 @@
       </trans-unit>
       <trans-unit id="form.group_gallery">
         <source>form.group_gallery</source>
-        <target>Gallerie</target>
+        <target>Galerie</target>
       </trans-unit>
       <trans-unit id="form.group_options">
         <source>form.group_options</source>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
This PR fixes the french translation for the word "Gallery"
It should be "Galerie" not "Gallerie".

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting the 4.x branch because it patches translations

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- Improve French translation
```