### PR TITLE
fix: don't call s3 reference while s3.async is used

### DIFF
--- a/src/DependencyInjection/SonataMediaExtension.php
+++ b/src/DependencyInjection/SonataMediaExtension.php
@@ -310,9 +310,6 @@ final class SonataMediaExtension extends Extension implements PrependExtensionIn
                 ];
             }
 
-            $container->getDefinition('sonata.media.adapter.service.s3')
-                ->replaceArgument(0, $arguments);
-
             if ($async) {
                 if (isset($arguments['credentials']['key'], $arguments['credentials']['secret'])) {
                     $arguments['accessKeyId'] = $arguments['credentials']['key'];
@@ -322,6 +319,9 @@ final class SonataMediaExtension extends Extension implements PrependExtensionIn
 
                 unset($arguments['version']);
                 $container->getDefinition('sonata.media.adapter.service.s3.async')
+                    ->replaceArgument(0, $arguments);
+            } else {
+                $container->getDefinition('sonata.media.adapter.service.s3')
                     ->replaceArgument(0, $arguments);
             }
         } else {


### PR DESCRIPTION
## Subject

I am targeting this branch, to fix configuration issue while S3 is used with async client. In this case there is no reference `sonata.media.adapter.service.s3` and should not be called in configuration.

## Changelog

[fix: don't call s3 reference while s3.async is used](https://github.com/sonata-project/SonataMediaBundle/commit/0737cf3c84982b90910cd40f3bd2ff5b9a166e6c)




