### PR TITLE
ProviderDataTransformer: throw TransformationFailedException on error

### DIFF
--- a/src/Form/Type/MediaType.php
+++ b/src/Form/Type/MediaType.php
@@ -15,7 +15,6 @@ namespace Sonata\MediaBundle\Form\Type;
 
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
-use Psr\Log\NullLogger;
 use Sonata\MediaBundle\Form\DataTransformer\ProviderDataTransformer;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Provider\Pool;
@@ -53,7 +52,6 @@ final class MediaType extends AbstractType implements LoggerAwareInterface
             'empty_on_new' => $options['empty_on_new'],
             'new_on_update' => $options['new_on_update'],
         ]);
-        $dataTransformer->setLogger($this->logger ?? new NullLogger());
 
         $builder->addModelTransformer($dataTransformer);
 


### PR DESCRIPTION
## Subject

A user of my Sonata application tried to submit a heic image in a field that only allows jpeg and png. He received a 500 Internal Server Error caused by an `UploadException` thrown by `ImageProvider`.

I found out that `ImageProvider->doTransform()` is called twice. First by `ProviderDataTransformer` when the form is transformed to a model. Here the exception is caught and logged.

Later, this method is invoked again by `BaseMediaEventSubscriber->prePersist()`. This exception is not caught and this causes the 500 Internal Server Error.

`ProviderDataTransformer` has this comment:

```
// #1107 We must never throw an exception here.
// An exception here would prevent us to provide meaningful errors through the Form
// Error message inspired from Monolog\ErrorHandler
```

I don't understand this comment because it just ignores the error and nothing is returned to the form. Also, as mentioned above, the `transform` method is called again later and the exception occurs anyway.

My solution is to use the `TransformationFailedException` as suggested by the documentation of `DataTransformerInterface`:

```
* @throws TransformationFailedException when the transformation fails
```

If I replace the log with this exception, a pretty exception is displayed:

![image](https://github.com/sonata-project/SonataMediaBundle/assets/521449/1245a9f6-ff5d-4c7a-83af-cda7a56fc3c0)

I am targeting this branch, because it's backwards compatible.

Possible considerations:

 * I convert all exceptions to a `TransformationFailedException`. I could also only transform `UploadException`s and keep the current code to handle all other exceptions.
 * The error messages are not translated. This could be improved because `TransformationFailedException` supports translations.

## Changelog

```markdown
### Changed

Throw TransformationFailedException when reverse transformation fails in ProviderDataTransformer.

```



`