### PR TITLE
Fix: check interface instead of class

### DIFF
--- a/src/Command/CleanMediaCommand.php
+++ b/src/Command/CleanMediaCommand.php
@@ -15,7 +15,7 @@ namespace Sonata\MediaBundle\Command;
 
 use Sonata\MediaBundle\Filesystem\Local;
 use Sonata\MediaBundle\Model\MediaManagerInterface;
-use Sonata\MediaBundle\Provider\FileProvider;
+use Sonata\MediaBundle\Provider\FileProviderInterface;
 use Sonata\MediaBundle\Provider\Pool;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -116,7 +116,7 @@ final class CleanMediaCommand extends Command
             $this->providers = [];
 
             foreach ($this->mediaPool->getProviders() as $provider) {
-                if ($provider instanceof FileProvider) {
+                if ($provider instanceof FileProviderInterface) {
                     $this->providers[] = $provider->getName();
                 }
             }


### PR DESCRIPTION
## Subject

Check interface instead of class

I am targeting this branch, because this is a backwards compatible fix.

## Changelog

```markdown
### Fixed
- Check FileProviderInterface instead of FileProvider when adding providers in CleanMediaCommand
```