### PR TITLE
fix #2486

### DIFF
--- a/src/Controller/MediaAdminController.php
+++ b/src/Controller/MediaAdminController.php
@@ -88,33 +88,37 @@ final class MediaAdminController extends CRUDController
         $datagrid->setValue('context', null, $context);
 
         $rootCategory = null;
-        $categoryManager = $this->container->get('sonata.media.manager.category');
-        $contextManager = $this->container->get('sonata.media.manager.context');
+        try {
+            $categoryManager = $this->container->get('sonata.media.manager.category');
+            $contextManager = $this->container->get('sonata.media.manager.context');
 
-        if ($categoryManager instanceof CategoryManagerInterface && $contextManager instanceof ContextManagerInterface) {
-            $rootCategories = $categoryManager->getRootCategoriesForContext($contextManager->find($context));
+            if ($categoryManager instanceof CategoryManagerInterface && $contextManager instanceof ContextManagerInterface) {
+                $rootCategories = $categoryManager->getRootCategoriesForContext($contextManager->find($context));
 
-            if ([] !== $rootCategories) {
-                $rootCategory = current($rootCategories);
-            }
+                if ([] !== $rootCategories) {
+                    $rootCategory = current($rootCategories);
+                }
 
-            if (null !== $rootCategory && [] === $filters) {
-                $datagrid->setValue('category', null, $rootCategory->getId());
-            }
-
-            $categoryParam = $request->query->get('category');
-            if (null !== $categoryParam && '' !== $categoryParam) {
-                $category = $categoryManager->findOneBy([
-                    'id' => $request->query->getInt('category'),
-                    'context' => $context,
-                ]);
-
-                if (null !== $category) {
-                    $datagrid->setValue('category', null, $category->getId());
-                } elseif (null !== $rootCategory) {
+                if (null !== $rootCategory && [] === $filters) {
                     $datagrid->setValue('category', null, $rootCategory->getId());
                 }
+
+                $categoryParam = $request->query->get('category');
+                if (null !== $categoryParam && '' !== $categoryParam) {
+                    $category = $categoryManager->findOneBy([
+                        'id' => $request->query->getInt('category'),
+                        'context' => $context,
+                    ]);
+
+                    if (null !== $category) {
+                        $datagrid->setValue('category', null, $category->getId());
+                    } elseif (null !== $rootCategory) {
+                        $datagrid->setValue('category', null, $rootCategory->getId());
+                    }
+                }
             }
+        } catch (\Throwable) {
+            // Category services not available
         }
 
         $formView = $datagrid->getForm()->createView();

--- a/src/Controller/MediaAdminController.php
+++ b/src/Controller/MediaAdminController.php
@@ -88,41 +88,33 @@ final class MediaAdminController extends CRUDController
         $datagrid->setValue('context', null, $context);
 
         $rootCategory = null;
-        try {
-            if (
-                $this->container->has('sonata.media.manager.category')
-                && $this->container->has('sonata.media.manager.context')
-            ) {
-                $categoryManager = $this->container->get('sonata.media.manager.category');
-                \assert($categoryManager instanceof CategoryManagerInterface);
-                $contextManager = $this->container->get('sonata.media.manager.context');
-                \assert($contextManager instanceof ContextManagerInterface);
+        $categoryManager = $this->container->get('sonata.media.manager.category');
+        $contextManager = $this->container->get('sonata.media.manager.context');
 
-                $rootCategories = $categoryManager->getRootCategoriesForContext($contextManager->find($context));
+        if ($categoryManager instanceof CategoryManagerInterface && $contextManager instanceof ContextManagerInterface) {
+            $rootCategories = $categoryManager->getRootCategoriesForContext($contextManager->find($context));
 
-                if ([] !== $rootCategories) {
-                    $rootCategory = current($rootCategories);
-                }
+            if ([] !== $rootCategories) {
+                $rootCategory = current($rootCategories);
+            }
 
-                if (null !== $rootCategory && [] === $filters) {
+            if (null !== $rootCategory && [] === $filters) {
+                $datagrid->setValue('category', null, $rootCategory->getId());
+            }
+
+            $categoryParam = $request->query->get('category');
+            if (null !== $categoryParam && '' !== $categoryParam) {
+                $category = $categoryManager->findOneBy([
+                    'id' => $request->query->getInt('category'),
+                    'context' => $context,
+                ]);
+
+                if (null !== $category) {
+                    $datagrid->setValue('category', null, $category->getId());
+                } elseif (null !== $rootCategory) {
                     $datagrid->setValue('category', null, $rootCategory->getId());
                 }
-
-                if (null !== $request->query->get('category') && '' !== $request->query->get('category')) {
-                    $category = $categoryManager->findOneBy([
-                        'id' => $request->query->getInt('category'),
-                        'context' => $context,
-                    ]);
-
-                    if (null !== $category) {
-                        $datagrid->setValue('category', null, $category->getId());
-                    } elseif (null !== $rootCategory) {
-                        $datagrid->setValue('category', null, $rootCategory->getId());
-                    }
-                }
             }
-        } catch (\Throwable) {
-            // Category services not available - continue without category filtering
         }
 
         $formView = $datagrid->getForm()->createView();

--- a/src/Controller/MediaAdminController.php
+++ b/src/Controller/MediaAdminController.php
@@ -88,37 +88,41 @@ final class MediaAdminController extends CRUDController
         $datagrid->setValue('context', null, $context);
 
         $rootCategory = null;
-        if (
-            $this->container->has('sonata.media.manager.category')
-            && $this->container->has('sonata.media.manager.context')
-        ) {
-            $categoryManager = $this->container->get('sonata.media.manager.category');
-            \assert($categoryManager instanceof CategoryManagerInterface);
-            $contextManager = $this->container->get('sonata.media.manager.context');
-            \assert($contextManager instanceof ContextManagerInterface);
+        try {
+            if (
+                $this->container->has('sonata.media.manager.category')
+                && $this->container->has('sonata.media.manager.context')
+            ) {
+                $categoryManager = $this->container->get('sonata.media.manager.category');
+                \assert($categoryManager instanceof CategoryManagerInterface);
+                $contextManager = $this->container->get('sonata.media.manager.context');
+                \assert($contextManager instanceof ContextManagerInterface);
 
-            $rootCategories = $categoryManager->getRootCategoriesForContext($contextManager->find($context));
+                $rootCategories = $categoryManager->getRootCategoriesForContext($contextManager->find($context));
 
-            if ([] !== $rootCategories) {
-                $rootCategory = current($rootCategories);
-            }
+                if ([] !== $rootCategories) {
+                    $rootCategory = current($rootCategories);
+                }
 
-            if (null !== $rootCategory && [] === $filters) {
-                $datagrid->setValue('category', null, $rootCategory->getId());
-            }
-
-            if (null !== $request->query->get('category')) {
-                $category = $categoryManager->findOneBy([
-                    'id' => $request->query->getInt('category'),
-                    'context' => $context,
-                ]);
-
-                if (null !== $category) {
-                    $datagrid->setValue('category', null, $category->getId());
-                } elseif (null !== $rootCategory) {
+                if (null !== $rootCategory && [] === $filters) {
                     $datagrid->setValue('category', null, $rootCategory->getId());
                 }
+
+                if (null !== $request->query->get('category') && '' !== $request->query->get('category')) {
+                    $category = $categoryManager->findOneBy([
+                        'id' => $request->query->getInt('category'),
+                        'context' => $context,
+                    ]);
+
+                    if (null !== $category) {
+                        $datagrid->setValue('category', null, $category->getId());
+                    } elseif (null !== $rootCategory) {
+                        $datagrid->setValue('category', null, $rootCategory->getId());
+                    }
+                }
             }
+        } catch (\Throwable) {
+            // Category services not available - continue without category filtering
         }
 
         $formView = $datagrid->getForm()->createView();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
disabled categories break the admin

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it just hardens checks of the category in the media admin.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #2486 

## Changelog

```markdown
### Fixed
Disabled category does not break the admin filtering

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
