### PR TITLE
Use `BIGINT` for `Media::$contentSize`

### DIFF
--- a/src/Resources/config/doctrine/BaseMedia.orm.xml
+++ b/src/Resources/config/doctrine/BaseMedia.orm.xml
@@ -16,7 +16,7 @@
         <field name="height" column="height" type="integer" nullable="true"/>
         <field name="length" column="length" type="decimal" nullable="true" precision="10"/>
         <field name="contentType" column="content_type" type="string" nullable="true" length="255"/>
-        <field name="size" column="content_size" type="integer" nullable="true"/>
+        <field name="size" column="content_size" type="integer" length="5" nullable="true"/>
         <field name="copyright" column="copyright" type="string" nullable="true"/>
         <field name="authorName" column="author_name" type="string" nullable="true"/>
         <field name="context" column="context" type="string" nullable="true" length="64"/>

--- a/src/Resources/config/doctrine/BaseMedia.orm.xml
+++ b/src/Resources/config/doctrine/BaseMedia.orm.xml
@@ -16,7 +16,7 @@
         <field name="height" column="height" type="integer" nullable="true"/>
         <field name="length" column="length" type="decimal" nullable="true" precision="10"/>
         <field name="contentType" column="content_type" type="string" nullable="true" length="255"/>
-        <field name="size" column="content_size" type="integer" length="5" nullable="true"/>
+        <field name="size" column="content_size" type="bigint" nullable="true"/>
         <field name="copyright" column="copyright" type="string" nullable="true"/>
         <field name="authorName" column="author_name" type="string" nullable="true"/>
         <field name="context" column="context" type="string" nullable="true" length="64"/>


### PR DESCRIPTION
Otherwise you cannot upload 3GB files and add the content size

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Changed
- Use BIGINT for Media::$contentSize
```