### PR TITLE
Enhancement: Use FilesystemInterface for lazy loading

### DIFF
--- a/src/Provider/BaseProvider.php
+++ b/src/Provider/BaseProvider.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Provider;
 
-use Gaufrette\Filesystem;
+use Gaufrette\FilesystemInterface;
 use Sonata\Form\Validator\ErrorElement;
 use Sonata\MediaBundle\CDN\CDNInterface;
 use Sonata\MediaBundle\Generator\GeneratorInterface;
@@ -48,7 +48,7 @@ abstract class BaseProvider implements MediaProviderInterface
 
     public function __construct(
         protected string $name,
-        protected Filesystem $filesystem,
+        protected FilesystemInterface $filesystem,
         protected CDNInterface $cdn,
         protected GeneratorInterface $pathGenerator,
         protected ThumbnailInterface $thumbnail,
@@ -229,7 +229,7 @@ abstract class BaseProvider implements MediaProviderInterface
         return $this->resizer;
     }
 
-    final public function getFilesystem(): Filesystem
+    final public function getFilesystem(): FilesystemInterface
     {
         return $this->filesystem;
     }

--- a/src/Provider/BaseVideoProvider.php
+++ b/src/Provider/BaseVideoProvider.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\MediaBundle\Provider;
 
 use Gaufrette\File;
-use Gaufrette\Filesystem;
+use Gaufrette\FilesystemInterface;
 use Imagine\Image\Box;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
@@ -33,7 +33,7 @@ abstract class BaseVideoProvider extends BaseProvider
 {
     public function __construct(
         string $name,
-        Filesystem $filesystem,
+        FilesystemInterface $filesystem,
         CDNInterface $cdn,
         GeneratorInterface $pathGenerator,
         ThumbnailInterface $thumbnail,

--- a/src/Provider/FileProvider.php
+++ b/src/Provider/FileProvider.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\MediaBundle\Provider;
 
 use Gaufrette\File as GaufretteFile;
-use Gaufrette\Filesystem;
+use Gaufrette\FilesystemInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\Form\Validator\ErrorElement;
 use Sonata\MediaBundle\CDN\CDNInterface;
@@ -42,7 +42,7 @@ class FileProvider extends BaseProvider implements FileProviderInterface
      */
     public function __construct(
         string $name,
-        Filesystem $filesystem,
+        FilesystemInterface $filesystem,
         CDNInterface $cdn,
         GeneratorInterface $pathGenerator,
         ThumbnailInterface $thumbnail,

--- a/src/Provider/ImageProvider.php
+++ b/src/Provider/ImageProvider.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\MediaBundle\Provider;
 
-use Gaufrette\Filesystem;
+use Gaufrette\FilesystemInterface;
 use Imagine\Image\ImagineInterface;
 use Sonata\MediaBundle\CDN\CDNInterface;
 use Sonata\MediaBundle\Generator\GeneratorInterface;
@@ -28,7 +28,7 @@ final class ImageProvider extends FileProvider implements ImageProviderInterface
 {
     public function __construct(
         string $name,
-        Filesystem $filesystem,
+        FilesystemInterface $filesystem,
         CDNInterface $cdn,
         GeneratorInterface $pathGenerator,
         ThumbnailInterface $thumbnail,

--- a/src/Provider/MediaProviderInterface.php
+++ b/src/Provider/MediaProviderInterface.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\MediaBundle\Provider;
 
 use Gaufrette\File;
-use Gaufrette\Filesystem;
+use Gaufrette\FilesystemInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\Form\Validator\ErrorElement;
 use Sonata\MediaBundle\CDN\CDNInterface;
@@ -175,7 +175,7 @@ interface MediaProviderInterface
 
     public function getResizer(): ?ResizerInterface;
 
-    public function getFilesystem(): Filesystem;
+    public function getFilesystem(): FilesystemInterface;
 
     public function getCdn(): CDNInterface;
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I'd like to mark filesystem instantiation lazy. At the moment I need to load heavy services like [`S3Client`](https://github.com/KnpLabs/Gaufrette/blob/ceb9f239f9c22f452bc09814cc4ad0700b26078e/src/Gaufrette/Adapter/AwsS3.php#L35) because Gaufrette's adapter won't accept a `S3ClientInterface` :-/ 

At the moment I got stuck at accessing `::getAdapter()` in my tests, because of this:

https://github.com/sonata-project/SonataMediaBundle/blob/bffb26b554ecea46d76f2b63d2abe8a0ac06dce7/src/Metadata/ProxyMetadataBuilder.php#L57

Any ideas on how to solve this in a non-BC-break manner? Maybe even getting rid of Gaufrette #1985?


<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
<!-- I am targeting this branch, because {reason}. -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

<!-- Closes #{put_issue_number_here}. -->

<!-- ## Changelog -->

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->

<!--
```markdown
### Added
- Some `Class::newMethod()` to do great stuff

### Changed

### Deprecated

### Removed

### Fixed

### Security
```

-->

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
