### PR TITLE
Fix getMediaBuilder and getGalleryBuilder

### DIFF
--- a/src/Block/MediaBlockService.php
+++ b/src/Block/MediaBlockService.php
@@ -25,6 +25,7 @@ use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\Form\Type\ImmutableArrayType;
 use Sonata\Form\Validator\ErrorElement;
+use Sonata\MediaBundle\Model\GalleryInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Sonata\MediaBundle\Provider\Pool;
@@ -71,7 +72,7 @@ final class MediaBlockService extends AbstractBlockService implements EditableBl
     public function configureEditForm(FormMapper $form, BlockInterface $block): void
     {
         if (!$form instanceof AdminFormMapper) {
-            throw new \InvalidArgumentException('Media Block requires to be used in the Admin context');
+            throw new \InvalidArgumentException('Media block requires to be used in the Admin context');
         }
 
         if (!$block->getSetting('mediaId') instanceof MediaInterface) {
@@ -223,8 +224,8 @@ final class MediaBlockService extends AbstractBlockService implements EditableBl
         ]);
 
         $formBuilder->addModelTransformer(new CallbackTransformer(
-            static fn (?MediaInterface $value): ?MediaInterface => $value,
-            static fn (?MediaInterface $value) => $value instanceof MediaInterface ? $value->getId() : $value
+            static fn (?GalleryInterface $value): ?GalleryInterface => $value,
+            static fn (?GalleryInterface $value) => $value instanceof GalleryInterface ? $value->getId() : $value
         ));
 
         return $formBuilder;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Similar to https://github.com/sonata-project/SonataMediaBundle/pull/2402

Closes #2436

## Changelog

```markdown
### Fixed
- Resole "Admin has no subject" error from the getMediaBuilder
- Resole "Admin has no subject" error from the getGalleryBuilder
```
