### PR TITLE
Fix async S3 filesystem adapter throwing error if the full AWS SDK is not installed, even though it is not used in this case

### DIFF
--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -308,10 +308,10 @@ final class SonataMediaExtension extends Extension implements PrependExtensionIn
                 ];
             }
 
-            $container->getDefinition('sonata.media.adapter.service.s3')
-                ->replaceArgument(0, $arguments);
-
-            if ($async) {
+            if (!$async) {
+                $container->getDefinition('sonata.media.adapter.service.s3')
+                    ->replaceArgument(0, $arguments);
+            } else {
                 if (isset($arguments['credentials']['key'], $arguments['credentials']['secret'])) {
                     $arguments['accessKeyId'] = $arguments['credentials']['key'];
                     $arguments['accessKeySecret'] = $arguments['credentials']['secret'];

--- a/src/Resources/config/gaufrette.php
+++ b/src/Resources/config/gaufrette.php
@@ -76,13 +76,19 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         ->set('sonata.media.metadata.noop', NoopMetadataBuilder::class);
 
-    if (class_exists(S3Client::class)) {
+    if (
+        class_exists(S3Client::class)
+        && ($_ENV['PHPUNIT_TESTS_SONATA_MEDIA_FORCE_DISABLE_S3_CLIENT'] ?? 'false') !== 'true'
+    ) {
         $containerConfigurator->services()
             ->set('sonata.media.adapter.service.s3', S3Client::class)
             ->args([abstract_arg('settings')]);
     }
 
-    if (class_exists(SimpleS3Client::class)) {
+    if (
+        class_exists(SimpleS3Client::class)
+        && ($_ENV['PHPUNIT_TESTS_SONATA_MEDIA_FORCE_DISABLE_S3_ASYNC_CLIENT'] ?? 'false') !== 'true'
+    ) {
         $containerConfigurator->services()
             ->set('sonata.media.adapter.service.s3.async', SimpleS3Client::class)
             ->args([abstract_arg('settings')]);

--- a/tests/DependencyInjection/SonataMediaExtensionTest.php
+++ b/tests/DependencyInjection/SonataMediaExtensionTest.php
@@ -237,12 +237,12 @@ final class SonataMediaExtensionTest extends AbstractExtensionTestCase
     }
 
     /**
-     * @dataProvider provideLoadWithFilesystemConfigurationV3Cases
+     * @dataProvider provideLoadWithFilesystemConfigurationS3Cases
      *
      * @param array<string, mixed> $expected
      * @param array<string, mixed> $configs
      */
-    public function testLoadWithFilesystemConfigurationV3(
+    public function testLoadWithFilesystemConfigurationS3(
         array $expected,
         array $configs,
     ): void {
@@ -271,7 +271,7 @@ final class SonataMediaExtensionTest extends AbstractExtensionTestCase
     /**
      * @phpstan-return iterable<array{array<string, mixed>, array<string, mixed>}>
      */
-    public function provideLoadWithFilesystemConfigurationV3Cases(): iterable
+    public function provideLoadWithFilesystemConfigurationS3Cases(): iterable
     {
         yield [
             [
@@ -361,7 +361,7 @@ final class SonataMediaExtensionTest extends AbstractExtensionTestCase
         ];
     }
 
-    public function testLoadWithFilesystemConfigurationV3ASync(): void
+    public function testLoadWithFilesystemConfigurationS3ASync(): void
     {
         if (!class_exists(SimpleS3Client::class)) {
             static::markTestSkipped('This test requires async-aws/simple-s3.');

--- a/tests/DependencyInjection/SonataMediaExtensionTest.php
+++ b/tests/DependencyInjection/SonataMediaExtensionTest.php
@@ -56,6 +56,16 @@ final class SonataMediaExtensionTest extends AbstractExtensionTestCase
         ]);
     }
 
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        unset(
+            $_ENV['PHPUNIT_TESTS_SONATA_MEDIA_FORCE_DISABLE_S3_CLIENT'],
+            $_ENV['PHPUNIT_TESTS_SONATA_MEDIA_FORCE_DISABLE_S3_ASYNC_CLIENT'],
+        );
+    }
+
     public function testLoadWithForceDisableTrue(): void
     {
         $this->load([
@@ -236,6 +246,30 @@ final class SonataMediaExtensionTest extends AbstractExtensionTestCase
         );
     }
 
+    public function testLoadWithFilesystemConfigurationS3DoesNotRequireS3AsyncLibrary(): void
+    {
+        if (!class_exists(Sdk::class)) {
+            static::markTestSkipped('This test requires aws/aws-sdk-php 3.x.');
+        }
+
+        $_ENV['PHPUNIT_TESTS_SONATA_MEDIA_FORCE_DISABLE_S3_ASYNC_CLIENT'] = 'true';
+
+        $this->load([
+            'filesystem' => [
+                's3' => [
+                    'bucket' => 'bucket_name',
+                    'region' => 'region',
+                    'version' => 'version',
+                    'secretKey' => 'secret',
+                    'accessKey' => 'access',
+                ],
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasService('sonata.media.adapter.service.s3', S3Client::class);
+        $this->assertContainerBuilderNotHasService('sonata.media.adapter.service.s3.async');
+    }
+
     /**
      * @dataProvider provideLoadWithFilesystemConfigurationS3Cases
      *
@@ -359,6 +393,31 @@ final class SonataMediaExtensionTest extends AbstractExtensionTestCase
                 ],
             ],
         ];
+    }
+
+    public function testLoadWithFilesystemConfigurationS3AsyncDoesNotRequireS3Library(): void
+    {
+        if (!class_exists(SimpleS3Client::class)) {
+            static::markTestSkipped('This test requires async-aws/simple-s3.');
+        }
+
+        $_ENV['PHPUNIT_TESTS_SONATA_MEDIA_FORCE_DISABLE_S3_CLIENT'] = 'true';
+
+        $this->load([
+            'filesystem' => [
+                's3' => [
+                    'async' => true,
+                    'bucket' => 'bucket_name',
+                    'region' => 'region',
+                    'version' => 'version',
+                    'secretKey' => 'secret',
+                    'accessKey' => 'access',
+                ],
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasService('sonata.media.adapter.service.s3.async', SimpleS3Client::class);
+        $this->assertContainerBuilderNotHasService('sonata.media.adapter.service.s3');
     }
 
     public function testLoadWithFilesystemConfigurationS3ASync(): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

When i followed the [S3 setup documentation](https://docs.sonata-project.org/projects/SonataMediaBundle/en/4.x/reference/amazon_s3), I ran into an error that the `sonata.media.adapter.service.s3` does not exist.

As it turns out, even when using the `async-aws/simple-s3` client like described in the documentation and therefore the `sonata.media.adapter.service.s3.async` service, the container builder still expects the `sonata.media.adapter.service.s3` to exist, even though this service is not used in this case.

The full error i received:
> You have requested a non-existent service "sonata.media.adapter.service.s3".

I added a failing test that reproduces this error. If you run the PHPUnit tests with the commit a9ebea4 you can see the failing test and the error described above is thrown.

After verifying that the new test "successfully" fails, i added another commit that fixes this.

I actually had a bit of trouble preventing the AWS SDK S3 service from registering because both clients are installed in the test environment, hence why the tests were also not throwing any errors before. If there is a better way to prevent that service from being registered in the test environment, please let me know.

*(I also renamed the S3 tests from `...V3..` to `...S3...`. If the `V3` name was on purpose, i am happy to change that back)*

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a backwards compatible fix.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataMediaBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- Using the `async: true` S3 filesystem adapter throws an error if the full AWS SDK is not installed, even though it is not used in this case.
```
