### PR TITLE
Replace deprecated spaceless tag with whitespace control

### DIFF
--- a/src/Resources/views/MediaAdmin/edit.html.twig
+++ b/src/Resources/views/MediaAdmin/edit.html.twig
@@ -12,18 +12,16 @@ file that was distributed with this source code.
 {% import _self as macros %}
 
 {% macro bytesToSize(bytes) %}
-{% apply spaceless %}
-    {% set kilobyte = 1024 %}
-    {% set megabyte = kilobyte * 1024 %}
+    {%- set kilobyte = 1024 -%}
+    {%- set megabyte = kilobyte * 1024 -%}
 
-    {% if bytes < kilobyte %}
+    {%- if bytes < kilobyte -%}
         {{ bytes ~ ' B' }}
-    {% elseif bytes < megabyte %}
+    {%- elseif bytes < megabyte -%}
         {{ (bytes / kilobyte)|number_format(2) ~ ' KB' }}
-    {% else %}
+    {%- else -%}
         {{ (bytes / megabyte)|number_format(2) ~ ' MB' }}
-    {% endif %}
-{% endapply %}
+    {%- endif -%}
 {% endmacro %}
 
 {% extends '@SonataAdmin/CRUD/base_edit.html.twig' %}

--- a/tests/App/templates/truncate_test.html.twig
+++ b/tests/App/templates/truncate_test.html.twig
@@ -1,3 +1,1 @@
-{% apply spaceless %}
-    {{ 'test for u.truncate'|u.truncate(4) }}
-{% endapply %}
+{{- 'test for u.truncate'|u.truncate(4) -}}


### PR DESCRIPTION
The `spaceless` tag/filter is deprecated since Twig 3.12 and will be removed in Twig 4. Replace the two remaining occurrences with whitespace-control modifiers (`{%- -%}`), which is the recommended migration path and preserves the rendered output.

- `src/Resources/views/MediaAdmin/edit.html.twig` (bytesToSize macro)
- `tests/App/templates/truncate_test.html.twig` (truncate test fixture)

## Changelog

```markdown
### Changed
- Replace deprecated Twig `spaceless` tag with whitespace-control modifiers
```