### PR TITLE
Fixed callback transformers types

### DIFF
--- a/src/Block/GalleryBlockService.php
+++ b/src/Block/GalleryBlockService.php
@@ -212,8 +212,8 @@ final class GalleryBlockService extends AbstractBlockService implements Editable
         ]);
 
         $formBuilder->addModelTransformer(new CallbackTransformer(
-            static fn (?MediaInterface $value): ?MediaInterface => $value,
-            static fn (?MediaInterface $value) => $value instanceof MediaInterface ? $value->getId() : $value
+            static fn (?GalleryInterface $value): ?GalleryInterface => $value,
+            static fn (?GalleryInterface $value) => $value instanceof GalleryInterface ? $value->getId() : $value
         ));
 
         return $formBuilder;

--- a/src/Block/MediaBlockService.php
+++ b/src/Block/MediaBlockService.php
@@ -25,7 +25,6 @@ use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
 use Sonata\Form\Type\ImmutableArrayType;
 use Sonata\Form\Validator\ErrorElement;
-use Sonata\MediaBundle\Model\GalleryInterface;
 use Sonata\MediaBundle\Model\MediaInterface;
 use Sonata\MediaBundle\Model\MediaManagerInterface;
 use Sonata\MediaBundle\Provider\Pool;
@@ -224,8 +223,8 @@ final class MediaBlockService extends AbstractBlockService implements EditableBl
         ]);
 
         $formBuilder->addModelTransformer(new CallbackTransformer(
-            static fn (?GalleryInterface $value): ?GalleryInterface => $value,
-            static fn (?GalleryInterface $value) => $value instanceof GalleryInterface ? $value->getId() : $value
+            static fn (?MediaInterface $value): ?MediaInterface => $value,
+            static fn (?MediaInterface $value) => $value instanceof MediaInterface ? $value->getId() : $value
         ));
 
         return $formBuilder;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
It seems there's a typo in the two gallery/media block services, the types of the transformers are inverted. I noticed it using media-bundle + admin + page-bundle, the page composer for the media/gallery blocks is broken. Switching them makes them properly work again.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
Fixed the callback transformers of media/gallery block services.
```
