### PR TITLE
Fix doctrine mapping

### DIFF
--- a/src/Model/Media.php
+++ b/src/Model/Media.php
@@ -41,7 +41,7 @@ abstract class Media implements MediaInterface, \Stringable
 
     protected ?int $height = null;
 
-    protected ?float $length = null;
+    protected ?string $length = null;
 
     protected ?string $copyright = null;
 
@@ -184,12 +184,12 @@ abstract class Media implements MediaInterface, \Stringable
 
     public function setLength(?float $length): void
     {
-        $this->length = $length;
+        $this->length = null !== $length ? (string) $length : null;
     }
 
     public function getLength(): ?float
     {
-        return $this->length;
+        return null !== $this->length ? (float) $this->length : null;
     }
 
     public function setCopyright(?string $copyright): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

The recent doctrine dbal update introduced a deprecation warning
```
 [FAIL] The entity-class App\Entity\Media\Media mapping is invalid:

 * The field 'App\Entity\Media\Media#length' has the property type 'float' that differs from the metadata field type 'string' returned by the 'decimal' DBAL type.

 [FAIL] The entity-class Sonata\MediaBundle\Entity\BaseMedia mapping is invalid:

 * The field 'Sonata\MediaBundle\Entity\BaseMedia#length' has the property type 'float' that differs from the metadata field type 'string' returned by the 'decimal' DBAL type.

 [FAIL] The entity-class Core23\MediaBundle\Entity\BaseMedia mapping is invalid:

 * The field 'Core23\MediaBundle\Entity\BaseMedia#length' has the property type 'float' that differs from the metadata field type 'string' returned by the 'decimal' DBAL type.
```

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- Fix doctrine mapping for media length
```

